### PR TITLE
feat(m2): event-sourced recurring transactions and projection engine

### DIFF
--- a/core/account.go
+++ b/core/account.go
@@ -3,10 +3,13 @@ package core
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type AccountType int
@@ -22,18 +25,47 @@ const (
 	AccountTypeBrokerage    AccountType = 7
 )
 
+const aggregateTypeAccount = "account"
+
+// Account event types.
+const (
+	EventAccountCreated     = "AccountCreated"
+	EventAccountRenamed     = "AccountRenamed"
+	EventAccountTypeChanged = "AccountTypeChanged"
+)
+
 type Account struct {
-	ID        int64
+	ID        string
 	Name      string
 	Type      AccountType
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
+// AccountCreatedPayload is the event payload for account creation.
+type AccountCreatedPayload struct {
+	Name string `json:"name"`
+	Type int    `json:"type"`
+}
+
+// AccountRenamedPayload is the event payload for renaming an account.
+type AccountRenamedPayload struct {
+	OldName string `json:"old_name"`
+	NewName string `json:"new_name"`
+}
+
+// AccountTypeChangedPayload is the event payload for changing an account's type.
+type AccountTypeChangedPayload struct {
+	OldType int `json:"old_type"`
+	NewType int `json:"new_type"`
+}
+
 func ValidAccountType(t AccountType) bool {
 	return t >= AccountTypeChecking && t <= AccountTypeBrokerage
 }
 
+// CreateAccount validates input, appends an AccountCreated event, and updates
+// the read model — all within a single transaction.
 func (db *DB) CreateAccount(ctx context.Context, name string, accountType AccountType) (*Account, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -42,18 +74,42 @@ func (db *DB) CreateAccount(ctx context.Context, name string, accountType Accoun
 	if !ValidAccountType(accountType) {
 		return nil, fmt.Errorf("invalid account type: %d", accountType)
 	}
-	now := time.Now().UTC()
-	result, err := db.conn.ExecContext(ctx,
-		"INSERT INTO accounts (name, type, created_at, updated_at) VALUES (?, ?, ?, ?)",
-		name, int(accountType), now.Unix(), now.Unix(),
-	)
+
+	id := uuid.New().String()
+	payload, err := json.Marshal(AccountCreatedPayload{
+		Name: name,
+		Type: int(accountType),
+	})
 	if err != nil {
-		return nil, fmt.Errorf("insert account: %w", err)
+		return nil, fmt.Errorf("marshal event payload: %w", err)
 	}
-	id, err := result.LastInsertId()
+
+	tx, err := db.conn.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("last insert id: %w", err)
+		return nil, fmt.Errorf("begin tx: %w", err)
 	}
+
+	events, err := appendEvents(ctx, tx, aggregateTypeAccount, id, []NewEvent{
+		{EventType: EventAccountCreated, Payload: payload},
+	})
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, fmt.Errorf("append event: %w", err)
+	}
+
+	now := events[0].RecordedAt
+	if _, err := tx.ExecContext(ctx,
+		"INSERT INTO accounts (id, name, type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+		id, name, int(accountType), now.Unix(), now.Unix(),
+	); err != nil {
+		_ = tx.Rollback()
+		return nil, fmt.Errorf("insert account read model: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+
 	return &Account{
 		ID:        id,
 		Name:      name,
@@ -63,6 +119,7 @@ func (db *DB) CreateAccount(ctx context.Context, name string, accountType Accoun
 	}, nil
 }
 
+// ListAccounts returns all accounts from the read model, ordered by name.
 func (db *DB) ListAccounts(ctx context.Context) ([]Account, error) {
 	rows, err := db.conn.QueryContext(ctx, "SELECT id, name, type, created_at, updated_at FROM accounts ORDER BY name")
 	if err != nil {
@@ -70,6 +127,11 @@ func (db *DB) ListAccounts(ctx context.Context) ([]Account, error) {
 	}
 	defer func() { _ = rows.Close() }()
 	return scanAccounts(rows)
+}
+
+// GetAccountHistory returns the event history for a specific account.
+func (db *DB) GetAccountHistory(ctx context.Context, accountID string) ([]Event, error) {
+	return db.LoadEvents(ctx, aggregateTypeAccount, accountID)
 }
 
 func scanAccounts(rows *sql.Rows) ([]Account, error) {

--- a/core/account_test.go
+++ b/core/account_test.go
@@ -2,6 +2,7 @@ package core_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/jakewan/finch/core"
@@ -16,8 +17,8 @@ func TestCreateAndListAccounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateAccount: %v", err)
 	}
-	if acct.ID == 0 {
-		t.Fatal("expected non-zero ID")
+	if acct.ID == "" {
+		t.Fatal("expected non-empty ID")
 	}
 	if acct.Name != "Checking" {
 		t.Fatalf("expected name Checking, got %s", acct.Name)
@@ -63,5 +64,50 @@ func TestCreateAccountValidation(t *testing.T) {
 	}
 	if _, err := db.CreateAccount(ctx, "Test", core.AccountType(99)); err == nil {
 		t.Fatal("expected error for invalid account type")
+	}
+}
+
+func TestCreateAccountStoresEvent(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	acct, err := db.CreateAccount(ctx, "Test Account", core.AccountTypeChecking)
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	events, err := db.GetAccountHistory(ctx, acct.ID)
+	if err != nil {
+		t.Fatalf("GetAccountHistory: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].EventType != "AccountCreated" {
+		t.Fatalf("expected AccountCreated, got %s", events[0].EventType)
+	}
+
+	var payload core.AccountCreatedPayload
+	if err := json.Unmarshal(events[0].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.Name != "Test Account" {
+		t.Fatalf("expected name Test Account in payload, got %s", payload.Name)
+	}
+	if payload.Type != int(core.AccountTypeChecking) {
+		t.Fatalf("expected type %d in payload, got %d", core.AccountTypeChecking, payload.Type)
+	}
+}
+
+func TestGetAccountHistoryEmpty(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	events, err := db.GetAccountHistory(ctx, "nonexistent-id")
+	if err != nil {
+		t.Fatalf("GetAccountHistory: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events, got %d", len(events))
 	}
 }

--- a/core/event.go
+++ b/core/event.go
@@ -1,0 +1,153 @@
+package core
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Event represents a persisted domain event.
+type Event struct {
+	ID            int64
+	AggregateType string
+	AggregateID   string
+	EventType     string
+	Payload       json.RawMessage
+	RecordedAt    time.Time
+	Sequence      int64
+}
+
+// NewEvent holds the data needed to append a new event (before persistence assigns ID/sequence).
+type NewEvent struct {
+	EventType string
+	Payload   json.RawMessage
+}
+
+// appendEvents inserts events for a single aggregate within an existing transaction.
+// It assigns monotonically increasing sequence numbers starting after the current max.
+func appendEvents(ctx context.Context, tx *sql.Tx, aggregateType, aggregateID string, events []NewEvent) ([]Event, error) {
+	if len(events) == 0 {
+		return nil, nil
+	}
+
+	var maxSeq int64
+	row := tx.QueryRowContext(ctx,
+		"SELECT COALESCE(MAX(sequence), 0) FROM events WHERE aggregate_type = ? AND aggregate_id = ?",
+		aggregateType, aggregateID,
+	)
+	if err := row.Scan(&maxSeq); err != nil {
+		return nil, fmt.Errorf("read max sequence: %w", err)
+	}
+
+	now := time.Now().UTC()
+	recorded := make([]Event, len(events))
+
+	for i, ne := range events {
+		seq := maxSeq + int64(i) + 1
+		result, err := tx.ExecContext(ctx,
+			`INSERT INTO events (aggregate_type, aggregate_id, event_type, payload, recorded_at, sequence)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			aggregateType, aggregateID, ne.EventType, string(ne.Payload), now.Unix(), seq,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("insert event %s seq %d: %w", ne.EventType, seq, err)
+		}
+		id, err := result.LastInsertId()
+		if err != nil {
+			return nil, fmt.Errorf("last insert id: %w", err)
+		}
+		recorded[i] = Event{
+			ID:            id,
+			AggregateType: aggregateType,
+			AggregateID:   aggregateID,
+			EventType:     ne.EventType,
+			Payload:       ne.Payload,
+			RecordedAt:    now,
+			Sequence:      seq,
+		}
+	}
+	return recorded, nil
+}
+
+// AppendEvents persists events for a single aggregate in its own transaction.
+func (db *DB) AppendEvents(ctx context.Context, aggregateType, aggregateID string, events []NewEvent) ([]Event, error) {
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	recorded, err := appendEvents(ctx, tx, aggregateType, aggregateID, events)
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+	return recorded, nil
+}
+
+// LoadEvents returns all events for a specific aggregate, ordered by sequence.
+func (db *DB) LoadEvents(ctx context.Context, aggregateType, aggregateID string) ([]Event, error) {
+	rows, err := db.conn.QueryContext(ctx,
+		`SELECT id, aggregate_type, aggregate_id, event_type, payload, recorded_at, sequence
+		 FROM events
+		 WHERE aggregate_type = ? AND aggregate_id = ?
+		 ORDER BY sequence`,
+		aggregateType, aggregateID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query events: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanEvents(rows)
+}
+
+// LoadEventsSince returns events for an aggregate after a given sequence number.
+func (db *DB) LoadEventsSince(ctx context.Context, aggregateType, aggregateID string, afterSequence int64) ([]Event, error) {
+	rows, err := db.conn.QueryContext(ctx,
+		`SELECT id, aggregate_type, aggregate_id, event_type, payload, recorded_at, sequence
+		 FROM events
+		 WHERE aggregate_type = ? AND aggregate_id = ? AND sequence > ?
+		 ORDER BY sequence`,
+		aggregateType, aggregateID, afterSequence,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query events since %d: %w", afterSequence, err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanEvents(rows)
+}
+
+// LoadAllEvents returns all events of a given aggregate type, ordered by aggregate_id then sequence.
+func (db *DB) LoadAllEvents(ctx context.Context, aggregateType string) ([]Event, error) {
+	rows, err := db.conn.QueryContext(ctx,
+		`SELECT id, aggregate_type, aggregate_id, event_type, payload, recorded_at, sequence
+		 FROM events
+		 WHERE aggregate_type = ?
+		 ORDER BY aggregate_id, sequence`,
+		aggregateType,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query all events for %s: %w", aggregateType, err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanEvents(rows)
+}
+
+func scanEvents(rows *sql.Rows) ([]Event, error) {
+	var events []Event
+	for rows.Next() {
+		var e Event
+		var recordedUnix int64
+		var payload string
+		if err := rows.Scan(&e.ID, &e.AggregateType, &e.AggregateID, &e.EventType, &payload, &recordedUnix, &e.Sequence); err != nil {
+			return nil, fmt.Errorf("scan event: %w", err)
+		}
+		e.Payload = json.RawMessage(payload)
+		e.RecordedAt = time.Unix(recordedUnix, 0).UTC()
+		events = append(events, e)
+	}
+	return events, rows.Err()
+}

--- a/core/event_test.go
+++ b/core/event_test.go
@@ -1,0 +1,138 @@
+package core_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jakewan/finch/core"
+)
+
+func TestAppendAndLoadEvents(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	events, err := db.AppendEvents(ctx, "test_aggregate", "agg-1", []core.NewEvent{
+		{EventType: "Created", Payload: json.RawMessage(`{"name":"first"}`)},
+		{EventType: "Updated", Payload: json.RawMessage(`{"name":"second"}`)},
+	})
+	if err != nil {
+		t.Fatalf("AppendEvents: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Sequence != 1 {
+		t.Fatalf("expected sequence 1, got %d", events[0].Sequence)
+	}
+	if events[1].Sequence != 2 {
+		t.Fatalf("expected sequence 2, got %d", events[1].Sequence)
+	}
+
+	loaded, err := db.LoadEvents(ctx, "test_aggregate", "agg-1")
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(loaded) != 2 {
+		t.Fatalf("expected 2 loaded events, got %d", len(loaded))
+	}
+	if loaded[0].EventType != "Created" {
+		t.Fatalf("expected Created, got %s", loaded[0].EventType)
+	}
+	if loaded[1].EventType != "Updated" {
+		t.Fatalf("expected Updated, got %s", loaded[1].EventType)
+	}
+}
+
+func TestAppendEventsSequenceContinues(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.AppendEvents(ctx, "test", "agg-1", []core.NewEvent{
+		{EventType: "First", Payload: json.RawMessage(`{}`)},
+	})
+	if err != nil {
+		t.Fatalf("first append: %v", err)
+	}
+
+	events, err := db.AppendEvents(ctx, "test", "agg-1", []core.NewEvent{
+		{EventType: "Second", Payload: json.RawMessage(`{}`)},
+	})
+	if err != nil {
+		t.Fatalf("second append: %v", err)
+	}
+	if events[0].Sequence != 2 {
+		t.Fatalf("expected sequence 2 for second append, got %d", events[0].Sequence)
+	}
+}
+
+func TestLoadEventsSince(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.AppendEvents(ctx, "test", "agg-1", []core.NewEvent{
+		{EventType: "A", Payload: json.RawMessage(`{}`)},
+		{EventType: "B", Payload: json.RawMessage(`{}`)},
+		{EventType: "C", Payload: json.RawMessage(`{}`)},
+	})
+	if err != nil {
+		t.Fatalf("AppendEvents: %v", err)
+	}
+
+	events, err := db.LoadEventsSince(ctx, "test", "agg-1", 1)
+	if err != nil {
+		t.Fatalf("LoadEventsSince: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events after sequence 1, got %d", len(events))
+	}
+	if events[0].EventType != "B" {
+		t.Fatalf("expected B, got %s", events[0].EventType)
+	}
+}
+
+func TestLoadAllEvents(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.AppendEvents(ctx, "type_a", "agg-1", []core.NewEvent{
+		{EventType: "X", Payload: json.RawMessage(`{}`)},
+	})
+	if err != nil {
+		t.Fatalf("append agg-1: %v", err)
+	}
+	_, err = db.AppendEvents(ctx, "type_a", "agg-2", []core.NewEvent{
+		{EventType: "Y", Payload: json.RawMessage(`{}`)},
+	})
+	if err != nil {
+		t.Fatalf("append agg-2: %v", err)
+	}
+	// Different aggregate type — should not appear.
+	_, err = db.AppendEvents(ctx, "type_b", "agg-3", []core.NewEvent{
+		{EventType: "Z", Payload: json.RawMessage(`{}`)},
+	})
+	if err != nil {
+		t.Fatalf("append agg-3: %v", err)
+	}
+
+	events, err := db.LoadAllEvents(ctx, "type_a")
+	if err != nil {
+		t.Fatalf("LoadAllEvents: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events for type_a, got %d", len(events))
+	}
+}
+
+func TestLoadEventsEmpty(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	events, err := db.LoadEvents(ctx, "nonexistent", "no-such-id")
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events, got %d", len(events))
+	}
+}

--- a/core/frequency.go
+++ b/core/frequency.go
@@ -1,0 +1,187 @@
+package core
+
+import (
+	"fmt"
+	"time"
+)
+
+// Frequency defines how often a recurring rule generates occurrences.
+type Frequency int
+
+const (
+	FrequencyWeekly      Frequency = 1
+	FrequencyBiweekly    Frequency = 2
+	FrequencySemiMonthly Frequency = 3
+	FrequencyMonthly     Frequency = 4
+	FrequencyYearly      Frequency = 5
+)
+
+func ValidFrequency(f Frequency) bool {
+	return f >= FrequencyWeekly && f <= FrequencyYearly
+}
+
+// ExpandOccurrences generates all occurrence dates for a recurring rule within [from, to].
+// startDate is the anchor for weekly/biweekly calculations.
+// dayOfMonth is used for monthly rules (1-28, capped to month end).
+// semiMonthlyDays holds two day-of-month values for semi-monthly rules.
+func ExpandOccurrences(freq Frequency, startDate, from, to time.Time, dayOfMonth int, semiMonthlyDays [2]int, endDate *time.Time) []time.Time {
+	if endDate != nil && from.After(*endDate) {
+		return nil
+	}
+	effectiveTo := to
+	if endDate != nil && endDate.Before(to) {
+		effectiveTo = *endDate
+	}
+
+	switch freq {
+	case FrequencyWeekly:
+		return expandInterval(startDate, from, effectiveTo, 7)
+	case FrequencyBiweekly:
+		return expandInterval(startDate, from, effectiveTo, 14)
+	case FrequencySemiMonthly:
+		return expandSemiMonthly(semiMonthlyDays, from, effectiveTo)
+	case FrequencyMonthly:
+		return expandMonthly(dayOfMonth, startDate, from, effectiveTo)
+	case FrequencyYearly:
+		return expandYearly(startDate, from, effectiveTo)
+	default:
+		return nil
+	}
+}
+
+// expandInterval handles weekly and biweekly by stepping forward from startDate in dayStep increments.
+func expandInterval(startDate, from, to time.Time, dayStep int) []time.Time {
+	if startDate.After(to) {
+		return nil
+	}
+
+	var dates []time.Time
+	// If startDate is before from, advance to the first occurrence on or after from.
+	cur := startDate
+	if cur.Before(from) {
+		daysBehind := int(from.Sub(cur).Hours()/24) + 1
+		steps := daysBehind / dayStep
+		cur = cur.AddDate(0, 0, steps*dayStep)
+		if cur.Before(from) {
+			cur = cur.AddDate(0, 0, dayStep)
+		}
+	}
+	for !cur.After(to) {
+		dates = append(dates, cur)
+		cur = cur.AddDate(0, 0, dayStep)
+	}
+	return dates
+}
+
+func expandSemiMonthly(days [2]int, from, to time.Time) []time.Time {
+	if days[0] <= 0 || days[1] <= 0 {
+		return nil
+	}
+	d1, d2 := days[0], days[1]
+	if d1 > d2 {
+		d1, d2 = d2, d1
+	}
+
+	var dates []time.Time
+	y, m, _ := from.Date()
+	loc := from.Location()
+
+	for {
+		for _, day := range []int{d1, d2} {
+			capped := capDay(y, m, day)
+			d := time.Date(y, m, capped, 0, 0, 0, 0, loc)
+			if d.Before(from) {
+				continue
+			}
+			if d.After(to) {
+				return dates
+			}
+			dates = append(dates, d)
+		}
+		m++
+		if m > 12 {
+			m = 1
+			y++
+		}
+	}
+}
+
+func expandMonthly(dayOfMonth int, startDate, from, to time.Time) []time.Time {
+	if dayOfMonth <= 0 || dayOfMonth > 31 {
+		return nil
+	}
+
+	var dates []time.Time
+	y, m, _ := startDate.Date()
+	loc := startDate.Location()
+
+	// Start from startDate's month, skip forward if needed.
+	for {
+		capped := capDay(y, m, dayOfMonth)
+		d := time.Date(y, m, capped, 0, 0, 0, 0, loc)
+		if d.After(to) {
+			break
+		}
+		if !d.Before(from) {
+			dates = append(dates, d)
+		}
+		m++
+		if m > 12 {
+			m = 1
+			y++
+		}
+	}
+	return dates
+}
+
+func expandYearly(startDate, from, to time.Time) []time.Time {
+	var dates []time.Time
+	y := startDate.Year()
+	m := startDate.Month()
+	day := startDate.Day()
+	loc := startDate.Location()
+
+	for {
+		capped := capDay(y, m, day)
+		d := time.Date(y, m, capped, 0, 0, 0, 0, loc)
+		if d.After(to) {
+			break
+		}
+		if !d.Before(from) {
+			dates = append(dates, d)
+		}
+		y++
+	}
+	return dates
+}
+
+// capDay caps a day-of-month to the last day of the given month/year.
+func capDay(year int, month time.Month, day int) int {
+	lastDay := daysInMonth(year, month)
+	if day > lastDay {
+		return lastDay
+	}
+	return day
+}
+
+func daysInMonth(year int, month time.Month) int {
+	// The zeroth day of the next month is the last day of this month.
+	return time.Date(year, month+1, 0, 0, 0, 0, 0, time.UTC).Day()
+}
+
+func (f Frequency) String() string {
+	switch f {
+	case FrequencyWeekly:
+		return "weekly"
+	case FrequencyBiweekly:
+		return "biweekly"
+	case FrequencySemiMonthly:
+		return "semi_monthly"
+	case FrequencyMonthly:
+		return "monthly"
+	case FrequencyYearly:
+		return "yearly"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(f))
+	}
+}

--- a/core/frequency_test.go
+++ b/core/frequency_test.go
@@ -1,0 +1,168 @@
+package core_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jakewan/finch/core"
+)
+
+func date(y int, m time.Month, d int) time.Time {
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}
+
+func datePtr(y int, m time.Month, d int) *time.Time {
+	t := date(y, m, d)
+	return &t
+}
+
+func TestExpandWeekly(t *testing.T) {
+	start := date(2025, 1, 6) // Monday
+	from := date(2025, 1, 6)
+	to := date(2025, 1, 27)
+
+	dates := core.ExpandOccurrences(core.FrequencyWeekly, start, from, to, 0, [2]int{}, nil)
+	if len(dates) != 4 {
+		t.Fatalf("expected 4 weekly occurrences, got %d", len(dates))
+	}
+	expected := []time.Time{
+		date(2025, 1, 6), date(2025, 1, 13), date(2025, 1, 20), date(2025, 1, 27),
+	}
+	for i, d := range dates {
+		if !d.Equal(expected[i]) {
+			t.Errorf("occurrence %d: expected %s, got %s", i, expected[i], d)
+		}
+	}
+}
+
+func TestExpandBiweekly(t *testing.T) {
+	start := date(2025, 1, 3) // Friday
+	from := date(2025, 1, 1)
+	to := date(2025, 2, 28)
+
+	dates := core.ExpandOccurrences(core.FrequencyBiweekly, start, from, to, 0, [2]int{}, nil)
+	expected := []time.Time{
+		date(2025, 1, 3), date(2025, 1, 17), date(2025, 1, 31), date(2025, 2, 14), date(2025, 2, 28),
+	}
+	if len(dates) != len(expected) {
+		t.Fatalf("expected %d biweekly occurrences, got %d", len(expected), len(dates))
+	}
+	for i, d := range dates {
+		if !d.Equal(expected[i]) {
+			t.Errorf("occurrence %d: expected %s, got %s", i, expected[i], d)
+		}
+	}
+}
+
+func TestExpandSemiMonthly(t *testing.T) {
+	from := date(2025, 1, 1)
+	to := date(2025, 3, 31)
+	days := [2]int{1, 15}
+
+	dates := core.ExpandOccurrences(core.FrequencySemiMonthly, from, from, to, 0, days, nil)
+	if len(dates) != 6 {
+		t.Fatalf("expected 6 semi-monthly occurrences, got %d", len(dates))
+	}
+	expected := []time.Time{
+		date(2025, 1, 1), date(2025, 1, 15),
+		date(2025, 2, 1), date(2025, 2, 15),
+		date(2025, 3, 1), date(2025, 3, 15),
+	}
+	for i, d := range dates {
+		if !d.Equal(expected[i]) {
+			t.Errorf("occurrence %d: expected %s, got %s", i, expected[i], d)
+		}
+	}
+}
+
+func TestExpandMonthly(t *testing.T) {
+	start := date(2025, 1, 15)
+	from := date(2025, 1, 1)
+	to := date(2025, 4, 30)
+
+	dates := core.ExpandOccurrences(core.FrequencyMonthly, start, from, to, 15, [2]int{}, nil)
+	if len(dates) != 4 {
+		t.Fatalf("expected 4 monthly occurrences, got %d", len(dates))
+	}
+}
+
+func TestExpandMonthlyDayCapping(t *testing.T) {
+	start := date(2025, 1, 31)
+	from := date(2025, 1, 1)
+	to := date(2025, 4, 30)
+
+	dates := core.ExpandOccurrences(core.FrequencyMonthly, start, from, to, 31, [2]int{}, nil)
+	// Jan 31, Feb 28, Mar 31, Apr 30
+	expected := []time.Time{
+		date(2025, 1, 31), date(2025, 2, 28), date(2025, 3, 31), date(2025, 4, 30),
+	}
+	if len(dates) != len(expected) {
+		t.Fatalf("expected %d, got %d", len(expected), len(dates))
+	}
+	for i, d := range dates {
+		if !d.Equal(expected[i]) {
+			t.Errorf("occurrence %d: expected %s, got %s", i, expected[i], d)
+		}
+	}
+}
+
+func TestExpandMonthlyLeapYear(t *testing.T) {
+	start := date(2024, 1, 29)
+	from := date(2024, 1, 1)
+	to := date(2024, 3, 31)
+
+	dates := core.ExpandOccurrences(core.FrequencyMonthly, start, from, to, 29, [2]int{}, nil)
+	expected := []time.Time{
+		date(2024, 1, 29), date(2024, 2, 29), date(2024, 3, 29),
+	}
+	if len(dates) != len(expected) {
+		t.Fatalf("expected %d, got %d", len(expected), len(dates))
+	}
+	for i, d := range dates {
+		if !d.Equal(expected[i]) {
+			t.Errorf("occurrence %d: expected %s, got %s", i, expected[i], d)
+		}
+	}
+}
+
+func TestExpandYearly(t *testing.T) {
+	start := date(2020, 3, 15)
+	from := date(2023, 1, 1)
+	to := date(2026, 12, 31)
+
+	dates := core.ExpandOccurrences(core.FrequencyYearly, start, from, to, 0, [2]int{}, nil)
+	expected := []time.Time{
+		date(2023, 3, 15), date(2024, 3, 15), date(2025, 3, 15), date(2026, 3, 15),
+	}
+	if len(dates) != len(expected) {
+		t.Fatalf("expected %d yearly occurrences, got %d", len(expected), len(dates))
+	}
+}
+
+func TestExpandWithEndDate(t *testing.T) {
+	start := date(2025, 1, 1)
+	from := date(2025, 1, 1)
+	to := date(2025, 12, 31)
+	endDate := datePtr(2025, 3, 15)
+
+	dates := core.ExpandOccurrences(core.FrequencyMonthly, start, from, to, 1, [2]int{}, endDate)
+	// Should stop at end date: Jan 1, Feb 1, Mar 1
+	if len(dates) != 3 {
+		t.Fatalf("expected 3 occurrences with end date, got %d", len(dates))
+	}
+}
+
+func TestExpandWeeklyFromMidRange(t *testing.T) {
+	start := date(2025, 1, 1)
+	from := date(2025, 1, 10) // Start querying after the rule started
+	to := date(2025, 1, 31)
+
+	dates := core.ExpandOccurrences(core.FrequencyWeekly, start, from, to, 0, [2]int{}, nil)
+	// First occurrence on or after Jan 10 from a Jan 1 weekly: Jan 15, Jan 22, Jan 29
+	if len(dates) != 3 {
+		t.Fatalf("expected 3 occurrences, got %d", len(dates))
+	}
+	if !dates[0].Equal(date(2025, 1, 15)) {
+		t.Errorf("first occurrence: expected 2025-01-15, got %s", dates[0])
+	}
+}

--- a/core/go.mod
+++ b/core/go.mod
@@ -4,11 +4,13 @@ go 1.24.0
 
 toolchain go1.24.1
 
-require modernc.org/sqlite v1.46.1
+require (
+	github.com/google/uuid v1.6.0
+	modernc.org/sqlite v1.46.1
+)
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/core/migrations/002_event_store.sql
+++ b/core/migrations/002_event_store.sql
@@ -1,0 +1,22 @@
+CREATE TABLE events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    aggregate_type TEXT NOT NULL,
+    aggregate_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    recorded_at INTEGER NOT NULL,
+    sequence INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_events_aggregate_seq ON events(aggregate_type, aggregate_id, sequence);
+CREATE INDEX idx_events_aggregate ON events(aggregate_type, aggregate_id);
+
+-- Recreate accounts with TEXT id for UUID-based aggregate identity.
+DROP TABLE IF EXISTS accounts;
+CREATE TABLE accounts (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    type INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);

--- a/core/migrations/003_recurring_and_transactions.sql
+++ b/core/migrations/003_recurring_and_transactions.sql
@@ -1,0 +1,27 @@
+CREATE TABLE recurring_rules (
+    id TEXT PRIMARY KEY,
+    account_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    amount INTEGER NOT NULL,
+    frequency INTEGER NOT NULL,
+    start_date TEXT NOT NULL,
+    end_date TEXT,
+    day_of_month INTEGER,
+    semi_monthly_days TEXT,
+    is_transfer INTEGER NOT NULL DEFAULT 0,
+    transfer_target_account_id TEXT,
+    paused INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (account_id) REFERENCES accounts(id)
+);
+
+CREATE TABLE transactions (
+    id TEXT PRIMARY KEY,
+    account_id TEXT NOT NULL,
+    date TEXT NOT NULL,
+    amount INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    status INTEGER NOT NULL DEFAULT 1,
+    recurring_rule_id TEXT,
+    FOREIGN KEY (account_id) REFERENCES accounts(id)
+);

--- a/core/projection.go
+++ b/core/projection.go
@@ -1,0 +1,349 @@
+package core
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// ProjectedTransaction represents a single transaction entry in a projection.
+type ProjectedTransaction struct {
+	Date            time.Time
+	Amount          int64
+	Name            string
+	AccountID       string
+	RecurringRuleID string
+	Status          TransactionStatus
+	IsProjected     bool // true if generated from a recurring rule, false if from a recorded transaction
+}
+
+// DailyBalance represents the projected balance for one account on one day.
+type DailyBalance struct {
+	Date         time.Time
+	AccountID    string
+	Balance      int64
+	Transactions []ProjectedTransaction
+}
+
+// ProjectionComparison shows how a projection changed between two points in time.
+type ProjectionComparison struct {
+	TargetDate    time.Time
+	AsOfDate1     time.Time
+	AsOfDate2     time.Time
+	AccountDeltas []AccountDelta
+}
+
+// AccountDelta shows the balance difference for one account between two projections.
+type AccountDelta struct {
+	AccountID       string
+	BalanceAsOf1    int64
+	BalanceAsOf2    int64
+	Delta           int64
+}
+
+// ProjectBalances computes daily balances for the given date range by merging
+// recorded transactions with expanded recurring rule occurrences.
+func (db *DB) ProjectBalances(ctx context.Context, from, to time.Time, accountIDs []string) ([]DailyBalance, error) {
+	var accounts []Account
+	var err error
+
+	if len(accountIDs) > 0 {
+		for _, id := range accountIDs {
+			acct, err := db.getAccount(ctx, id)
+			if err != nil {
+				return nil, fmt.Errorf("get account %s: %w", id, err)
+			}
+			accounts = append(accounts, *acct)
+		}
+	} else {
+		accounts, err = db.ListAccounts(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list accounts: %w", err)
+		}
+	}
+
+	var allBalances []DailyBalance
+
+	for _, acct := range accounts {
+		balances, err := db.projectAccountBalances(ctx, acct.ID, from, to)
+		if err != nil {
+			return nil, fmt.Errorf("project account %s: %w", acct.ID, err)
+		}
+		allBalances = append(allBalances, balances...)
+	}
+
+	sort.Slice(allBalances, func(i, j int) bool {
+		if allBalances[i].Date.Equal(allBalances[j].Date) {
+			return allBalances[i].AccountID < allBalances[j].AccountID
+		}
+		return allBalances[i].Date.Before(allBalances[j].Date)
+	})
+
+	return allBalances, nil
+}
+
+// ProjectBalanceOnDate returns the projected balance for a single account on a specific date.
+// It projects from the earliest relevant date through the target date to capture
+// all recorded transactions and recurring rule expansions.
+func (db *DB) ProjectBalanceOnDate(ctx context.Context, targetDate time.Time, accountID string) (int64, error) {
+	// Find the earliest relevant date (earliest transaction or rule start).
+	earliest, err := db.earliestDateForAccount(ctx, accountID)
+	if err != nil {
+		return 0, err
+	}
+	if earliest == nil {
+		return 0, nil // No data for this account.
+	}
+
+	balances, err := db.projectAccountBalances(ctx, accountID, *earliest, targetDate)
+	if err != nil {
+		return 0, err
+	}
+	if len(balances) == 0 {
+		return 0, nil
+	}
+	return balances[len(balances)-1].Balance, nil
+}
+
+func (db *DB) projectAccountBalances(ctx context.Context, accountID string, from, to time.Time) ([]DailyBalance, error) {
+	// Load recurring rules (needed for both starting balance and range projection).
+	rules, err := db.ListRecurringRules(ctx, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("list recurring rules: %w", err)
+	}
+
+	// Starting balance = recorded transactions before `from` + recurring rule
+	// expansions before `from` (excluding dates that have recorded transactions
+	// linked to the same rule).
+	beforeFrom := from.AddDate(0, 0, -1)
+	recordedBalance, err := db.computeBalanceUpTo(ctx, accountID, beforeFrom)
+	if err != nil {
+		return nil, fmt.Errorf("compute recorded balance: %w", err)
+	}
+
+	// Build a set of (date, ruleID) pairs that already have recorded transactions
+	// before the range, so we don't double-count recurring rule expansions.
+	priorRecorded, err := db.recordedRuleDatesBefore(ctx, accountID, from)
+	if err != nil {
+		return nil, fmt.Errorf("load prior recorded rule dates: %w", err)
+	}
+
+	// Add recurring rule occurrences before `from` to the starting balance.
+	startingBalance := recordedBalance
+	for _, rule := range rules {
+		if rule.Paused {
+			continue
+		}
+		priorOccurrences := ExpandOccurrences(
+			rule.Frequency, rule.StartDate, rule.StartDate, beforeFrom,
+			rule.DayOfMonth, rule.SemiMonthlyDays, rule.EndDate,
+		)
+		for _, occ := range priorOccurrences {
+			dateKey := occ.Format(time.DateOnly)
+			if priorRecorded[dateKey] != nil && priorRecorded[dateKey][rule.ID] {
+				continue
+			}
+			startingBalance += rule.Amount
+		}
+	}
+
+	// Collect all transaction entries in the [from, to] range.
+	var entries []ProjectedTransaction
+
+	// 1. Recorded transactions in the date range.
+	txns, err := db.listTransactionsInRange(ctx, accountID, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("list transactions in range: %w", err)
+	}
+	recordedDates := make(map[string]map[string]bool) // date -> recurringRuleID -> exists
+	for _, t := range txns {
+		entries = append(entries, ProjectedTransaction{
+			Date:            t.Date,
+			Amount:          t.Amount,
+			Name:            t.Name,
+			AccountID:       accountID,
+			RecurringRuleID: t.RecurringRuleID,
+			Status:          t.Status,
+			IsProjected:     false,
+		})
+		if t.RecurringRuleID != "" {
+			dateKey := t.Date.Format(time.DateOnly)
+			if recordedDates[dateKey] == nil {
+				recordedDates[dateKey] = make(map[string]bool)
+			}
+			recordedDates[dateKey][t.RecurringRuleID] = true
+		}
+	}
+
+	// 2. Expand recurring rules in the [from, to] range.
+	for _, rule := range rules {
+		if rule.Paused {
+			continue
+		}
+		occurrences := ExpandOccurrences(
+			rule.Frequency, rule.StartDate, from, to,
+			rule.DayOfMonth, rule.SemiMonthlyDays, rule.EndDate,
+		)
+		for _, occ := range occurrences {
+			dateKey := occ.Format(time.DateOnly)
+			if recordedDates[dateKey] != nil && recordedDates[dateKey][rule.ID] {
+				continue
+			}
+			entries = append(entries, ProjectedTransaction{
+				Date:            occ,
+				Amount:          rule.Amount,
+				Name:            rule.Name,
+				AccountID:       accountID,
+				RecurringRuleID: rule.ID,
+				Status:          TransactionStatusProjected,
+				IsProjected:     true,
+			})
+		}
+	}
+
+	// Sort entries by date, then name for stable ordering.
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Date.Equal(entries[j].Date) {
+			return entries[i].Name < entries[j].Name
+		}
+		return entries[i].Date.Before(entries[j].Date)
+	})
+
+	// Build daily balances.
+	balancesByDate := make(map[string]*DailyBalance)
+	var dateOrder []string
+
+	runningBalance := startingBalance
+	for _, entry := range entries {
+		dateKey := entry.Date.Format(time.DateOnly)
+		runningBalance += entry.Amount
+
+		if _, exists := balancesByDate[dateKey]; !exists {
+			balancesByDate[dateKey] = &DailyBalance{
+				Date:      entry.Date,
+				AccountID: accountID,
+			}
+			dateOrder = append(dateOrder, dateKey)
+		}
+		balancesByDate[dateKey].Balance = runningBalance
+		balancesByDate[dateKey].Transactions = append(balancesByDate[dateKey].Transactions, entry)
+	}
+
+	result := make([]DailyBalance, len(dateOrder))
+	for i, dk := range dateOrder {
+		result[i] = *balancesByDate[dk]
+	}
+	return result, nil
+}
+
+// earliestDateForAccount finds the earliest date relevant for projection:
+// the minimum of the earliest transaction date and earliest recurring rule start date.
+func (db *DB) earliestDateForAccount(ctx context.Context, accountID string) (*time.Time, error) {
+	var earliest *time.Time
+
+	var txnDate sql.NullString
+	row := db.conn.QueryRowContext(ctx,
+		"SELECT MIN(date) FROM transactions WHERE account_id = ?", accountID)
+	if err := row.Scan(&txnDate); err != nil {
+		return nil, fmt.Errorf("earliest transaction date: %w", err)
+	}
+	if txnDate.Valid {
+		t, err := time.Parse(time.DateOnly, txnDate.String)
+		if err != nil {
+			return nil, fmt.Errorf("parse transaction date: %w", err)
+		}
+		earliest = &t
+	}
+
+	var ruleDate sql.NullString
+	row = db.conn.QueryRowContext(ctx,
+		"SELECT MIN(start_date) FROM recurring_rules WHERE account_id = ? AND paused = 0", accountID)
+	if err := row.Scan(&ruleDate); err != nil {
+		return nil, fmt.Errorf("earliest rule start date: %w", err)
+	}
+	if ruleDate.Valid {
+		t, err := time.Parse(time.DateOnly, ruleDate.String)
+		if err != nil {
+			return nil, fmt.Errorf("parse rule date: %w", err)
+		}
+		if earliest == nil || t.Before(*earliest) {
+			earliest = &t
+		}
+	}
+
+	return earliest, nil
+}
+
+// recordedRuleDatesBefore returns a map of date -> ruleID for all transactions
+// with a recurring_rule_id before the given date. Used to avoid double-counting
+// recurring rule expansions when computing starting balances.
+func (db *DB) recordedRuleDatesBefore(ctx context.Context, accountID string, before time.Time) (map[string]map[string]bool, error) {
+	rows, err := db.conn.QueryContext(ctx,
+		`SELECT date, recurring_rule_id FROM transactions
+		 WHERE account_id = ? AND date < ? AND recurring_rule_id IS NOT NULL`,
+		accountID, before.Format(time.DateOnly),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query recorded rule dates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make(map[string]map[string]bool)
+	for rows.Next() {
+		var dateStr, ruleID string
+		if err := rows.Scan(&dateStr, &ruleID); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		if result[dateStr] == nil {
+			result[dateStr] = make(map[string]bool)
+		}
+		result[dateStr][ruleID] = true
+	}
+	return result, rows.Err()
+}
+
+// computeBalanceUpTo returns the sum of all transaction amounts on or before the given date.
+func (db *DB) computeBalanceUpTo(ctx context.Context, accountID string, upTo time.Time) (int64, error) {
+	var balance int64
+	row := db.conn.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(amount), 0) FROM transactions
+		 WHERE account_id = ? AND date <= ?`,
+		accountID, upTo.Format(time.DateOnly),
+	)
+	if err := row.Scan(&balance); err != nil {
+		return 0, fmt.Errorf("sum transactions: %w", err)
+	}
+	return balance, nil
+}
+
+// listTransactionsInRange returns transactions for an account within [from, to].
+func (db *DB) listTransactionsInRange(ctx context.Context, accountID string, from, to time.Time) ([]Transaction, error) {
+	rows, err := db.conn.QueryContext(ctx,
+		`SELECT id, account_id, date, amount, name, description, status, recurring_rule_id
+		 FROM transactions
+		 WHERE account_id = ? AND date >= ? AND date <= ?
+		 ORDER BY date, name`,
+		accountID, from.Format(time.DateOnly), to.Format(time.DateOnly),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query transactions in range: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanTransactions(rows)
+}
+
+// getAccount returns a single account by ID.
+func (db *DB) getAccount(ctx context.Context, id string) (*Account, error) {
+	row := db.conn.QueryRowContext(ctx,
+		"SELECT id, name, type, created_at, updated_at FROM accounts WHERE id = ?", id)
+	var a Account
+	var createdUnix, updatedUnix int64
+	if err := row.Scan(&a.ID, &a.Name, &a.Type, &createdUnix, &updatedUnix); err != nil {
+		return nil, fmt.Errorf("get account %s: %w", id, err)
+	}
+	a.CreatedAt = time.Unix(createdUnix, 0).UTC()
+	a.UpdatedAt = time.Unix(updatedUnix, 0).UTC()
+	return &a, nil
+}

--- a/core/projection_test.go
+++ b/core/projection_test.go
@@ -1,0 +1,482 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jakewan/finch/core"
+)
+
+func TestProjectBalancesSingleAccount(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	// Record a starting balance transaction.
+	_, err := db.RecordTransaction(ctx, core.RecordTransactionParams{
+		AccountID: acct.ID,
+		Date:      date(2025, 1, 1),
+		Amount:    500000, // $5000
+		Name:      "Opening Balance",
+		Status:    core.TransactionStatusReconciled,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction: %v", err)
+	}
+
+	// Create a monthly recurring rule: rent of -$1500 on the 1st.
+	_, err = db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+		AccountID:  acct.ID,
+		Name:       "Rent",
+		Amount:     -150000,
+		Frequency:  core.FrequencyMonthly,
+		StartDate:  date(2025, 1, 1),
+		DayOfMonth: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule: %v", err)
+	}
+
+	balances, err := db.ProjectBalances(ctx, date(2025, 1, 1), date(2025, 3, 31), []string{acct.ID})
+	if err != nil {
+		t.Fatalf("ProjectBalances: %v", err)
+	}
+
+	if len(balances) == 0 {
+		t.Fatal("expected non-empty balances")
+	}
+
+	// First day: opening balance ($5000) + rent (-$1500) = $3500
+	if balances[0].Balance != 350000 {
+		t.Fatalf("expected balance 350000 on first day, got %d", balances[0].Balance)
+	}
+
+	// Find Feb 1st balance: $3500 + (-$1500) = $2000
+	var febBalance *core.DailyBalance
+	for i := range balances {
+		if balances[i].Date.Equal(date(2025, 2, 1)) {
+			febBalance = &balances[i]
+			break
+		}
+	}
+	if febBalance == nil {
+		t.Fatal("expected balance entry for Feb 1")
+	}
+	if febBalance.Balance != 200000 {
+		t.Fatalf("expected Feb 1 balance 200000, got %d", febBalance.Balance)
+	}
+
+	// Mar 1st: $2000 + (-$1500) = $500
+	var marBalance *core.DailyBalance
+	for i := range balances {
+		if balances[i].Date.Equal(date(2025, 3, 1)) {
+			marBalance = &balances[i]
+			break
+		}
+	}
+	if marBalance == nil {
+		t.Fatal("expected balance entry for Mar 1")
+	}
+	if marBalance.Balance != 50000 {
+		t.Fatalf("expected Mar 1 balance 50000, got %d", marBalance.Balance)
+	}
+}
+
+func TestProjectBalancesNoDoubleCount(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	rule, err := db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+		AccountID:  acct.ID,
+		Name:       "Salary",
+		Amount:     300000,
+		Frequency:  core.FrequencyMonthly,
+		StartDate:  date(2025, 1, 15),
+		DayOfMonth: 15,
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule: %v", err)
+	}
+
+	// Record a transaction for Jan 15 matching this rule (simulating reconciliation).
+	_, err = db.RecordTransaction(ctx, core.RecordTransactionParams{
+		AccountID:       acct.ID,
+		Date:            date(2025, 1, 15),
+		Amount:          300000,
+		Name:            "Salary",
+		Status:          core.TransactionStatusReconciled,
+		RecurringRuleID: rule.ID,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction: %v", err)
+	}
+
+	balances, err := db.ProjectBalances(ctx, date(2025, 1, 1), date(2025, 2, 28), []string{acct.ID})
+	if err != nil {
+		t.Fatalf("ProjectBalances: %v", err)
+	}
+
+	// Jan 15 should have only one entry (the recorded one), not double-counted.
+	var jan15 *core.DailyBalance
+	for i := range balances {
+		if balances[i].Date.Equal(date(2025, 1, 15)) {
+			jan15 = &balances[i]
+			break
+		}
+	}
+	if jan15 == nil {
+		t.Fatal("expected balance entry for Jan 15")
+	}
+	if jan15.Balance != 300000 {
+		t.Fatalf("expected Jan 15 balance 300000 (no double count), got %d", jan15.Balance)
+	}
+	if len(jan15.Transactions) != 1 {
+		t.Fatalf("expected 1 transaction on Jan 15, got %d", len(jan15.Transactions))
+	}
+}
+
+func TestProjectBalanceOnDate(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	_, err := db.RecordTransaction(ctx, core.RecordTransactionParams{
+		AccountID: acct.ID,
+		Date:      date(2025, 1, 1),
+		Amount:    1000000,
+		Name:      "Opening",
+		Status:    core.TransactionStatusReconciled,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction: %v", err)
+	}
+
+	_, err = db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+		AccountID:  acct.ID,
+		Name:       "Rent",
+		Amount:     -150000,
+		Frequency:  core.FrequencyMonthly,
+		StartDate:  date(2025, 1, 1),
+		DayOfMonth: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule: %v", err)
+	}
+
+	// Balance on April 1: $10000 + 4 months of -$1500 = $10000 - $6000 = $4000
+	balance, err := db.ProjectBalanceOnDate(ctx, date(2025, 4, 1), acct.ID)
+	if err != nil {
+		t.Fatalf("ProjectBalanceOnDate: %v", err)
+	}
+	if balance != 400000 {
+		t.Fatalf("expected balance 400000, got %d", balance)
+	}
+}
+
+func TestProjectBalancesTransferNoDoubleCount(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	checking := createTestAccount(t, db)
+	savings, err := db.CreateAccount(ctx, "Savings", core.AccountTypeSavings)
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	// Opening balance in checking.
+	_, err = db.RecordTransaction(ctx, core.RecordTransactionParams{
+		AccountID: checking.ID,
+		Date:      date(2025, 1, 1),
+		Amount:    500000,
+		Name:      "Opening",
+		Status:    core.TransactionStatusReconciled,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction: %v", err)
+	}
+
+	// Transfer $1000 from checking to savings.
+	err = db.CreateTransfer(ctx, core.CreateTransferParams{
+		SourceAccountID:      checking.ID,
+		DestinationAccountID: savings.ID,
+		Amount:               100000,
+		Date:                 date(2025, 1, 15),
+		Name:                 "Transfer to Savings",
+		Status:               core.TransactionStatusReconciled,
+	})
+	if err != nil {
+		t.Fatalf("CreateTransfer: %v", err)
+	}
+
+	balances, err := db.ProjectBalances(ctx, date(2025, 1, 1), date(2025, 1, 31), nil)
+	if err != nil {
+		t.Fatalf("ProjectBalances: %v", err)
+	}
+
+	// Find checking balance on Jan 15.
+	var checkingJan15 int64
+	var savingsJan15 int64
+	for _, b := range balances {
+		if b.Date.Equal(date(2025, 1, 15)) {
+			switch b.AccountID {
+			case checking.ID:
+				checkingJan15 = b.Balance
+			case savings.ID:
+				savingsJan15 = b.Balance
+			}
+		}
+	}
+
+	// Checking: $5000 - $1000 = $4000
+	if checkingJan15 != 400000 {
+		t.Fatalf("expected checking balance 400000, got %d", checkingJan15)
+	}
+	// Savings: $0 + $1000 = $1000
+	if savingsJan15 != 100000 {
+		t.Fatalf("expected savings balance 100000, got %d", savingsJan15)
+	}
+}
+
+func TestProjectBalancesEmptyAccount(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	balances, err := db.ProjectBalances(ctx, date(2025, 1, 1), date(2025, 3, 31), []string{acct.ID})
+	if err != nil {
+		t.Fatalf("ProjectBalances: %v", err)
+	}
+	if len(balances) != 0 {
+		t.Fatalf("expected 0 balances for empty account, got %d", len(balances))
+	}
+}
+
+func TestProjectBalancesPausedRuleExcluded(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	rule, err := db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+		AccountID:  acct.ID,
+		Name:       "Subscription",
+		Amount:     -1499,
+		Frequency:  core.FrequencyMonthly,
+		StartDate:  date(2025, 1, 1),
+		DayOfMonth: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule: %v", err)
+	}
+
+	if err := db.PauseRecurringRule(ctx, rule.ID); err != nil {
+		t.Fatalf("PauseRecurringRule: %v", err)
+	}
+
+	balances, err := db.ProjectBalances(ctx, date(2025, 1, 1), date(2025, 3, 31), []string{acct.ID})
+	if err != nil {
+		t.Fatalf("ProjectBalances: %v", err)
+	}
+	if len(balances) != 0 {
+		t.Fatalf("expected 0 balances (rule paused), got %d", len(balances))
+	}
+}
+
+func TestProjectBalancesMixedRecurringAndOneOff(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	// Opening balance.
+	_, err := db.RecordTransaction(ctx, core.RecordTransactionParams{
+		AccountID: acct.ID,
+		Date:      date(2025, 1, 1),
+		Amount:    200000,
+		Name:      "Opening",
+		Status:    core.TransactionStatusReconciled,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction opening: %v", err)
+	}
+
+	// Monthly subscription.
+	_, err = db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+		AccountID:  acct.ID,
+		Name:       "Netflix",
+		Amount:     -1599,
+		Frequency:  core.FrequencyMonthly,
+		StartDate:  date(2025, 1, 15),
+		DayOfMonth: 15,
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule: %v", err)
+	}
+
+	// One-off expense.
+	_, err = db.RecordTransaction(ctx, core.RecordTransactionParams{
+		AccountID: acct.ID,
+		Date:      date(2025, 1, 20),
+		Amount:    -5000,
+		Name:      "Lunch",
+		Status:    core.TransactionStatusReconciled,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction lunch: %v", err)
+	}
+
+	balances, err := db.ProjectBalances(ctx, date(2025, 1, 1), date(2025, 2, 28), []string{acct.ID})
+	if err != nil {
+		t.Fatalf("ProjectBalances: %v", err)
+	}
+
+	// Verify the final balance on Feb 15:
+	// Opening: $2000.00
+	// Jan 15 Netflix: -$15.99 → $1984.01
+	// Jan 20 Lunch: -$50.00 → $1934.01
+	// Feb 15 Netflix: -$15.99 → $1918.02
+	expectedFinal := int64(200000 - 1599 - 5000 - 1599) // 191802
+	var feb15 *core.DailyBalance
+	for i := range balances {
+		if balances[i].Date.Equal(date(2025, 2, 15)) {
+			feb15 = &balances[i]
+			break
+		}
+	}
+	if feb15 == nil {
+		t.Fatal("expected balance entry for Feb 15")
+	}
+	if feb15.Balance != expectedFinal {
+		t.Fatalf("expected Feb 15 balance %d, got %d", expectedFinal, feb15.Balance)
+	}
+}
+
+func TestProjectBalanceOnDateNoTransactionsOnDate(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	_, err := db.RecordTransaction(ctx, core.RecordTransactionParams{
+		AccountID: acct.ID,
+		Date:      date(2025, 1, 1),
+		Amount:    100000,
+		Name:      "Opening",
+		Status:    core.TransactionStatusReconciled,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction: %v", err)
+	}
+
+	// Query a date with no transactions — should show the prior balance.
+	balance, err := db.ProjectBalanceOnDate(ctx, date(2025, 1, 10), acct.ID)
+	if err != nil {
+		t.Fatalf("ProjectBalanceOnDate: %v", err)
+	}
+	if balance != 100000 {
+		t.Fatalf("expected balance 100000, got %d", balance)
+	}
+}
+
+func TestProjectBalancesMultipleAccounts(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	checking := createTestAccount(t, db)
+	savings, err := db.CreateAccount(ctx, "Savings", core.AccountTypeSavings)
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	_, err = db.RecordTransaction(ctx, core.RecordTransactionParams{
+		AccountID: checking.ID, Date: date(2025, 1, 1), Amount: 500000,
+		Name: "Opening", Status: core.TransactionStatusReconciled,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction checking: %v", err)
+	}
+
+	_, err = db.RecordTransaction(ctx, core.RecordTransactionParams{
+		AccountID: savings.ID, Date: date(2025, 1, 1), Amount: 1000000,
+		Name: "Opening", Status: core.TransactionStatusReconciled,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction savings: %v", err)
+	}
+
+	// Project all accounts (nil = all).
+	balances, err := db.ProjectBalances(ctx, date(2025, 1, 1), date(2025, 1, 1), nil)
+	if err != nil {
+		t.Fatalf("ProjectBalances: %v", err)
+	}
+
+	if len(balances) != 2 {
+		t.Fatalf("expected 2 balance entries, got %d", len(balances))
+	}
+
+	// Both should be on Jan 1, ordered by account ID.
+	foundChecking := false
+	foundSavings := false
+	for _, b := range balances {
+		if b.AccountID == checking.ID && b.Balance == 500000 {
+			foundChecking = true
+		}
+		if b.AccountID == savings.ID && b.Balance == 1000000 {
+			foundSavings = true
+		}
+	}
+	if !foundChecking {
+		t.Fatal("missing checking balance")
+	}
+	if !foundSavings {
+		t.Fatal("missing savings balance")
+	}
+}
+
+// TestProjectBalanceOnDateWithRecurringRules verifies the convenience method
+// correctly incorporates recurring rule expansions.
+func TestProjectBalanceOnDateWithRecurringRules(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	// Opening: $10000
+	_, err := db.RecordTransaction(ctx, core.RecordTransactionParams{
+		AccountID: acct.ID, Date: date(2025, 1, 1), Amount: 1000000,
+		Name: "Opening", Status: core.TransactionStatusReconciled,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction: %v", err)
+	}
+
+	// Biweekly paycheck of $2000 starting Jan 3.
+	_, err = db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+		AccountID: acct.ID, Name: "Paycheck", Amount: 200000,
+		Frequency: core.FrequencyBiweekly, StartDate: date(2025, 1, 3),
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule: %v", err)
+	}
+
+	// Monthly rent of -$1500 on the 1st.
+	_, err = db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+		AccountID: acct.ID, Name: "Rent", Amount: -150000,
+		Frequency: core.FrequencyMonthly, StartDate: date(2025, 1, 1), DayOfMonth: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule rent: %v", err)
+	}
+
+	// Balance on Feb 1:
+	// Jan 1: Opening $10000 + Rent -$1500 = $8500
+	// Jan 3: Paycheck +$2000 = $10500
+	// Jan 17: Paycheck +$2000 = $12500
+	// Jan 31: Paycheck +$2000 = $14500
+	// Feb 1: Rent -$1500 = $13000
+	balance, err := db.ProjectBalanceOnDate(ctx, date(2025, 2, 1), acct.ID)
+	if err != nil {
+		t.Fatalf("ProjectBalanceOnDate: %v", err)
+	}
+	expected := int64(1000000 - 150000 + 200000 + 200000 + 200000 - 150000) // 1300000
+	if balance != expected {
+		t.Fatalf("expected balance %d, got %d", expected, balance)
+	}
+}

--- a/core/recurring.go
+++ b/core/recurring.go
@@ -1,0 +1,364 @@
+package core
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const aggregateTypeRecurringRule = "recurring_rule"
+
+// Recurring rule event types.
+const (
+	EventRecurringRuleCreated       = "RecurringRuleCreated"
+	EventRecurringRuleAmountChanged = "RecurringRuleAmountChanged"
+	EventRecurringRulePaused        = "RecurringRulePaused"
+	EventRecurringRuleResumed       = "RecurringRuleResumed"
+	EventRecurringRuleEnded         = "RecurringRuleEnded"
+)
+
+// RecurringRule represents the read model for a recurring transaction template.
+type RecurringRule struct {
+	ID                     string
+	AccountID              string
+	Name                   string
+	Amount                 int64 // cents
+	Frequency              Frequency
+	StartDate              time.Time
+	EndDate                *time.Time
+	DayOfMonth             int
+	SemiMonthlyDays        [2]int
+	IsTransfer             bool
+	TransferTargetAccountID string
+	Paused                 bool
+}
+
+// RecurringRuleCreatedPayload is the event data for rule creation.
+type RecurringRuleCreatedPayload struct {
+	AccountID              string `json:"account_id"`
+	Name                   string `json:"name"`
+	Amount                 int64  `json:"amount"`
+	Frequency              int    `json:"frequency"`
+	StartDate              string `json:"start_date"`
+	EndDate                string `json:"end_date,omitempty"`
+	DayOfMonth             int    `json:"day_of_month,omitempty"`
+	SemiMonthlyDays        []int  `json:"semi_monthly_days,omitempty"`
+	IsTransfer             bool   `json:"is_transfer,omitempty"`
+	TransferTargetAccountID string `json:"transfer_target_account_id,omitempty"`
+}
+
+// RecurringRuleAmountChangedPayload records an amount change with context.
+type RecurringRuleAmountChangedPayload struct {
+	OldAmount     int64  `json:"old_amount"`
+	NewAmount     int64  `json:"new_amount"`
+	EffectiveDate string `json:"effective_date"`
+	Reason        string `json:"reason,omitempty"`
+}
+
+// RecurringRulePausedPayload records when a rule was paused.
+type RecurringRulePausedPayload struct{}
+
+// RecurringRuleResumedPayload records when a rule was resumed.
+type RecurringRuleResumedPayload struct{}
+
+// RecurringRuleEndedPayload records the end date for a rule.
+type RecurringRuleEndedPayload struct {
+	EndDate string `json:"end_date"`
+}
+
+// CreateRecurringRuleParams holds validated input for creating a recurring rule.
+type CreateRecurringRuleParams struct {
+	AccountID              string
+	Name                   string
+	Amount                 int64
+	Frequency              Frequency
+	StartDate              time.Time
+	EndDate                *time.Time
+	DayOfMonth             int
+	SemiMonthlyDays        [2]int
+	IsTransfer             bool
+	TransferTargetAccountID string
+}
+
+// CreateRecurringRule validates input, appends a RecurringRuleCreated event,
+// and updates the read model within a single transaction.
+func (db *DB) CreateRecurringRule(ctx context.Context, params CreateRecurringRuleParams) (*RecurringRule, error) {
+	params.Name = strings.TrimSpace(params.Name)
+	if params.Name == "" {
+		return nil, errors.New("recurring rule name must not be empty")
+	}
+	if params.AccountID == "" {
+		return nil, errors.New("account_id must not be empty")
+	}
+	if !ValidFrequency(params.Frequency) {
+		return nil, fmt.Errorf("invalid frequency: %d", params.Frequency)
+	}
+	if params.Frequency == FrequencyMonthly && (params.DayOfMonth < 1 || params.DayOfMonth > 31) {
+		return nil, fmt.Errorf("day_of_month must be 1-31 for monthly frequency, got %d", params.DayOfMonth)
+	}
+	if params.Frequency == FrequencySemiMonthly {
+		if params.SemiMonthlyDays[0] < 1 || params.SemiMonthlyDays[0] > 31 ||
+			params.SemiMonthlyDays[1] < 1 || params.SemiMonthlyDays[1] > 31 {
+			return nil, fmt.Errorf("semi_monthly_days must each be 1-31")
+		}
+	}
+
+	id := uuid.New().String()
+
+	p := RecurringRuleCreatedPayload{
+		AccountID:              params.AccountID,
+		Name:                   params.Name,
+		Amount:                 params.Amount,
+		Frequency:              int(params.Frequency),
+		StartDate:              params.StartDate.Format(time.DateOnly),
+		IsTransfer:             params.IsTransfer,
+		TransferTargetAccountID: params.TransferTargetAccountID,
+	}
+	if params.EndDate != nil {
+		p.EndDate = params.EndDate.Format(time.DateOnly)
+	}
+	if params.DayOfMonth > 0 {
+		p.DayOfMonth = params.DayOfMonth
+	}
+	if params.Frequency == FrequencySemiMonthly {
+		p.SemiMonthlyDays = []int{params.SemiMonthlyDays[0], params.SemiMonthlyDays[1]}
+	}
+
+	payload, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("marshal event payload: %w", err)
+	}
+
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+
+	if _, err := appendEvents(ctx, tx, aggregateTypeRecurringRule, id, []NewEvent{
+		{EventType: EventRecurringRuleCreated, Payload: payload},
+	}); err != nil {
+		_ = tx.Rollback()
+		return nil, fmt.Errorf("append event: %w", err)
+	}
+
+	var endDateStr *string
+	if params.EndDate != nil {
+		s := params.EndDate.Format(time.DateOnly)
+		endDateStr = &s
+	}
+	var semiMonthlyJSON *string
+	if params.Frequency == FrequencySemiMonthly {
+		b, _ := json.Marshal([]int{params.SemiMonthlyDays[0], params.SemiMonthlyDays[1]})
+		s := string(b)
+		semiMonthlyJSON = &s
+	}
+	var transferTarget *string
+	if params.TransferTargetAccountID != "" {
+		transferTarget = &params.TransferTargetAccountID
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO recurring_rules (id, account_id, name, amount, frequency, start_date, end_date,
+		 day_of_month, semi_monthly_days, is_transfer, transfer_target_account_id, paused)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+		id, params.AccountID, params.Name, params.Amount, int(params.Frequency),
+		params.StartDate.Format(time.DateOnly), endDateStr,
+		params.DayOfMonth, semiMonthlyJSON,
+		boolToInt(params.IsTransfer), transferTarget,
+	); err != nil {
+		_ = tx.Rollback()
+		return nil, fmt.Errorf("insert recurring_rules read model: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+
+	return &RecurringRule{
+		ID:                     id,
+		AccountID:              params.AccountID,
+		Name:                   params.Name,
+		Amount:                 params.Amount,
+		Frequency:              params.Frequency,
+		StartDate:              params.StartDate,
+		EndDate:                params.EndDate,
+		DayOfMonth:             params.DayOfMonth,
+		SemiMonthlyDays:        params.SemiMonthlyDays,
+		IsTransfer:             params.IsTransfer,
+		TransferTargetAccountID: params.TransferTargetAccountID,
+		Paused:                 false,
+	}, nil
+}
+
+// ListRecurringRules returns recurring rules, optionally filtered by account.
+func (db *DB) ListRecurringRules(ctx context.Context, accountID string) ([]RecurringRule, error) {
+	var rows *sql.Rows
+	var err error
+	if accountID != "" {
+		rows, err = db.conn.QueryContext(ctx,
+			`SELECT id, account_id, name, amount, frequency, start_date, end_date,
+			 day_of_month, semi_monthly_days, is_transfer, transfer_target_account_id, paused
+			 FROM recurring_rules WHERE account_id = ? ORDER BY name`, accountID)
+	} else {
+		rows, err = db.conn.QueryContext(ctx,
+			`SELECT id, account_id, name, amount, frequency, start_date, end_date,
+			 day_of_month, semi_monthly_days, is_transfer, transfer_target_account_id, paused
+			 FROM recurring_rules ORDER BY name`)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query recurring_rules: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanRecurringRules(rows)
+}
+
+// UpdateRecurringRuleAmount changes a rule's amount and records the change event.
+func (db *DB) UpdateRecurringRuleAmount(ctx context.Context, ruleID string, newAmount int64, effectiveDate time.Time, reason string) error {
+	if ruleID == "" {
+		return errors.New("rule_id must not be empty")
+	}
+
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+
+	var oldAmount int64
+	row := tx.QueryRowContext(ctx, "SELECT amount FROM recurring_rules WHERE id = ?", ruleID)
+	if err := row.Scan(&oldAmount); err != nil {
+		_ = tx.Rollback()
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("recurring rule %s not found", ruleID)
+		}
+		return fmt.Errorf("read current amount: %w", err)
+	}
+
+	payload, err := json.Marshal(RecurringRuleAmountChangedPayload{
+		OldAmount:     oldAmount,
+		NewAmount:     newAmount,
+		EffectiveDate: effectiveDate.Format(time.DateOnly),
+		Reason:        reason,
+	})
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	if _, err := appendEvents(ctx, tx, aggregateTypeRecurringRule, ruleID, []NewEvent{
+		{EventType: EventRecurringRuleAmountChanged, Payload: payload},
+	}); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("append event: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		"UPDATE recurring_rules SET amount = ? WHERE id = ?", newAmount, ruleID); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("update read model: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// PauseRecurringRule marks a rule as paused.
+func (db *DB) PauseRecurringRule(ctx context.Context, ruleID string) error {
+	return db.setRecurringRulePaused(ctx, ruleID, true, EventRecurringRulePaused)
+}
+
+// ResumeRecurringRule marks a rule as active.
+func (db *DB) ResumeRecurringRule(ctx context.Context, ruleID string) error {
+	return db.setRecurringRulePaused(ctx, ruleID, false, EventRecurringRuleResumed)
+}
+
+func (db *DB) setRecurringRulePaused(ctx context.Context, ruleID string, paused bool, eventType string) error {
+	if ruleID == "" {
+		return errors.New("rule_id must not be empty")
+	}
+
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+
+	payload, _ := json.Marshal(struct{}{})
+	if _, err := appendEvents(ctx, tx, aggregateTypeRecurringRule, ruleID, []NewEvent{
+		{EventType: eventType, Payload: payload},
+	}); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("append event: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		"UPDATE recurring_rules SET paused = ? WHERE id = ?", boolToInt(paused), ruleID); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("update read model: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// GetRecurringRuleHistory returns the event history for a specific recurring rule.
+func (db *DB) GetRecurringRuleHistory(ctx context.Context, ruleID string) ([]Event, error) {
+	return db.LoadEvents(ctx, aggregateTypeRecurringRule, ruleID)
+}
+
+func scanRecurringRules(rows *sql.Rows) ([]RecurringRule, error) {
+	var rules []RecurringRule
+	for rows.Next() {
+		var r RecurringRule
+		var startDateStr string
+		var endDateStr sql.NullString
+		var semiMonthlyStr sql.NullString
+		var transferTarget sql.NullString
+		var isTransfer, paused int
+
+		if err := rows.Scan(&r.ID, &r.AccountID, &r.Name, &r.Amount, &r.Frequency,
+			&startDateStr, &endDateStr, &r.DayOfMonth, &semiMonthlyStr,
+			&isTransfer, &transferTarget, &paused); err != nil {
+			return nil, fmt.Errorf("scan recurring_rule: %w", err)
+		}
+
+		sd, err := time.Parse(time.DateOnly, startDateStr)
+		if err != nil {
+			return nil, fmt.Errorf("parse start_date: %w", err)
+		}
+		r.StartDate = sd
+
+		if endDateStr.Valid {
+			ed, err := time.Parse(time.DateOnly, endDateStr.String)
+			if err != nil {
+				return nil, fmt.Errorf("parse end_date: %w", err)
+			}
+			r.EndDate = &ed
+		}
+
+		if semiMonthlyStr.Valid {
+			var days []int
+			if err := json.Unmarshal([]byte(semiMonthlyStr.String), &days); err == nil && len(days) == 2 {
+				r.SemiMonthlyDays = [2]int{days[0], days[1]}
+			}
+		}
+
+		r.IsTransfer = isTransfer != 0
+		r.Paused = paused != 0
+		if transferTarget.Valid {
+			r.TransferTargetAccountID = transferTarget.String
+		}
+
+		rules = append(rules, r)
+	}
+	return rules, rows.Err()
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/core/recurring_test.go
+++ b/core/recurring_test.go
@@ -1,0 +1,237 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jakewan/finch/core"
+)
+
+func createTestAccount(t *testing.T, db *core.DB) *core.Account {
+	t.Helper()
+	acct, err := db.CreateAccount(context.Background(), "Test Account", core.AccountTypeChecking)
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	return acct
+}
+
+func TestCreateAndListRecurringRules(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	rule, err := db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+		AccountID: acct.ID,
+		Name:      "Rent",
+		Amount:    150000, // $1500.00
+		Frequency: core.FrequencyMonthly,
+		StartDate: date(2025, 1, 1),
+		DayOfMonth: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule: %v", err)
+	}
+	if rule.ID == "" {
+		t.Fatal("expected non-empty rule ID")
+	}
+	if rule.Amount != 150000 {
+		t.Fatalf("expected amount 150000, got %d", rule.Amount)
+	}
+
+	rules, err := db.ListRecurringRules(ctx, acct.ID)
+	if err != nil {
+		t.Fatalf("ListRecurringRules: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
+	}
+	if rules[0].Name != "Rent" {
+		t.Fatalf("expected Rent, got %s", rules[0].Name)
+	}
+}
+
+func TestCreateRecurringRuleValidation(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	tests := []struct {
+		name   string
+		params core.CreateRecurringRuleParams
+	}{
+		{"empty name", core.CreateRecurringRuleParams{AccountID: acct.ID, Frequency: core.FrequencyMonthly, DayOfMonth: 1, StartDate: date(2025, 1, 1)}},
+		{"empty account", core.CreateRecurringRuleParams{Name: "Test", Frequency: core.FrequencyMonthly, DayOfMonth: 1, StartDate: date(2025, 1, 1)}},
+		{"invalid frequency", core.CreateRecurringRuleParams{AccountID: acct.ID, Name: "Test", Frequency: 99, StartDate: date(2025, 1, 1)}},
+		{"monthly without day", core.CreateRecurringRuleParams{AccountID: acct.ID, Name: "Test", Frequency: core.FrequencyMonthly, StartDate: date(2025, 1, 1)}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := db.CreateRecurringRule(ctx, tc.params); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestUpdateRecurringRuleAmount(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	rule, err := db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+		AccountID:  acct.ID,
+		Name:       "Car Payment",
+		Amount:     45000,
+		Frequency:  core.FrequencyMonthly,
+		StartDate:  date(2025, 1, 15),
+		DayOfMonth: 15,
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule: %v", err)
+	}
+
+	if err := db.UpdateRecurringRuleAmount(ctx, rule.ID, 50000, date(2025, 6, 1), "rate adjustment"); err != nil {
+		t.Fatalf("UpdateRecurringRuleAmount: %v", err)
+	}
+
+	rules, err := db.ListRecurringRules(ctx, acct.ID)
+	if err != nil {
+		t.Fatalf("ListRecurringRules: %v", err)
+	}
+	if rules[0].Amount != 50000 {
+		t.Fatalf("expected updated amount 50000, got %d", rules[0].Amount)
+	}
+
+	// Verify event history records the change.
+	events, err := db.GetRecurringRuleHistory(ctx, rule.ID)
+	if err != nil {
+		t.Fatalf("GetRecurringRuleHistory: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[1].EventType != "RecurringRuleAmountChanged" {
+		t.Fatalf("expected RecurringRuleAmountChanged, got %s", events[1].EventType)
+	}
+}
+
+func TestPauseAndResumeRecurringRule(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	rule, err := db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+		AccountID:  acct.ID,
+		Name:       "Subscription",
+		Amount:     1499,
+		Frequency:  core.FrequencyMonthly,
+		StartDate:  date(2025, 1, 1),
+		DayOfMonth: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule: %v", err)
+	}
+
+	if err := db.PauseRecurringRule(ctx, rule.ID); err != nil {
+		t.Fatalf("PauseRecurringRule: %v", err)
+	}
+
+	rules, err := db.ListRecurringRules(ctx, acct.ID)
+	if err != nil {
+		t.Fatalf("ListRecurringRules: %v", err)
+	}
+	if !rules[0].Paused {
+		t.Fatal("expected rule to be paused")
+	}
+
+	if err := db.ResumeRecurringRule(ctx, rule.ID); err != nil {
+		t.Fatalf("ResumeRecurringRule: %v", err)
+	}
+
+	rules, err = db.ListRecurringRules(ctx, acct.ID)
+	if err != nil {
+		t.Fatalf("ListRecurringRules: %v", err)
+	}
+	if rules[0].Paused {
+		t.Fatal("expected rule to be resumed")
+	}
+}
+
+func TestListRecurringRulesAllAccounts(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	acct1 := createTestAccount(t, db)
+	acct2, err := db.CreateAccount(ctx, "Savings", core.AccountTypeSavings)
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	_, err = db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+		AccountID: acct1.ID, Name: "Rule A", Amount: 100, Frequency: core.FrequencyWeekly,
+		StartDate: date(2025, 1, 1),
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule A: %v", err)
+	}
+	_, err = db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+		AccountID: acct2.ID, Name: "Rule B", Amount: 200, Frequency: core.FrequencyWeekly,
+		StartDate: date(2025, 1, 1),
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule B: %v", err)
+	}
+
+	// Filter by account.
+	rules, err := db.ListRecurringRules(ctx, acct1.ID)
+	if err != nil {
+		t.Fatalf("ListRecurringRules: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule for acct1, got %d", len(rules))
+	}
+
+	// All accounts.
+	allRules, err := db.ListRecurringRules(ctx, "")
+	if err != nil {
+		t.Fatalf("ListRecurringRules all: %v", err)
+	}
+	if len(allRules) != 2 {
+		t.Fatalf("expected 2 rules total, got %d", len(allRules))
+	}
+}
+
+func TestRecurringRuleWithEndDate(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	endDate := time.Date(2025, 6, 30, 0, 0, 0, 0, time.UTC)
+	rule, err := db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+		AccountID:  acct.ID,
+		Name:       "Temp Subscription",
+		Amount:     999,
+		Frequency:  core.FrequencyMonthly,
+		StartDate:  date(2025, 1, 1),
+		EndDate:    &endDate,
+		DayOfMonth: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule: %v", err)
+	}
+
+	rules, err := db.ListRecurringRules(ctx, acct.ID)
+	if err != nil {
+		t.Fatalf("ListRecurringRules: %v", err)
+	}
+	if rules[0].EndDate == nil {
+		t.Fatal("expected non-nil end date")
+	}
+	if !rules[0].EndDate.Equal(endDate) {
+		t.Fatalf("expected end date %s, got %s", endDate, *rules[0].EndDate)
+	}
+	_ = rule
+}

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -1,0 +1,366 @@
+package core
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const aggregateTypeTransaction = "transaction"
+
+// Transaction event types.
+const (
+	EventTransactionRecorded      = "TransactionRecorded"
+	EventTransactionStatusChanged = "TransactionStatusChanged"
+	EventTransferCreated          = "TransferCreated"
+)
+
+// TransactionStatus represents the lifecycle state of a transaction.
+type TransactionStatus int
+
+const (
+	TransactionStatusUnspecified TransactionStatus = 0
+	TransactionStatusProjected  TransactionStatus = 1
+	TransactionStatusScheduled  TransactionStatus = 2
+	TransactionStatusReconciled TransactionStatus = 3
+)
+
+func ValidTransactionStatus(s TransactionStatus) bool {
+	return s >= TransactionStatusProjected && s <= TransactionStatusReconciled
+}
+
+// Transaction represents the read model for a financial transaction.
+type Transaction struct {
+	ID              string
+	AccountID       string
+	Date            time.Time
+	Amount          int64 // cents
+	Name            string
+	Description     string
+	Status          TransactionStatus
+	RecurringRuleID string
+}
+
+// TransactionRecordedPayload is the event data for recording a transaction.
+type TransactionRecordedPayload struct {
+	AccountID       string `json:"account_id"`
+	Date            string `json:"date"`
+	Amount          int64  `json:"amount"`
+	Name            string `json:"name"`
+	Description     string `json:"description,omitempty"`
+	Status          int    `json:"status"`
+	RecurringRuleID string `json:"recurring_rule_id,omitempty"`
+}
+
+// TransactionStatusChangedPayload records a status transition.
+type TransactionStatusChangedPayload struct {
+	OldStatus int `json:"old_status"`
+	NewStatus int `json:"new_status"`
+}
+
+// TransferCreatedPayload records both sides of a transfer.
+type TransferCreatedPayload struct {
+	SourceAccountID      string `json:"source_account_id"`
+	DestinationAccountID string `json:"destination_account_id"`
+	RecurringRuleID      string `json:"recurring_rule_id,omitempty"`
+	Amount               int64  `json:"amount"`
+	Date                 string `json:"date"`
+	SourceTransactionID  string `json:"source_transaction_id"`
+	DestTransactionID    string `json:"dest_transaction_id"`
+}
+
+// RecordTransactionParams holds validated input for recording a transaction.
+type RecordTransactionParams struct {
+	AccountID       string
+	Date            time.Time
+	Amount          int64
+	Name            string
+	Description     string
+	Status          TransactionStatus
+	RecurringRuleID string
+}
+
+// RecordTransaction creates a new transaction with event sourcing.
+func (db *DB) RecordTransaction(ctx context.Context, params RecordTransactionParams) (*Transaction, error) {
+	params.Name = strings.TrimSpace(params.Name)
+	if params.Name == "" {
+		return nil, errors.New("transaction name must not be empty")
+	}
+	if params.AccountID == "" {
+		return nil, errors.New("account_id must not be empty")
+	}
+	if !ValidTransactionStatus(params.Status) {
+		return nil, fmt.Errorf("invalid transaction status: %d", params.Status)
+	}
+
+	id := uuid.New().String()
+
+	payload, err := json.Marshal(TransactionRecordedPayload{
+		AccountID:       params.AccountID,
+		Date:            params.Date.Format(time.DateOnly),
+		Amount:          params.Amount,
+		Name:            params.Name,
+		Description:     params.Description,
+		Status:          int(params.Status),
+		RecurringRuleID: params.RecurringRuleID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal event payload: %w", err)
+	}
+
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+
+	if _, err := appendEvents(ctx, tx, aggregateTypeTransaction, id, []NewEvent{
+		{EventType: EventTransactionRecorded, Payload: payload},
+	}); err != nil {
+		_ = tx.Rollback()
+		return nil, fmt.Errorf("append event: %w", err)
+	}
+
+	var recurringRuleID *string
+	if params.RecurringRuleID != "" {
+		recurringRuleID = &params.RecurringRuleID
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO transactions (id, account_id, date, amount, name, description, status, recurring_rule_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, params.AccountID, params.Date.Format(time.DateOnly), params.Amount,
+		params.Name, nilIfEmpty(params.Description), int(params.Status), recurringRuleID,
+	); err != nil {
+		_ = tx.Rollback()
+		return nil, fmt.Errorf("insert transaction read model: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+
+	return &Transaction{
+		ID:              id,
+		AccountID:       params.AccountID,
+		Date:            params.Date,
+		Amount:          params.Amount,
+		Name:            params.Name,
+		Description:     params.Description,
+		Status:          params.Status,
+		RecurringRuleID: params.RecurringRuleID,
+	}, nil
+}
+
+// UpdateTransactionStatus transitions a transaction to a new status.
+func (db *DB) UpdateTransactionStatus(ctx context.Context, txnID string, newStatus TransactionStatus) error {
+	if txnID == "" {
+		return errors.New("transaction_id must not be empty")
+	}
+	if !ValidTransactionStatus(newStatus) {
+		return fmt.Errorf("invalid transaction status: %d", newStatus)
+	}
+
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+
+	var oldStatus int
+	row := tx.QueryRowContext(ctx, "SELECT status FROM transactions WHERE id = ?", txnID)
+	if err := row.Scan(&oldStatus); err != nil {
+		_ = tx.Rollback()
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("transaction %s not found", txnID)
+		}
+		return fmt.Errorf("read current status: %w", err)
+	}
+
+	payload, err := json.Marshal(TransactionStatusChangedPayload{
+		OldStatus: oldStatus,
+		NewStatus: int(newStatus),
+	})
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	if _, err := appendEvents(ctx, tx, aggregateTypeTransaction, txnID, []NewEvent{
+		{EventType: EventTransactionStatusChanged, Payload: payload},
+	}); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("append event: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		"UPDATE transactions SET status = ? WHERE id = ?", int(newStatus), txnID); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("update read model: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// CreateTransferParams holds input for creating a transfer between accounts.
+type CreateTransferParams struct {
+	SourceAccountID      string
+	DestinationAccountID string
+	Amount               int64 // positive amount, will be negated for source
+	Date                 time.Time
+	Name                 string
+	Description          string
+	Status               TransactionStatus
+	RecurringRuleID      string
+}
+
+// CreateTransfer records a transfer as paired transactions on source and destination accounts.
+func (db *DB) CreateTransfer(ctx context.Context, params CreateTransferParams) error {
+	if params.SourceAccountID == "" || params.DestinationAccountID == "" {
+		return errors.New("both source and destination account_id must be provided")
+	}
+	if params.Amount <= 0 {
+		return errors.New("transfer amount must be positive")
+	}
+	params.Name = strings.TrimSpace(params.Name)
+	if params.Name == "" {
+		return errors.New("transfer name must not be empty")
+	}
+
+	sourceID := uuid.New().String()
+	destID := uuid.New().String()
+	dateStr := params.Date.Format(time.DateOnly)
+
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+
+	// Source transaction (negative amount — money leaving).
+	sourcePayload, _ := json.Marshal(TransactionRecordedPayload{
+		AccountID:       params.SourceAccountID,
+		Date:            dateStr,
+		Amount:          -params.Amount,
+		Name:            params.Name,
+		Status:          int(params.Status),
+		RecurringRuleID: params.RecurringRuleID,
+	})
+	if _, err := appendEvents(ctx, tx, aggregateTypeTransaction, sourceID, []NewEvent{
+		{EventType: EventTransactionRecorded, Payload: sourcePayload},
+	}); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("append source event: %w", err)
+	}
+
+	// Destination transaction (positive amount — money arriving).
+	destPayload, _ := json.Marshal(TransactionRecordedPayload{
+		AccountID:       params.DestinationAccountID,
+		Date:            dateStr,
+		Amount:          params.Amount,
+		Name:            params.Name,
+		Status:          int(params.Status),
+		RecurringRuleID: params.RecurringRuleID,
+	})
+	if _, err := appendEvents(ctx, tx, aggregateTypeTransaction, destID, []NewEvent{
+		{EventType: EventTransactionRecorded, Payload: destPayload},
+	}); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("append dest event: %w", err)
+	}
+
+	// Transfer event linking both sides.
+	transferPayload, _ := json.Marshal(TransferCreatedPayload{
+		SourceAccountID:      params.SourceAccountID,
+		DestinationAccountID: params.DestinationAccountID,
+		RecurringRuleID:      params.RecurringRuleID,
+		Amount:               params.Amount,
+		Date:                 dateStr,
+		SourceTransactionID:  sourceID,
+		DestTransactionID:    destID,
+	})
+	// Record the transfer event on the source transaction aggregate for traceability.
+	if _, err := appendEvents(ctx, tx, aggregateTypeTransaction, sourceID, []NewEvent{
+		{EventType: EventTransferCreated, Payload: transferPayload},
+	}); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("append transfer event: %w", err)
+	}
+
+	// Insert read model rows.
+	var recurringRuleID *string
+	if params.RecurringRuleID != "" {
+		recurringRuleID = &params.RecurringRuleID
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO transactions (id, account_id, date, amount, name, description, status, recurring_rule_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		sourceID, params.SourceAccountID, dateStr, -params.Amount,
+		params.Name, nilIfEmpty(params.Description), int(params.Status), recurringRuleID,
+	); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("insert source transaction: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO transactions (id, account_id, date, amount, name, description, status, recurring_rule_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		destID, params.DestinationAccountID, dateStr, params.Amount,
+		params.Name, nilIfEmpty(params.Description), int(params.Status), recurringRuleID,
+	); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("insert dest transaction: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// ListTransactions returns transactions for an account, ordered by date.
+func (db *DB) ListTransactions(ctx context.Context, accountID string) ([]Transaction, error) {
+	rows, err := db.conn.QueryContext(ctx,
+		`SELECT id, account_id, date, amount, name, description, status, recurring_rule_id
+		 FROM transactions WHERE account_id = ? ORDER BY date, name`, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("query transactions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanTransactions(rows)
+}
+
+func scanTransactions(rows *sql.Rows) ([]Transaction, error) {
+	var txns []Transaction
+	for rows.Next() {
+		var t Transaction
+		var dateStr string
+		var description sql.NullString
+		var recurringRuleID sql.NullString
+		if err := rows.Scan(&t.ID, &t.AccountID, &dateStr, &t.Amount, &t.Name,
+			&description, &t.Status, &recurringRuleID); err != nil {
+			return nil, fmt.Errorf("scan transaction: %w", err)
+		}
+		d, err := time.Parse(time.DateOnly, dateStr)
+		if err != nil {
+			return nil, fmt.Errorf("parse date: %w", err)
+		}
+		t.Date = d
+		if description.Valid {
+			t.Description = description.String
+		}
+		if recurringRuleID.Valid {
+			t.RecurringRuleID = recurringRuleID.String
+		}
+		txns = append(txns, t)
+	}
+	return txns, rows.Err()
+}
+
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -230,6 +230,9 @@ func (db *DB) CreateTransfer(ctx context.Context, params CreateTransferParams) e
 	if params.Name == "" {
 		return errors.New("transfer name must not be empty")
 	}
+	if !ValidTransactionStatus(params.Status) {
+		return fmt.Errorf("invalid transaction status: %d", params.Status)
+	}
 
 	sourceID := uuid.New().String()
 	destID := uuid.New().String()
@@ -241,7 +244,7 @@ func (db *DB) CreateTransfer(ctx context.Context, params CreateTransferParams) e
 	}
 
 	// Source transaction (negative amount — money leaving).
-	sourcePayload, _ := json.Marshal(TransactionRecordedPayload{
+	sourcePayload, err := json.Marshal(TransactionRecordedPayload{
 		AccountID:       params.SourceAccountID,
 		Date:            dateStr,
 		Amount:          -params.Amount,
@@ -249,6 +252,9 @@ func (db *DB) CreateTransfer(ctx context.Context, params CreateTransferParams) e
 		Status:          int(params.Status),
 		RecurringRuleID: params.RecurringRuleID,
 	})
+	if err != nil {
+		return fmt.Errorf("marshal source payload: %w", err)
+	}
 	if _, err := appendEvents(ctx, tx, aggregateTypeTransaction, sourceID, []NewEvent{
 		{EventType: EventTransactionRecorded, Payload: sourcePayload},
 	}); err != nil {
@@ -257,7 +263,7 @@ func (db *DB) CreateTransfer(ctx context.Context, params CreateTransferParams) e
 	}
 
 	// Destination transaction (positive amount — money arriving).
-	destPayload, _ := json.Marshal(TransactionRecordedPayload{
+	destPayload, err := json.Marshal(TransactionRecordedPayload{
 		AccountID:       params.DestinationAccountID,
 		Date:            dateStr,
 		Amount:          params.Amount,
@@ -265,6 +271,9 @@ func (db *DB) CreateTransfer(ctx context.Context, params CreateTransferParams) e
 		Status:          int(params.Status),
 		RecurringRuleID: params.RecurringRuleID,
 	})
+	if err != nil {
+		return fmt.Errorf("marshal dest payload: %w", err)
+	}
 	if _, err := appendEvents(ctx, tx, aggregateTypeTransaction, destID, []NewEvent{
 		{EventType: EventTransactionRecorded, Payload: destPayload},
 	}); err != nil {
@@ -273,7 +282,7 @@ func (db *DB) CreateTransfer(ctx context.Context, params CreateTransferParams) e
 	}
 
 	// Transfer event linking both sides.
-	transferPayload, _ := json.Marshal(TransferCreatedPayload{
+	transferPayload, err := json.Marshal(TransferCreatedPayload{
 		SourceAccountID:      params.SourceAccountID,
 		DestinationAccountID: params.DestinationAccountID,
 		RecurringRuleID:      params.RecurringRuleID,
@@ -282,6 +291,9 @@ func (db *DB) CreateTransfer(ctx context.Context, params CreateTransferParams) e
 		SourceTransactionID:  sourceID,
 		DestTransactionID:    destID,
 	})
+	if err != nil {
+		return fmt.Errorf("marshal transfer payload: %w", err)
+	}
 	// Record the transfer event on the source transaction aggregate for traceability.
 	if _, err := appendEvents(ctx, tx, aggregateTypeTransaction, sourceID, []NewEvent{
 		{EventType: EventTransferCreated, Payload: transferPayload},

--- a/core/transaction_test.go
+++ b/core/transaction_test.go
@@ -1,0 +1,163 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jakewan/finch/core"
+)
+
+func TestRecordAndListTransactions(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	txn, err := db.RecordTransaction(ctx, core.RecordTransactionParams{
+		AccountID: acct.ID,
+		Date:      date(2025, 1, 15),
+		Amount:    -5000,
+		Name:      "Grocery Store",
+		Status:    core.TransactionStatusReconciled,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction: %v", err)
+	}
+	if txn.ID == "" {
+		t.Fatal("expected non-empty transaction ID")
+	}
+	if txn.Amount != -5000 {
+		t.Fatalf("expected amount -5000, got %d", txn.Amount)
+	}
+
+	txns, err := db.ListTransactions(ctx, acct.ID)
+	if err != nil {
+		t.Fatalf("ListTransactions: %v", err)
+	}
+	if len(txns) != 1 {
+		t.Fatalf("expected 1 transaction, got %d", len(txns))
+	}
+}
+
+func TestRecordTransactionValidation(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	tests := []struct {
+		name   string
+		params core.RecordTransactionParams
+	}{
+		{"empty name", core.RecordTransactionParams{AccountID: acct.ID, Date: date(2025, 1, 1), Amount: 100}},
+		{"empty account", core.RecordTransactionParams{Name: "Test", Date: date(2025, 1, 1), Amount: 100}},
+		{"invalid status", core.RecordTransactionParams{AccountID: acct.ID, Name: "Test", Date: date(2025, 1, 1), Amount: 100, Status: 99}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := db.RecordTransaction(ctx, tc.params); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestUpdateTransactionStatus(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	txn, err := db.RecordTransaction(ctx, core.RecordTransactionParams{
+		AccountID: acct.ID,
+		Date:      date(2025, 2, 1),
+		Amount:    -150000,
+		Name:      "Rent",
+		Status:    core.TransactionStatusProjected,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction: %v", err)
+	}
+
+	if err := db.UpdateTransactionStatus(ctx, txn.ID, core.TransactionStatusScheduled); err != nil {
+		t.Fatalf("UpdateTransactionStatus: %v", err)
+	}
+
+	txns, err := db.ListTransactions(ctx, acct.ID)
+	if err != nil {
+		t.Fatalf("ListTransactions: %v", err)
+	}
+	if txns[0].Status != core.TransactionStatusScheduled {
+		t.Fatalf("expected scheduled status, got %d", txns[0].Status)
+	}
+}
+
+func TestCreateTransfer(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	checking := createTestAccount(t, db)
+	savings, err := db.CreateAccount(ctx, "Savings", core.AccountTypeSavings)
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	err = db.CreateTransfer(ctx, core.CreateTransferParams{
+		SourceAccountID:      checking.ID,
+		DestinationAccountID: savings.ID,
+		Amount:               25000, // $250
+		Date:                 date(2025, 1, 15),
+		Name:                 "Savings Transfer",
+		Status:               core.TransactionStatusReconciled,
+	})
+	if err != nil {
+		t.Fatalf("CreateTransfer: %v", err)
+	}
+
+	// Source account should have negative transaction.
+	srcTxns, err := db.ListTransactions(ctx, checking.ID)
+	if err != nil {
+		t.Fatalf("ListTransactions source: %v", err)
+	}
+	if len(srcTxns) != 1 {
+		t.Fatalf("expected 1 source transaction, got %d", len(srcTxns))
+	}
+	if srcTxns[0].Amount != -25000 {
+		t.Fatalf("expected source amount -25000, got %d", srcTxns[0].Amount)
+	}
+
+	// Destination account should have positive transaction.
+	destTxns, err := db.ListTransactions(ctx, savings.ID)
+	if err != nil {
+		t.Fatalf("ListTransactions dest: %v", err)
+	}
+	if len(destTxns) != 1 {
+		t.Fatalf("expected 1 dest transaction, got %d", len(destTxns))
+	}
+	if destTxns[0].Amount != 25000 {
+		t.Fatalf("expected dest amount 25000, got %d", destTxns[0].Amount)
+	}
+}
+
+func TestCreateTransferValidation(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	tests := []struct {
+		name   string
+		params core.CreateTransferParams
+	}{
+		{"missing source", core.CreateTransferParams{DestinationAccountID: acct.ID, Amount: 100, Date: date(2025, 1, 1), Name: "Test"}},
+		{"missing dest", core.CreateTransferParams{SourceAccountID: acct.ID, Amount: 100, Date: date(2025, 1, 1), Name: "Test"}},
+		{"zero amount", core.CreateTransferParams{SourceAccountID: acct.ID, DestinationAccountID: "other", Amount: 0, Date: date(2025, 1, 1), Name: "Test"}},
+		{"negative amount", core.CreateTransferParams{SourceAccountID: acct.ID, DestinationAccountID: "other", Amount: -100, Date: date(2025, 1, 1), Name: "Test"}},
+		{"empty name", core.CreateTransferParams{SourceAccountID: acct.ID, DestinationAccountID: "other", Amount: 100, Date: date(2025, 1, 1)}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := db.CreateTransfer(ctx, tc.params); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -56,3 +56,24 @@ func (s *finchServer) CreateAccount(ctx context.Context, req *finchv1.CreateAcco
 		},
 	}, nil
 }
+
+func (s *finchServer) GetAccountHistory(ctx context.Context, req *finchv1.GetAccountHistoryRequest) (*finchv1.GetAccountHistoryResponse, error) {
+	if strings.TrimSpace(req.AccountId) == "" {
+		return nil, status.Error(codes.InvalidArgument, "account_id must not be empty")
+	}
+	events, err := s.db.GetAccountHistory(ctx, req.AccountId)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "get account history: %v", err)
+	}
+	resp := &finchv1.GetAccountHistoryResponse{}
+	for _, e := range events {
+		resp.Events = append(resp.Events, &finchv1.AccountEvent{
+			Id:         e.ID,
+			EventType:  e.EventType,
+			Payload:    string(e.Payload),
+			RecordedAt: e.RecordedAt.Unix(),
+			Sequence:   e.Sequence,
+		})
+	}
+	return resp, nil
+}

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -223,6 +223,60 @@ func (s *finchServer) CreateTransfer(ctx context.Context, req *finchv1.CreateTra
 	return &finchv1.CreateTransferResponse{}, nil
 }
 
+func (s *finchServer) ProjectBalances(ctx context.Context, req *finchv1.ProjectBalancesRequest) (*finchv1.ProjectBalancesResponse, error) {
+	fromDate, err := time.Parse(time.DateOnly, req.FromDate)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid from_date: %v", err)
+	}
+	toDate, err := time.Parse(time.DateOnly, req.ToDate)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid to_date: %v", err)
+	}
+
+	balances, err := s.db.ProjectBalances(ctx, fromDate, toDate, req.AccountIds)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "project balances: %v", err)
+	}
+
+	resp := &finchv1.ProjectBalancesResponse{}
+	for _, b := range balances {
+		pb := &finchv1.DailyBalance{
+			Date:      b.Date.Format(time.DateOnly),
+			AccountId: b.AccountID,
+			Balance:   b.Balance,
+		}
+		for _, t := range b.Transactions {
+			pb.Transactions = append(pb.Transactions, &finchv1.ProjectedTransaction{
+				Date:            t.Date.Format(time.DateOnly),
+				Amount:          t.Amount,
+				Name:            t.Name,
+				AccountId:       t.AccountID,
+				RecurringRuleId: t.RecurringRuleID,
+				Status:          finchv1.TransactionStatus(t.Status),
+				IsProjected:     t.IsProjected,
+			})
+		}
+		resp.Balances = append(resp.Balances, pb)
+	}
+	return resp, nil
+}
+
+func (s *finchServer) ProjectBalanceOnDate(ctx context.Context, req *finchv1.ProjectBalanceOnDateRequest) (*finchv1.ProjectBalanceOnDateResponse, error) {
+	if req.AccountId == "" {
+		return nil, status.Error(codes.InvalidArgument, "account_id must not be empty")
+	}
+	targetDate, err := time.Parse(time.DateOnly, req.Date)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid date: %v", err)
+	}
+
+	balance, err := s.db.ProjectBalanceOnDate(ctx, targetDate, req.AccountId)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "project balance on date: %v", err)
+	}
+	return &finchv1.ProjectBalanceOnDateResponse{Balance: balance}, nil
+}
+
 // Mapping helpers
 
 func eventsToProto(events []core.Event) *finchv1.GetAccountHistoryResponse {

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -163,6 +163,9 @@ func (s *finchServer) RecordTransaction(ctx context.Context, req *finchv1.Record
 	if req.AccountId == "" {
 		return nil, status.Error(codes.InvalidArgument, "account_id must not be empty")
 	}
+	if req.Status == finchv1.TransactionStatus_TRANSACTION_STATUS_UNSPECIFIED {
+		return nil, status.Error(codes.InvalidArgument, "transaction status must be specified")
+	}
 	txnDate, err := time.Parse(time.DateOnly, req.Date)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid date: %v", err)
@@ -190,6 +193,9 @@ func (s *finchServer) UpdateTransactionStatus(ctx context.Context, req *finchv1.
 	if req.TransactionId == "" {
 		return nil, status.Error(codes.InvalidArgument, "transaction_id must not be empty")
 	}
+	if req.NewStatus == finchv1.TransactionStatus_TRANSACTION_STATUS_UNSPECIFIED {
+		return nil, status.Error(codes.InvalidArgument, "new_status must be specified")
+	}
 	if err := s.db.UpdateTransactionStatus(ctx, req.TransactionId, core.TransactionStatus(req.NewStatus)); err != nil {
 		return nil, status.Errorf(codes.Internal, "update transaction status: %v", err)
 	}
@@ -202,6 +208,9 @@ func (s *finchServer) CreateTransfer(ctx context.Context, req *finchv1.CreateTra
 	}
 	if req.Amount <= 0 {
 		return nil, status.Error(codes.InvalidArgument, "amount must be positive")
+	}
+	if req.Status == finchv1.TransactionStatus_TRANSACTION_STATUS_UNSPECIFIED {
+		return nil, status.Error(codes.InvalidArgument, "transaction status must be specified")
 	}
 	txnDate, err := time.Parse(time.DateOnly, req.Date)
 	if err != nil {

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/jakewan/finch/core"
 	finchv1 "github.com/jakewan/finch/daemon/gen/finch/v1"
@@ -65,6 +66,166 @@ func (s *finchServer) GetAccountHistory(ctx context.Context, req *finchv1.GetAcc
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "get account history: %v", err)
 	}
+	return eventsToProto(events), nil
+}
+
+func (s *finchServer) CreateRecurringRule(ctx context.Context, req *finchv1.CreateRecurringRuleRequest) (*finchv1.CreateRecurringRuleResponse, error) {
+	if strings.TrimSpace(req.Name) == "" {
+		return nil, status.Error(codes.InvalidArgument, "name must not be empty")
+	}
+	if req.AccountId == "" {
+		return nil, status.Error(codes.InvalidArgument, "account_id must not be empty")
+	}
+	if req.Frequency == finchv1.Frequency_FREQUENCY_UNSPECIFIED {
+		return nil, status.Error(codes.InvalidArgument, "frequency must be specified")
+	}
+
+	startDate, err := time.Parse(time.DateOnly, req.StartDate)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid start_date: %v", err)
+	}
+
+	params := core.CreateRecurringRuleParams{
+		AccountID:              req.AccountId,
+		Name:                   req.Name,
+		Amount:                 req.Amount,
+		Frequency:              core.Frequency(req.Frequency),
+		StartDate:              startDate,
+		DayOfMonth:             int(req.DayOfMonth),
+		IsTransfer:             req.IsTransfer,
+		TransferTargetAccountID: req.TransferTargetAccountId,
+	}
+
+	if req.EndDate != "" {
+		endDate, err := time.Parse(time.DateOnly, req.EndDate)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid end_date: %v", err)
+		}
+		params.EndDate = &endDate
+	}
+
+	if len(req.SemiMonthlyDays) == 2 {
+		params.SemiMonthlyDays = [2]int{int(req.SemiMonthlyDays[0]), int(req.SemiMonthlyDays[1])}
+	}
+
+	rule, err := s.db.CreateRecurringRule(ctx, params)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "create recurring rule: %v", err)
+	}
+
+	return &finchv1.CreateRecurringRuleResponse{
+		Rule: recurringRuleToProto(rule),
+	}, nil
+}
+
+func (s *finchServer) ListRecurringRules(ctx context.Context, req *finchv1.ListRecurringRulesRequest) (*finchv1.ListRecurringRulesResponse, error) {
+	rules, err := s.db.ListRecurringRules(ctx, req.AccountId)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list recurring rules: %v", err)
+	}
+	resp := &finchv1.ListRecurringRulesResponse{}
+	for _, r := range rules {
+		resp.Rules = append(resp.Rules, recurringRuleToProto(&r))
+	}
+	return resp, nil
+}
+
+func (s *finchServer) UpdateRecurringRuleAmount(ctx context.Context, req *finchv1.UpdateRecurringRuleAmountRequest) (*finchv1.UpdateRecurringRuleAmountResponse, error) {
+	if req.RuleId == "" {
+		return nil, status.Error(codes.InvalidArgument, "rule_id must not be empty")
+	}
+	effectiveDate, err := time.Parse(time.DateOnly, req.EffectiveDate)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid effective_date: %v", err)
+	}
+	if err := s.db.UpdateRecurringRuleAmount(ctx, req.RuleId, req.NewAmount, effectiveDate, req.Reason); err != nil {
+		return nil, status.Errorf(codes.Internal, "update recurring rule amount: %v", err)
+	}
+	return &finchv1.UpdateRecurringRuleAmountResponse{}, nil
+}
+
+func (s *finchServer) GetRecurringRuleHistory(ctx context.Context, req *finchv1.GetRecurringRuleHistoryRequest) (*finchv1.GetRecurringRuleHistoryResponse, error) {
+	if req.RuleId == "" {
+		return nil, status.Error(codes.InvalidArgument, "rule_id must not be empty")
+	}
+	events, err := s.db.GetRecurringRuleHistory(ctx, req.RuleId)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "get recurring rule history: %v", err)
+	}
+	proto := eventsToProto(events)
+	return &finchv1.GetRecurringRuleHistoryResponse{Events: proto.Events}, nil
+}
+
+func (s *finchServer) RecordTransaction(ctx context.Context, req *finchv1.RecordTransactionRequest) (*finchv1.RecordTransactionResponse, error) {
+	if strings.TrimSpace(req.Name) == "" {
+		return nil, status.Error(codes.InvalidArgument, "name must not be empty")
+	}
+	if req.AccountId == "" {
+		return nil, status.Error(codes.InvalidArgument, "account_id must not be empty")
+	}
+	txnDate, err := time.Parse(time.DateOnly, req.Date)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid date: %v", err)
+	}
+
+	txn, err := s.db.RecordTransaction(ctx, core.RecordTransactionParams{
+		AccountID:       req.AccountId,
+		Date:            txnDate,
+		Amount:          req.Amount,
+		Name:            req.Name,
+		Description:     req.Description,
+		Status:          core.TransactionStatus(req.Status),
+		RecurringRuleID: req.RecurringRuleId,
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "record transaction: %v", err)
+	}
+
+	return &finchv1.RecordTransactionResponse{
+		Transaction: transactionToProto(txn),
+	}, nil
+}
+
+func (s *finchServer) UpdateTransactionStatus(ctx context.Context, req *finchv1.UpdateTransactionStatusRequest) (*finchv1.UpdateTransactionStatusResponse, error) {
+	if req.TransactionId == "" {
+		return nil, status.Error(codes.InvalidArgument, "transaction_id must not be empty")
+	}
+	if err := s.db.UpdateTransactionStatus(ctx, req.TransactionId, core.TransactionStatus(req.NewStatus)); err != nil {
+		return nil, status.Errorf(codes.Internal, "update transaction status: %v", err)
+	}
+	return &finchv1.UpdateTransactionStatusResponse{}, nil
+}
+
+func (s *finchServer) CreateTransfer(ctx context.Context, req *finchv1.CreateTransferRequest) (*finchv1.CreateTransferResponse, error) {
+	if req.SourceAccountId == "" || req.DestinationAccountId == "" {
+		return nil, status.Error(codes.InvalidArgument, "both source and destination account_id must be provided")
+	}
+	if req.Amount <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "amount must be positive")
+	}
+	txnDate, err := time.Parse(time.DateOnly, req.Date)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid date: %v", err)
+	}
+
+	if err := s.db.CreateTransfer(ctx, core.CreateTransferParams{
+		SourceAccountID:      req.SourceAccountId,
+		DestinationAccountID: req.DestinationAccountId,
+		Amount:               req.Amount,
+		Date:                 txnDate,
+		Name:                 req.Name,
+		Description:          req.Description,
+		Status:               core.TransactionStatus(req.Status),
+		RecurringRuleID:      req.RecurringRuleId,
+	}); err != nil {
+		return nil, status.Errorf(codes.Internal, "create transfer: %v", err)
+	}
+	return &finchv1.CreateTransferResponse{}, nil
+}
+
+// Mapping helpers
+
+func eventsToProto(events []core.Event) *finchv1.GetAccountHistoryResponse {
 	resp := &finchv1.GetAccountHistoryResponse{}
 	for _, e := range events {
 		resp.Events = append(resp.Events, &finchv1.AccountEvent{
@@ -75,5 +236,40 @@ func (s *finchServer) GetAccountHistory(ctx context.Context, req *finchv1.GetAcc
 			Sequence:   e.Sequence,
 		})
 	}
-	return resp, nil
+	return resp
+}
+
+func recurringRuleToProto(r *core.RecurringRule) *finchv1.RecurringRule {
+	rule := &finchv1.RecurringRule{
+		Id:                       r.ID,
+		AccountId:                r.AccountID,
+		Name:                     r.Name,
+		Amount:                   r.Amount,
+		Frequency:                finchv1.Frequency(r.Frequency),
+		StartDate:                r.StartDate.Format(time.DateOnly),
+		DayOfMonth:               int32(r.DayOfMonth),
+		IsTransfer:               r.IsTransfer,
+		TransferTargetAccountId:  r.TransferTargetAccountID,
+		Paused:                   r.Paused,
+	}
+	if r.EndDate != nil {
+		rule.EndDate = r.EndDate.Format(time.DateOnly)
+	}
+	if r.SemiMonthlyDays[0] != 0 {
+		rule.SemiMonthlyDays = []int32{int32(r.SemiMonthlyDays[0]), int32(r.SemiMonthlyDays[1])}
+	}
+	return rule
+}
+
+func transactionToProto(t *core.Transaction) *finchv1.Transaction {
+	return &finchv1.Transaction{
+		Id:              t.ID,
+		AccountId:       t.AccountID,
+		Date:            t.Date.Format(time.DateOnly),
+		Amount:          t.Amount,
+		Name:            t.Name,
+		Description:     t.Description,
+		Status:          finchv1.TransactionStatus(t.Status),
+		RecurringRuleId: t.RecurringRuleID,
+	}
 }

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -77,6 +77,9 @@ func TestCreateAndListAccountsViaGRPC(t *testing.T) {
 	if createResp.Account.Name != "Test Checking" {
 		t.Fatalf("expected name Test Checking, got %s", createResp.Account.Name)
 	}
+	if createResp.Account.Id == "" {
+		t.Fatal("expected non-empty account ID")
+	}
 
 	listResp, err := client.ListAccounts(ctx, &finchv1.ListAccountsRequest{})
 	if err != nil {
@@ -84,5 +87,31 @@ func TestCreateAndListAccountsViaGRPC(t *testing.T) {
 	}
 	if len(listResp.Accounts) != 1 {
 		t.Fatalf("expected 1 account, got %d", len(listResp.Accounts))
+	}
+}
+
+func TestGetAccountHistoryViaGRPC(t *testing.T) {
+	client := startTestServer(t)
+	ctx := context.Background()
+
+	createResp, err := client.CreateAccount(ctx, &finchv1.CreateAccountRequest{
+		Name: "History Test",
+		Type: finchv1.AccountType_ACCOUNT_TYPE_SAVINGS,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	histResp, err := client.GetAccountHistory(ctx, &finchv1.GetAccountHistoryRequest{
+		AccountId: createResp.Account.Id,
+	})
+	if err != nil {
+		t.Fatalf("GetAccountHistory: %v", err)
+	}
+	if len(histResp.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(histResp.Events))
+	}
+	if histResp.Events[0].EventType != "AccountCreated" {
+		t.Fatalf("expected AccountCreated, got %s", histResp.Events[0].EventType)
 	}
 }

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -115,3 +115,87 @@ func TestGetAccountHistoryViaGRPC(t *testing.T) {
 		t.Fatalf("expected AccountCreated, got %s", histResp.Events[0].EventType)
 	}
 }
+
+func TestProjectBalancesViaGRPC(t *testing.T) {
+	client := startTestServer(t)
+	ctx := context.Background()
+
+	// Create account and opening balance.
+	acctResp, err := client.CreateAccount(ctx, &finchv1.CreateAccountRequest{
+		Name: "Projection Test",
+		Type: finchv1.AccountType_ACCOUNT_TYPE_CHECKING,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	_, err = client.RecordTransaction(ctx, &finchv1.RecordTransactionRequest{
+		AccountId: acctResp.Account.Id,
+		Date:      "2025-01-01",
+		Amount:    500000,
+		Name:      "Opening Balance",
+		Status:    finchv1.TransactionStatus_TRANSACTION_STATUS_RECONCILED,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction: %v", err)
+	}
+
+	_, err = client.CreateRecurringRule(ctx, &finchv1.CreateRecurringRuleRequest{
+		AccountId:  acctResp.Account.Id,
+		Name:       "Rent",
+		Amount:     -150000,
+		Frequency:  finchv1.Frequency_FREQUENCY_MONTHLY,
+		StartDate:  "2025-01-01",
+		DayOfMonth: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule: %v", err)
+	}
+
+	projResp, err := client.ProjectBalances(ctx, &finchv1.ProjectBalancesRequest{
+		FromDate:   "2025-01-01",
+		ToDate:     "2025-03-31",
+		AccountIds: []string{acctResp.Account.Id},
+	})
+	if err != nil {
+		t.Fatalf("ProjectBalances: %v", err)
+	}
+	if len(projResp.Balances) == 0 {
+		t.Fatal("expected non-empty balances")
+	}
+}
+
+func TestProjectBalanceOnDateViaGRPC(t *testing.T) {
+	client := startTestServer(t)
+	ctx := context.Background()
+
+	acctResp, err := client.CreateAccount(ctx, &finchv1.CreateAccountRequest{
+		Name: "Point Query Test",
+		Type: finchv1.AccountType_ACCOUNT_TYPE_CHECKING,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	_, err = client.RecordTransaction(ctx, &finchv1.RecordTransactionRequest{
+		AccountId: acctResp.Account.Id,
+		Date:      "2025-01-01",
+		Amount:    1000000,
+		Name:      "Opening",
+		Status:    finchv1.TransactionStatus_TRANSACTION_STATUS_RECONCILED,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction: %v", err)
+	}
+
+	resp, err := client.ProjectBalanceOnDate(ctx, &finchv1.ProjectBalanceOnDateRequest{
+		Date:      "2025-01-15",
+		AccountId: acctResp.Account.Id,
+	})
+	if err != nil {
+		t.Fatalf("ProjectBalanceOnDate: %v", err)
+	}
+	if resp.Balance != 1000000 {
+		t.Fatalf("expected balance 1000000, got %d", resp.Balance)
+	}
+}

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -25,6 +25,11 @@ func registerTools(server *mcp.Server, client finchv1.FinchServiceClient) {
 		Name:        "create_account",
 		Description: "Create a new financial account.",
 	}, newCreateAccountHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_account_history",
+		Description: "Get the event history for an account, showing all changes over time.",
+	}, newGetAccountHistoryHandler(client))
 }
 
 // Ping
@@ -48,7 +53,7 @@ func newPingHandler(client finchv1.FinchServiceClient) func(context.Context, *mc
 
 type ListAccountsInput struct{}
 type AccountInfo struct {
-	ID   int64  `json:"id"`
+	ID   string `json:"id"`
 	Name string `json:"name"`
 	Type string `json:"type"`
 }
@@ -122,5 +127,43 @@ func newCreateAccountHandler(client finchv1.FinchServiceClient) func(context.Con
 				Type: resp.Account.Type.String(),
 			},
 		}, nil
+	}
+}
+
+// GetAccountHistory
+
+type GetAccountHistoryInput struct {
+	AccountID string `json:"account_id" jsonschema:"the UUID of the account"`
+}
+type AccountEventInfo struct {
+	ID         int64  `json:"id"`
+	EventType  string `json:"event_type"`
+	Payload    string `json:"payload"`
+	RecordedAt int64  `json:"recorded_at"`
+	Sequence   int64  `json:"sequence"`
+}
+type GetAccountHistoryOutput struct {
+	Events []AccountEventInfo `json:"events"`
+}
+
+func newGetAccountHistoryHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, GetAccountHistoryInput) (*mcp.CallToolResult, GetAccountHistoryOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input GetAccountHistoryInput) (*mcp.CallToolResult, GetAccountHistoryOutput, error) {
+		resp, err := client.GetAccountHistory(ctx, &finchv1.GetAccountHistoryRequest{
+			AccountId: input.AccountID,
+		})
+		if err != nil {
+			return nil, GetAccountHistoryOutput{}, fmt.Errorf("get account history: %w", err)
+		}
+		events := make([]AccountEventInfo, len(resp.Events))
+		for i, e := range resp.Events {
+			events[i] = AccountEventInfo{
+				ID:         e.Id,
+				EventType:  e.EventType,
+				Payload:    e.Payload,
+				RecordedAt: e.RecordedAt,
+				Sequence:   e.Sequence,
+			}
+		}
+		return nil, GetAccountHistoryOutput{Events: events}, nil
 	}
 }

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -30,6 +30,41 @@ func registerTools(server *mcp.Server, client finchv1.FinchServiceClient) {
 		Name:        "get_account_history",
 		Description: "Get the event history for an account, showing all changes over time.",
 	}, newGetAccountHistoryHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "create_recurring_rule",
+		Description: "Create a recurring transaction rule (template). Amount is in cents. Frequency: WEEKLY, BIWEEKLY, SEMI_MONTHLY, MONTHLY, YEARLY.",
+	}, newCreateRecurringRuleHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_recurring_rules",
+		Description: "List recurring transaction rules, optionally filtered by account.",
+	}, newListRecurringRulesHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "update_recurring_rule_amount",
+		Description: "Change the amount of a recurring rule with an effective date and optional reason.",
+	}, newUpdateRecurringRuleAmountHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_recurring_rule_history",
+		Description: "Get the event history for a recurring rule, showing all changes over time.",
+	}, newGetRecurringRuleHistoryHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "record_transaction",
+		Description: "Record a financial transaction. Amount is in cents (negative for withdrawals). Status: PROJECTED, SCHEDULED, or RECONCILED.",
+	}, newRecordTransactionHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "update_transaction_status",
+		Description: "Update the status of a transaction (PROJECTED → SCHEDULED → RECONCILED).",
+	}, newUpdateTransactionStatusHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "create_transfer",
+		Description: "Create a transfer between two accounts. Amount is in cents (positive, will be negated for source).",
+	}, newCreateTransferHandler(client))
 }
 
 // Ping
@@ -154,16 +189,341 @@ func newGetAccountHistoryHandler(client finchv1.FinchServiceClient) func(context
 		if err != nil {
 			return nil, GetAccountHistoryOutput{}, fmt.Errorf("get account history: %w", err)
 		}
-		events := make([]AccountEventInfo, len(resp.Events))
-		for i, e := range resp.Events {
-			events[i] = AccountEventInfo{
-				ID:         e.Id,
-				EventType:  e.EventType,
-				Payload:    e.Payload,
-				RecordedAt: e.RecordedAt,
-				Sequence:   e.Sequence,
+		return nil, GetAccountHistoryOutput{Events: protoEventsToInfo(resp.Events)}, nil
+	}
+}
+
+// CreateRecurringRule
+
+type CreateRecurringRuleInput struct {
+	AccountID              string  `json:"account_id" jsonschema:"UUID of the account"`
+	Name                   string  `json:"name" jsonschema:"name of the recurring rule"`
+	Amount                 int64   `json:"amount" jsonschema:"amount in cents"`
+	Frequency              string  `json:"frequency" jsonschema:"WEEKLY, BIWEEKLY, SEMI_MONTHLY, MONTHLY, or YEARLY"`
+	StartDate              string  `json:"start_date" jsonschema:"ISO 8601 date (YYYY-MM-DD)"`
+	EndDate                string  `json:"end_date,omitempty" jsonschema:"optional end date (YYYY-MM-DD)"`
+	DayOfMonth             int32   `json:"day_of_month,omitempty" jsonschema:"day of month for monthly rules (1-31)"`
+	SemiMonthlyDays        []int32 `json:"semi_monthly_days,omitempty" jsonschema:"two days for semi-monthly rules"`
+	IsTransfer             bool    `json:"is_transfer,omitempty" jsonschema:"whether this rule represents a transfer"`
+	TransferTargetAccountID string `json:"transfer_target_account_id,omitempty" jsonschema:"UUID of the target account for transfers"`
+}
+
+type RecurringRuleInfo struct {
+	ID                     string  `json:"id"`
+	AccountID              string  `json:"account_id"`
+	Name                   string  `json:"name"`
+	Amount                 int64   `json:"amount"`
+	Frequency              string  `json:"frequency"`
+	StartDate              string  `json:"start_date"`
+	EndDate                string  `json:"end_date,omitempty"`
+	DayOfMonth             int32   `json:"day_of_month,omitempty"`
+	SemiMonthlyDays        []int32 `json:"semi_monthly_days,omitempty"`
+	IsTransfer             bool    `json:"is_transfer,omitempty"`
+	TransferTargetAccountID string `json:"transfer_target_account_id,omitempty"`
+	Paused                 bool    `json:"paused"`
+}
+
+type CreateRecurringRuleOutput struct {
+	Rule RecurringRuleInfo `json:"rule"`
+}
+
+var frequencyMap = map[string]finchv1.Frequency{
+	"WEEKLY":       finchv1.Frequency_FREQUENCY_WEEKLY,
+	"BIWEEKLY":     finchv1.Frequency_FREQUENCY_BIWEEKLY,
+	"SEMI_MONTHLY": finchv1.Frequency_FREQUENCY_SEMI_MONTHLY,
+	"MONTHLY":      finchv1.Frequency_FREQUENCY_MONTHLY,
+	"YEARLY":       finchv1.Frequency_FREQUENCY_YEARLY,
+}
+
+func newCreateRecurringRuleHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, CreateRecurringRuleInput) (*mcp.CallToolResult, CreateRecurringRuleOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input CreateRecurringRuleInput) (*mcp.CallToolResult, CreateRecurringRuleOutput, error) {
+		normalized := strings.ToUpper(strings.TrimSpace(input.Frequency))
+		normalized = strings.TrimPrefix(normalized, "FREQUENCY_")
+		freq, ok := frequencyMap[normalized]
+		if !ok {
+			valid := make([]string, 0, len(frequencyMap))
+			for k := range frequencyMap {
+				valid = append(valid, k)
 			}
+			slices.Sort(valid)
+			return nil, CreateRecurringRuleOutput{}, fmt.Errorf("unknown frequency %q; valid: %s", input.Frequency, strings.Join(valid, ", "))
 		}
-		return nil, GetAccountHistoryOutput{Events: events}, nil
+
+		resp, err := client.CreateRecurringRule(ctx, &finchv1.CreateRecurringRuleRequest{
+			AccountId:              input.AccountID,
+			Name:                   input.Name,
+			Amount:                 input.Amount,
+			Frequency:              freq,
+			StartDate:              input.StartDate,
+			EndDate:                input.EndDate,
+			DayOfMonth:             input.DayOfMonth,
+			SemiMonthlyDays:        input.SemiMonthlyDays,
+			IsTransfer:             input.IsTransfer,
+			TransferTargetAccountId: input.TransferTargetAccountID,
+		})
+		if err != nil {
+			return nil, CreateRecurringRuleOutput{}, fmt.Errorf("create recurring rule: %w", err)
+		}
+		return nil, CreateRecurringRuleOutput{Rule: protoRuleToInfo(resp.Rule)}, nil
+	}
+}
+
+// ListRecurringRules
+
+type ListRecurringRulesInput struct {
+	AccountID string `json:"account_id,omitempty" jsonschema:"optional account UUID to filter by"`
+}
+type ListRecurringRulesOutput struct {
+	Rules []RecurringRuleInfo `json:"rules"`
+}
+
+func newListRecurringRulesHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, ListRecurringRulesInput) (*mcp.CallToolResult, ListRecurringRulesOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input ListRecurringRulesInput) (*mcp.CallToolResult, ListRecurringRulesOutput, error) {
+		resp, err := client.ListRecurringRules(ctx, &finchv1.ListRecurringRulesRequest{
+			AccountId: input.AccountID,
+		})
+		if err != nil {
+			return nil, ListRecurringRulesOutput{}, fmt.Errorf("list recurring rules: %w", err)
+		}
+		rules := make([]RecurringRuleInfo, len(resp.Rules))
+		for i, r := range resp.Rules {
+			rules[i] = protoRuleToInfo(r)
+		}
+		return nil, ListRecurringRulesOutput{Rules: rules}, nil
+	}
+}
+
+// UpdateRecurringRuleAmount
+
+type UpdateRecurringRuleAmountInput struct {
+	RuleID        string `json:"rule_id" jsonschema:"UUID of the recurring rule"`
+	NewAmount     int64  `json:"new_amount" jsonschema:"new amount in cents"`
+	EffectiveDate string `json:"effective_date" jsonschema:"when the new amount takes effect (YYYY-MM-DD)"`
+	Reason        string `json:"reason,omitempty" jsonschema:"optional reason for the change"`
+}
+type UpdateRecurringRuleAmountOutput struct{}
+
+func newUpdateRecurringRuleAmountHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, UpdateRecurringRuleAmountInput) (*mcp.CallToolResult, UpdateRecurringRuleAmountOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input UpdateRecurringRuleAmountInput) (*mcp.CallToolResult, UpdateRecurringRuleAmountOutput, error) {
+		_, err := client.UpdateRecurringRuleAmount(ctx, &finchv1.UpdateRecurringRuleAmountRequest{
+			RuleId:        input.RuleID,
+			NewAmount:     input.NewAmount,
+			EffectiveDate: input.EffectiveDate,
+			Reason:        input.Reason,
+		})
+		if err != nil {
+			return nil, UpdateRecurringRuleAmountOutput{}, fmt.Errorf("update recurring rule amount: %w", err)
+		}
+		return nil, UpdateRecurringRuleAmountOutput{}, nil
+	}
+}
+
+// GetRecurringRuleHistory
+
+type GetRecurringRuleHistoryInput struct {
+	RuleID string `json:"rule_id" jsonschema:"UUID of the recurring rule"`
+}
+type GetRecurringRuleHistoryOutput struct {
+	Events []AccountEventInfo `json:"events"`
+}
+
+func newGetRecurringRuleHistoryHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, GetRecurringRuleHistoryInput) (*mcp.CallToolResult, GetRecurringRuleHistoryOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input GetRecurringRuleHistoryInput) (*mcp.CallToolResult, GetRecurringRuleHistoryOutput, error) {
+		resp, err := client.GetRecurringRuleHistory(ctx, &finchv1.GetRecurringRuleHistoryRequest{
+			RuleId: input.RuleID,
+		})
+		if err != nil {
+			return nil, GetRecurringRuleHistoryOutput{}, fmt.Errorf("get recurring rule history: %w", err)
+		}
+		return nil, GetRecurringRuleHistoryOutput{Events: protoEventsToInfo(resp.Events)}, nil
+	}
+}
+
+// RecordTransaction
+
+type RecordTransactionInput struct {
+	AccountID       string `json:"account_id" jsonschema:"UUID of the account"`
+	Date            string `json:"date" jsonschema:"transaction date (YYYY-MM-DD)"`
+	Amount          int64  `json:"amount" jsonschema:"amount in cents (negative for withdrawals)"`
+	Name            string `json:"name" jsonschema:"transaction name"`
+	Description     string `json:"description,omitempty" jsonschema:"optional description"`
+	Status          string `json:"status" jsonschema:"PROJECTED, SCHEDULED, or RECONCILED"`
+	RecurringRuleID string `json:"recurring_rule_id,omitempty" jsonschema:"optional recurring rule UUID"`
+}
+
+type TransactionInfo struct {
+	ID              string `json:"id"`
+	AccountID       string `json:"account_id"`
+	Date            string `json:"date"`
+	Amount          int64  `json:"amount"`
+	Name            string `json:"name"`
+	Description     string `json:"description,omitempty"`
+	Status          string `json:"status"`
+	RecurringRuleID string `json:"recurring_rule_id,omitempty"`
+}
+
+type RecordTransactionOutput struct {
+	Transaction TransactionInfo `json:"transaction"`
+}
+
+var transactionStatusMap = map[string]finchv1.TransactionStatus{
+	"PROJECTED":  finchv1.TransactionStatus_TRANSACTION_STATUS_PROJECTED,
+	"SCHEDULED":  finchv1.TransactionStatus_TRANSACTION_STATUS_SCHEDULED,
+	"RECONCILED": finchv1.TransactionStatus_TRANSACTION_STATUS_RECONCILED,
+}
+
+func newRecordTransactionHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, RecordTransactionInput) (*mcp.CallToolResult, RecordTransactionOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input RecordTransactionInput) (*mcp.CallToolResult, RecordTransactionOutput, error) {
+		normalized := strings.ToUpper(strings.TrimSpace(input.Status))
+		normalized = strings.TrimPrefix(normalized, "TRANSACTION_STATUS_")
+		txnStatus, ok := transactionStatusMap[normalized]
+		if !ok {
+			valid := make([]string, 0, len(transactionStatusMap))
+			for k := range transactionStatusMap {
+				valid = append(valid, k)
+			}
+			slices.Sort(valid)
+			return nil, RecordTransactionOutput{}, fmt.Errorf("unknown status %q; valid: %s", input.Status, strings.Join(valid, ", "))
+		}
+
+		resp, err := client.RecordTransaction(ctx, &finchv1.RecordTransactionRequest{
+			AccountId:       input.AccountID,
+			Date:            input.Date,
+			Amount:          input.Amount,
+			Name:            input.Name,
+			Description:     input.Description,
+			Status:          txnStatus,
+			RecurringRuleId: input.RecurringRuleID,
+		})
+		if err != nil {
+			return nil, RecordTransactionOutput{}, fmt.Errorf("record transaction: %w", err)
+		}
+		return nil, RecordTransactionOutput{
+			Transaction: protoTxnToInfo(resp.Transaction),
+		}, nil
+	}
+}
+
+// UpdateTransactionStatus
+
+type UpdateTransactionStatusInput struct {
+	TransactionID string `json:"transaction_id" jsonschema:"UUID of the transaction"`
+	NewStatus     string `json:"new_status" jsonschema:"PROJECTED, SCHEDULED, or RECONCILED"`
+}
+type UpdateTransactionStatusOutput struct{}
+
+func newUpdateTransactionStatusHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, UpdateTransactionStatusInput) (*mcp.CallToolResult, UpdateTransactionStatusOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input UpdateTransactionStatusInput) (*mcp.CallToolResult, UpdateTransactionStatusOutput, error) {
+		normalized := strings.ToUpper(strings.TrimSpace(input.NewStatus))
+		normalized = strings.TrimPrefix(normalized, "TRANSACTION_STATUS_")
+		txnStatus, ok := transactionStatusMap[normalized]
+		if !ok {
+			valid := make([]string, 0, len(transactionStatusMap))
+			for k := range transactionStatusMap {
+				valid = append(valid, k)
+			}
+			slices.Sort(valid)
+			return nil, UpdateTransactionStatusOutput{}, fmt.Errorf("unknown status %q; valid: %s", input.NewStatus, strings.Join(valid, ", "))
+		}
+
+		_, err := client.UpdateTransactionStatus(ctx, &finchv1.UpdateTransactionStatusRequest{
+			TransactionId: input.TransactionID,
+			NewStatus:     txnStatus,
+		})
+		if err != nil {
+			return nil, UpdateTransactionStatusOutput{}, fmt.Errorf("update transaction status: %w", err)
+		}
+		return nil, UpdateTransactionStatusOutput{}, nil
+	}
+}
+
+// CreateTransfer
+
+type CreateTransferInput struct {
+	SourceAccountID      string `json:"source_account_id" jsonschema:"UUID of the source account"`
+	DestinationAccountID string `json:"destination_account_id" jsonschema:"UUID of the destination account"`
+	Amount               int64  `json:"amount" jsonschema:"transfer amount in cents (positive)"`
+	Date                 string `json:"date" jsonschema:"transfer date (YYYY-MM-DD)"`
+	Name                 string `json:"name" jsonschema:"transfer name"`
+	Description          string `json:"description,omitempty" jsonschema:"optional description"`
+	Status               string `json:"status" jsonschema:"PROJECTED, SCHEDULED, or RECONCILED"`
+	RecurringRuleID      string `json:"recurring_rule_id,omitempty" jsonschema:"optional recurring rule UUID"`
+}
+type CreateTransferOutput struct{}
+
+func newCreateTransferHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, CreateTransferInput) (*mcp.CallToolResult, CreateTransferOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input CreateTransferInput) (*mcp.CallToolResult, CreateTransferOutput, error) {
+		normalized := strings.ToUpper(strings.TrimSpace(input.Status))
+		normalized = strings.TrimPrefix(normalized, "TRANSACTION_STATUS_")
+		txnStatus, ok := transactionStatusMap[normalized]
+		if !ok {
+			valid := make([]string, 0, len(transactionStatusMap))
+			for k := range transactionStatusMap {
+				valid = append(valid, k)
+			}
+			slices.Sort(valid)
+			return nil, CreateTransferOutput{}, fmt.Errorf("unknown status %q; valid: %s", input.Status, strings.Join(valid, ", "))
+		}
+
+		_, err := client.CreateTransfer(ctx, &finchv1.CreateTransferRequest{
+			SourceAccountId:      input.SourceAccountID,
+			DestinationAccountId: input.DestinationAccountID,
+			Amount:               input.Amount,
+			Date:                 input.Date,
+			Name:                 input.Name,
+			Description:          input.Description,
+			Status:               txnStatus,
+			RecurringRuleId:      input.RecurringRuleID,
+		})
+		if err != nil {
+			return nil, CreateTransferOutput{}, fmt.Errorf("create transfer: %w", err)
+		}
+		return nil, CreateTransferOutput{}, nil
+	}
+}
+
+// Mapping helpers
+
+func protoEventsToInfo(events []*finchv1.AccountEvent) []AccountEventInfo {
+	result := make([]AccountEventInfo, len(events))
+	for i, e := range events {
+		result[i] = AccountEventInfo{
+			ID:         e.Id,
+			EventType:  e.EventType,
+			Payload:    e.Payload,
+			RecordedAt: e.RecordedAt,
+			Sequence:   e.Sequence,
+		}
+	}
+	return result
+}
+
+func protoRuleToInfo(r *finchv1.RecurringRule) RecurringRuleInfo {
+	return RecurringRuleInfo{
+		ID:                     r.Id,
+		AccountID:              r.AccountId,
+		Name:                   r.Name,
+		Amount:                 r.Amount,
+		Frequency:              r.Frequency.String(),
+		StartDate:              r.StartDate,
+		EndDate:                r.EndDate,
+		DayOfMonth:             r.DayOfMonth,
+		SemiMonthlyDays:        r.SemiMonthlyDays,
+		IsTransfer:             r.IsTransfer,
+		TransferTargetAccountID: r.TransferTargetAccountId,
+		Paused:                 r.Paused,
+	}
+}
+
+func protoTxnToInfo(t *finchv1.Transaction) TransactionInfo {
+	return TransactionInfo{
+		ID:              t.Id,
+		AccountID:       t.AccountId,
+		Date:            t.Date,
+		Amount:          t.Amount,
+		Name:            t.Name,
+		Description:     t.Description,
+		Status:          t.Status.String(),
+		RecurringRuleID: t.RecurringRuleId,
 	}
 }

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -65,6 +65,16 @@ func registerTools(server *mcp.Server, client finchv1.FinchServiceClient) {
 		Name:        "create_transfer",
 		Description: "Create a transfer between two accounts. Amount is in cents (positive, will be negated for source).",
 	}, newCreateTransferHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "project_balances",
+		Description: "Project account balances over a date range, merging recurring rules with recorded transactions.",
+	}, newProjectBalancesHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "project_balance_on_date",
+		Description: "Get the projected balance for a single account on a specific date.",
+	}, newProjectBalanceOnDateHandler(client))
 }
 
 // Ping
@@ -512,6 +522,93 @@ func protoRuleToInfo(r *finchv1.RecurringRule) RecurringRuleInfo {
 		IsTransfer:             r.IsTransfer,
 		TransferTargetAccountID: r.TransferTargetAccountId,
 		Paused:                 r.Paused,
+	}
+}
+
+// ProjectBalances
+
+type ProjectBalancesInput struct {
+	FromDate   string   `json:"from_date" jsonschema:"start date (YYYY-MM-DD)"`
+	ToDate     string   `json:"to_date" jsonschema:"end date (YYYY-MM-DD)"`
+	AccountIDs []string `json:"account_ids,omitempty" jsonschema:"optional list of account UUIDs to project (all if empty)"`
+}
+
+type ProjectedTransactionInfo struct {
+	Date            string `json:"date"`
+	Amount          int64  `json:"amount"`
+	Name            string `json:"name"`
+	AccountID       string `json:"account_id"`
+	RecurringRuleID string `json:"recurring_rule_id,omitempty"`
+	Status          string `json:"status"`
+	IsProjected     bool   `json:"is_projected"`
+}
+
+type DailyBalanceInfo struct {
+	Date         string                     `json:"date"`
+	AccountID    string                     `json:"account_id"`
+	Balance      int64                      `json:"balance"`
+	Transactions []ProjectedTransactionInfo `json:"transactions"`
+}
+
+type ProjectBalancesOutput struct {
+	Balances []DailyBalanceInfo `json:"balances"`
+}
+
+func newProjectBalancesHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, ProjectBalancesInput) (*mcp.CallToolResult, ProjectBalancesOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input ProjectBalancesInput) (*mcp.CallToolResult, ProjectBalancesOutput, error) {
+		resp, err := client.ProjectBalances(ctx, &finchv1.ProjectBalancesRequest{
+			FromDate:   input.FromDate,
+			ToDate:     input.ToDate,
+			AccountIds: input.AccountIDs,
+		})
+		if err != nil {
+			return nil, ProjectBalancesOutput{}, fmt.Errorf("project balances: %w", err)
+		}
+		balances := make([]DailyBalanceInfo, len(resp.Balances))
+		for i, b := range resp.Balances {
+			txns := make([]ProjectedTransactionInfo, len(b.Transactions))
+			for j, t := range b.Transactions {
+				txns[j] = ProjectedTransactionInfo{
+					Date:            t.Date,
+					Amount:          t.Amount,
+					Name:            t.Name,
+					AccountID:       t.AccountId,
+					RecurringRuleID: t.RecurringRuleId,
+					Status:          t.Status.String(),
+					IsProjected:     t.IsProjected,
+				}
+			}
+			balances[i] = DailyBalanceInfo{
+				Date:         b.Date,
+				AccountID:    b.AccountId,
+				Balance:      b.Balance,
+				Transactions: txns,
+			}
+		}
+		return nil, ProjectBalancesOutput{Balances: balances}, nil
+	}
+}
+
+// ProjectBalanceOnDate
+
+type ProjectBalanceOnDateInput struct {
+	Date      string `json:"date" jsonschema:"target date (YYYY-MM-DD)"`
+	AccountID string `json:"account_id" jsonschema:"UUID of the account"`
+}
+type ProjectBalanceOnDateOutput struct {
+	Balance int64 `json:"balance"`
+}
+
+func newProjectBalanceOnDateHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, ProjectBalanceOnDateInput) (*mcp.CallToolResult, ProjectBalanceOnDateOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input ProjectBalanceOnDateInput) (*mcp.CallToolResult, ProjectBalanceOnDateOutput, error) {
+		resp, err := client.ProjectBalanceOnDate(ctx, &finchv1.ProjectBalanceOnDateRequest{
+			Date:      input.Date,
+			AccountId: input.AccountID,
+		})
+		if err != nil {
+			return nil, ProjectBalanceOnDateOutput{}, fmt.Errorf("project balance on date: %w", err)
+		}
+		return nil, ProjectBalanceOnDateOutput{Balance: resp.Balance}, nil
 	}
 }
 

--- a/proto/finch/v1/finch.proto
+++ b/proto/finch/v1/finch.proto
@@ -9,6 +9,13 @@ service FinchService {
   rpc ListAccounts(ListAccountsRequest) returns (ListAccountsResponse);
   rpc CreateAccount(CreateAccountRequest) returns (CreateAccountResponse);
   rpc GetAccountHistory(GetAccountHistoryRequest) returns (GetAccountHistoryResponse);
+  rpc CreateRecurringRule(CreateRecurringRuleRequest) returns (CreateRecurringRuleResponse);
+  rpc ListRecurringRules(ListRecurringRulesRequest) returns (ListRecurringRulesResponse);
+  rpc UpdateRecurringRuleAmount(UpdateRecurringRuleAmountRequest) returns (UpdateRecurringRuleAmountResponse);
+  rpc GetRecurringRuleHistory(GetRecurringRuleHistoryRequest) returns (GetRecurringRuleHistoryResponse);
+  rpc RecordTransaction(RecordTransactionRequest) returns (RecordTransactionResponse);
+  rpc UpdateTransactionStatus(UpdateTransactionStatusRequest) returns (UpdateTransactionStatusResponse);
+  rpc CreateTransfer(CreateTransferRequest) returns (CreateTransferResponse);
 }
 
 message PingRequest {}
@@ -16,6 +23,8 @@ message PingRequest {}
 message PingResponse {
   string version = 1;
 }
+
+// Account types
 
 enum AccountType {
   ACCOUNT_TYPE_UNSPECIFIED = 0;
@@ -64,3 +73,125 @@ message AccountEvent {
 message GetAccountHistoryResponse {
   repeated AccountEvent events = 1;
 }
+
+// Recurring rules
+
+enum Frequency {
+  FREQUENCY_UNSPECIFIED = 0;
+  FREQUENCY_WEEKLY = 1;
+  FREQUENCY_BIWEEKLY = 2;
+  FREQUENCY_SEMI_MONTHLY = 3;
+  FREQUENCY_MONTHLY = 4;
+  FREQUENCY_YEARLY = 5;
+}
+
+enum TransactionStatus {
+  TRANSACTION_STATUS_UNSPECIFIED = 0;
+  TRANSACTION_STATUS_PROJECTED = 1;
+  TRANSACTION_STATUS_SCHEDULED = 2;
+  TRANSACTION_STATUS_RECONCILED = 3;
+}
+
+message RecurringRule {
+  string id = 1;
+  string account_id = 2;
+  string name = 3;
+  int64 amount = 4;
+  Frequency frequency = 5;
+  string start_date = 6;
+  string end_date = 7;
+  int32 day_of_month = 8;
+  repeated int32 semi_monthly_days = 9;
+  bool is_transfer = 10;
+  string transfer_target_account_id = 11;
+  bool paused = 12;
+}
+
+message CreateRecurringRuleRequest {
+  string account_id = 1;
+  string name = 2;
+  int64 amount = 3;
+  Frequency frequency = 4;
+  string start_date = 5;
+  string end_date = 6;
+  int32 day_of_month = 7;
+  repeated int32 semi_monthly_days = 8;
+  bool is_transfer = 9;
+  string transfer_target_account_id = 10;
+}
+
+message CreateRecurringRuleResponse {
+  RecurringRule rule = 1;
+}
+
+message ListRecurringRulesRequest {
+  string account_id = 1;
+}
+
+message ListRecurringRulesResponse {
+  repeated RecurringRule rules = 1;
+}
+
+message UpdateRecurringRuleAmountRequest {
+  string rule_id = 1;
+  int64 new_amount = 2;
+  string effective_date = 3;
+  string reason = 4;
+}
+
+message UpdateRecurringRuleAmountResponse {}
+
+message GetRecurringRuleHistoryRequest {
+  string rule_id = 1;
+}
+
+message GetRecurringRuleHistoryResponse {
+  repeated AccountEvent events = 1;
+}
+
+// Transactions
+
+message Transaction {
+  string id = 1;
+  string account_id = 2;
+  string date = 3;
+  int64 amount = 4;
+  string name = 5;
+  string description = 6;
+  TransactionStatus status = 7;
+  string recurring_rule_id = 8;
+}
+
+message RecordTransactionRequest {
+  string account_id = 1;
+  string date = 2;
+  int64 amount = 3;
+  string name = 4;
+  string description = 5;
+  TransactionStatus status = 6;
+  string recurring_rule_id = 7;
+}
+
+message RecordTransactionResponse {
+  Transaction transaction = 1;
+}
+
+message UpdateTransactionStatusRequest {
+  string transaction_id = 1;
+  TransactionStatus new_status = 2;
+}
+
+message UpdateTransactionStatusResponse {}
+
+message CreateTransferRequest {
+  string source_account_id = 1;
+  string destination_account_id = 2;
+  int64 amount = 3;
+  string date = 4;
+  string name = 5;
+  string description = 6;
+  TransactionStatus status = 7;
+  string recurring_rule_id = 8;
+}
+
+message CreateTransferResponse {}

--- a/proto/finch/v1/finch.proto
+++ b/proto/finch/v1/finch.proto
@@ -8,6 +8,7 @@ service FinchService {
   rpc Ping(PingRequest) returns (PingResponse);
   rpc ListAccounts(ListAccountsRequest) returns (ListAccountsResponse);
   rpc CreateAccount(CreateAccountRequest) returns (CreateAccountResponse);
+  rpc GetAccountHistory(GetAccountHistoryRequest) returns (GetAccountHistoryResponse);
 }
 
 message PingRequest {}
@@ -28,7 +29,7 @@ enum AccountType {
 }
 
 message Account {
-  int64 id = 1;
+  string id = 1;
   string name = 2;
   AccountType type = 3;
 }
@@ -46,4 +47,20 @@ message CreateAccountRequest {
 
 message CreateAccountResponse {
   Account account = 1;
+}
+
+message GetAccountHistoryRequest {
+  string account_id = 1;
+}
+
+message AccountEvent {
+  int64 id = 1;
+  string event_type = 2;
+  string payload = 3;
+  int64 recorded_at = 4;
+  int64 sequence = 5;
+}
+
+message GetAccountHistoryResponse {
+  repeated AccountEvent events = 1;
 }

--- a/proto/finch/v1/finch.proto
+++ b/proto/finch/v1/finch.proto
@@ -16,6 +16,8 @@ service FinchService {
   rpc RecordTransaction(RecordTransactionRequest) returns (RecordTransactionResponse);
   rpc UpdateTransactionStatus(UpdateTransactionStatusRequest) returns (UpdateTransactionStatusResponse);
   rpc CreateTransfer(CreateTransferRequest) returns (CreateTransferResponse);
+  rpc ProjectBalances(ProjectBalancesRequest) returns (ProjectBalancesResponse);
+  rpc ProjectBalanceOnDate(ProjectBalanceOnDateRequest) returns (ProjectBalanceOnDateResponse);
 }
 
 message PingRequest {}
@@ -195,3 +197,41 @@ message CreateTransferRequest {
 }
 
 message CreateTransferResponse {}
+
+// Projection
+
+message ProjectedTransaction {
+  string date = 1;
+  int64 amount = 2;
+  string name = 3;
+  string account_id = 4;
+  string recurring_rule_id = 5;
+  TransactionStatus status = 6;
+  bool is_projected = 7;
+}
+
+message DailyBalance {
+  string date = 1;
+  string account_id = 2;
+  int64 balance = 3;
+  repeated ProjectedTransaction transactions = 4;
+}
+
+message ProjectBalancesRequest {
+  string from_date = 1;
+  string to_date = 2;
+  repeated string account_ids = 3;
+}
+
+message ProjectBalancesResponse {
+  repeated DailyBalance balances = 1;
+}
+
+message ProjectBalanceOnDateRequest {
+  string date = 1;
+  string account_id = 2;
+}
+
+message ProjectBalanceOnDateResponse {
+  int64 balance = 1;
+}


### PR DESCRIPTION
## Overview

The purpose of this change is to deliver M2 of Finch: the event-sourced recurring transactions and projection engine that answers the core question — "What will my balance be on rent day?" It represents **innovation** in the persistence layer (introducing event sourcing as the foundation) combined with **incremental improvement** in capabilities (building recurring rules, transactions, and projections on top of M1's gRPC infrastructure).

Event sourcing was chosen over simple CRUD because it enables temporal queries ("how has my projection changed since last month?"), provides a complete audit trail of financial changes, and makes the system's history a first-class queryable resource rather than an afterthought.

## What's included

### M2a: Event Store Foundation + Account Retrofit
- SQLite-backed event store with per-aggregate sequence ordering
- Account IDs transition from int64 to UUID strings (breaking, acceptable pre-v1)
- Accounts retrofitted to event sourcing with synchronous read model updates
- `GetAccountHistory` RPC and MCP tool

### M2b: Recurring Rules + Transactions
- Template-based recurring transaction rules with 5 frequency types (weekly, biweekly, semi-monthly, monthly, yearly)
- Day-of-month capping for short months and leap years
- Transaction status workflow: projected → scheduled → reconciled
- First-class transfers linking source and destination accounts atomically
- Amounts stored in cents (int64) to avoid floating-point drift
- Rule lifecycle: create, update amount (with reason tracking), pause/resume
- 7 new RPCs and MCP tools

### M2c: Projection Engine
- `ProjectBalances`: computes daily balances over a date range by merging recorded transactions with expanded recurring rule occurrences
- `ProjectBalanceOnDate`: convenience for point-in-time balance queries
- Correctly handles: starting balances (including pre-range recurring projections), double-count avoidance (recorded transactions linked to rules), paused rules, transfers, empty accounts
- 2 new RPCs and MCP tools

## Key design decisions

- **Event sourcing across the domain**: events are the source of truth; read model tables updated synchronously within the same DB transaction
- **Amounts in cents** (int64): eliminates the floating-point drift visible in the spreadsheet (`5.684341886080802e-14`)
- **UUIDs for aggregate IDs**: event sourcing aggregates need stable, non-sequential identity
- **Transfer symmetry**: a transfer appends events to both aggregates within a single DB transaction
- **Proto enum alignment**: `TransactionStatus` includes `UNSPECIFIED` at zero per buf lint STANDARD rules; core domain values offset accordingly

## Test plan

- [x] Event store: append/load, sequence continuation, filtering by type, empty reads
- [x] Frequency expansion: all 5 types, month-end capping, leap year, end dates, mid-range starts
- [x] Recurring rules: CRUD via events, amount change with history, pause/resume, filtering
- [x] Transactions: record, status transitions, validation
- [x] Transfers: symmetric creation, validation
- [x] Projection: single/multiple accounts, no double-counting, transfers, paused rules, mixed recurring + one-off, point-in-time queries with recurring rules
- [x] gRPC integration: account history, projection balances, balance on date
- [x] All linters pass (golangci-lint v2, buf lint)
- [x] Binaries build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)