### PR TITLE
Decouple Qt app responsiveness from daemon availability

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Quick QuickControls2)
+find_package(Qt6 REQUIRED COMPONENTS Quick QuickControls2 Concurrent)
 find_package(Protobuf REQUIRED)
 find_package(gRPC CONFIG QUIET)
 
@@ -57,6 +57,7 @@ target_include_directories(finch-app PRIVATE ${GENERATED_DIR})
 target_link_libraries(finch-app PRIVATE
     Qt6::Quick
     Qt6::QuickControls2
+    Qt6::Concurrent
     protobuf::libprotobuf
 )
 

--- a/app/qml/Main.qml
+++ b/app/qml/Main.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import Finch 1.0
 
 ApplicationWindow {
     visible: true
@@ -18,15 +19,32 @@ ApplicationWindow {
         }
 
         Label {
-            text: finchClient.daemonVersion
-                ? "Connected to daemon v" + finchClient.daemonVersion
-                : "Not connected to daemon"
+            text: {
+                switch (finchClient.connectionState) {
+                case FinchClient.Connecting:
+                    return "Connecting to daemon…"
+                case FinchClient.Connected:
+                    return "Connected to daemon v" + finchClient.daemonVersion
+                default:
+                    return "Not connected to daemon"
+                }
+            }
+            color: {
+                switch (finchClient.connectionState) {
+                case FinchClient.Connecting:
+                    return "gray"
+                case FinchClient.Connected:
+                    return "green"
+                default:
+                    return "red"
+                }
+            }
             anchors.horizontalCenter: parent.horizontalCenter
-            color: finchClient.daemonVersion ? "green" : "red"
         }
 
         Button {
-            text: "Ping Daemon"
+            text: finchClient.pingInProgress ? "Pinging…" : "Ping Daemon"
+            enabled: !finchClient.pingInProgress
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: finchClient.ping()
         }

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -18,6 +18,13 @@ FinchClient::FinchClient(const QString& socketPath, QObject* parent)
             this, &FinchClient::onPingFinished);
 }
 
+FinchClient::~FinchClient()
+{
+    // Wait for in-flight ping to complete before destroying the stub.
+    // Bounded by the 3-second gRPC deadline.
+    m_pingWatcher.waitForFinished();
+}
+
 void FinchClient::ping()
 {
     if (m_pingInProgress)

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -1,5 +1,11 @@
 #include "finchclient.h"
+
+#include <QTimer>
+#include <QtConcurrent>
+#include <chrono>
 #include <grpcpp/grpcpp.h>
+
+static constexpr int kMinConnectingMs = 300;
 
 FinchClient::FinchClient(const QString& socketPath, QObject* parent)
     : QObject(parent)
@@ -7,19 +13,66 @@ FinchClient::FinchClient(const QString& socketPath, QObject* parent)
     std::string target = "unix:" + socketPath.toStdString();
     m_channel = grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
     m_stub = finch::v1::FinchService::NewStub(m_channel);
+
+    connect(&m_pingWatcher, &QFutureWatcher<PingResult>::finished,
+            this, &FinchClient::onPingFinished);
 }
 
-bool FinchClient::ping()
+void FinchClient::ping()
 {
-    grpc::ClientContext context;
-    finch::v1::PingRequest request;
-    finch::v1::PingResponse response;
+    if (m_pingInProgress)
+        return;
 
-    grpc::Status status = m_stub->Ping(&context, request, &response);
-    if (status.ok()) {
-        m_version = QString::fromStdString(response.version());
-        emit daemonVersionChanged();
-        return true;
+    m_pingInProgress = true;
+    emit pingInProgressChanged();
+
+    m_connectionState = Connecting;
+    emit connectionStateChanged();
+    m_connectingTimer.start();
+
+    auto stub = m_stub.get();
+    auto future = QtConcurrent::run([stub]() -> PingResult {
+        grpc::ClientContext context;
+        context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(3));
+
+        finch::v1::PingRequest request;
+        finch::v1::PingResponse response;
+
+        grpc::Status status = stub->Ping(&context, request, &response);
+        if (status.ok()) {
+            return {true, QString::fromStdString(response.version())};
+        }
+        return {false, {}};
+    });
+
+    m_pingWatcher.setFuture(future);
+}
+
+void FinchClient::onPingFinished()
+{
+    m_pendingResult = m_pingWatcher.result();
+
+    qint64 elapsed = m_connectingTimer.elapsed();
+    if (elapsed < kMinConnectingMs) {
+        QTimer::singleShot(kMinConnectingMs - elapsed, this, &FinchClient::applyPingResult);
+    } else {
+        applyPingResult();
     }
-    return false;
+}
+
+void FinchClient::applyPingResult()
+{
+    m_pingInProgress = false;
+    emit pingInProgressChanged();
+
+    if (m_pendingResult.ok) {
+        m_version = m_pendingResult.version;
+        m_connectionState = Connected;
+    } else {
+        m_version.clear();
+        m_connectionState = Disconnected;
+    }
+
+    emit daemonVersionChanged();
+    emit connectionStateChanged();
 }

--- a/app/src/finchclient.h
+++ b/app/src/finchclient.h
@@ -26,6 +26,7 @@ public:
     Q_ENUM(ConnectionState)
 
     explicit FinchClient(const QString& socketPath, QObject* parent = nullptr);
+    ~FinchClient() override;
 
     QString daemonVersion() const { return m_version; }
     ConnectionState connectionState() const { return m_connectionState; }

--- a/app/src/finchclient.h
+++ b/app/src/finchclient.h
@@ -1,6 +1,8 @@
 #ifndef FINCHCLIENT_H
 #define FINCHCLIENT_H
 
+#include <QElapsedTimer>
+#include <QFutureWatcher>
 #include <QObject>
 #include <QString>
 #include <memory>
@@ -8,23 +10,47 @@
 #include <grpcpp/grpcpp.h>
 #include "finch/v1/finch.grpc.pb.h"
 
+struct PingResult {
+    bool ok;
+    QString version;
+};
+
 class FinchClient : public QObject {
     Q_OBJECT
     Q_PROPERTY(QString daemonVersion READ daemonVersion NOTIFY daemonVersionChanged)
+    Q_PROPERTY(ConnectionState connectionState READ connectionState NOTIFY connectionStateChanged)
+    Q_PROPERTY(bool pingInProgress READ pingInProgress NOTIFY pingInProgressChanged)
 
 public:
+    enum ConnectionState { Disconnected, Connecting, Connected };
+    Q_ENUM(ConnectionState)
+
     explicit FinchClient(const QString& socketPath, QObject* parent = nullptr);
 
     QString daemonVersion() const { return m_version; }
-    Q_INVOKABLE bool ping();
+    ConnectionState connectionState() const { return m_connectionState; }
+    bool pingInProgress() const { return m_pingInProgress; }
+
+    Q_INVOKABLE void ping();
 
 signals:
     void daemonVersionChanged();
+    void connectionStateChanged();
+    void pingInProgressChanged();
+
+private slots:
+    void onPingFinished();
+    void applyPingResult();
 
 private:
     std::shared_ptr<grpc::Channel> m_channel;
     std::unique_ptr<finch::v1::FinchService::Stub> m_stub;
     QString m_version;
+    ConnectionState m_connectionState = Disconnected;
+    bool m_pingInProgress = false;
+    QFutureWatcher<PingResult> m_pingWatcher;
+    QElapsedTimer m_connectingTimer;
+    PingResult m_pendingResult;
 };
 
 #endif // FINCHCLIENT_H

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -2,6 +2,7 @@
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QUrl>
+#include <QtQml>
 
 #include "finchclient.h"
 
@@ -25,8 +26,10 @@ int main(int argc, char* argv[])
     app.setApplicationName("Finch");
     app.setApplicationVersion("0.1.0");
 
+    qmlRegisterUncreatableType<FinchClient>("Finch", 1, 0, "FinchClient",
+                                            "FinchClient is not creatable from QML");
+
     auto client = new FinchClient(QString::fromStdString(socketPath()), &app);
-    client->ping();
 
     QQmlApplicationEngine engine;
     engine.rootContext()->setContextProperty("finchClient", client);
@@ -34,6 +37,8 @@ int main(int argc, char* argv[])
 
     if (engine.rootObjects().isEmpty())
         return -1;
+
+    client->ping();
 
     return app.exec();
 }


### PR DESCRIPTION
## Overview

The purpose of this change is to prevent the Qt app from freezing when the daemon is slow or unreachable. It represents an incremental improvement — strengthening the UI's foundational responsiveness before the app takes on real data calls (accounts, projections, charts).

Previously, the app performed synchronous gRPC calls on the GUI thread with no deadline. If the daemon was unavailable, the window never appeared. The Ping button also hung the UI on click.

## Changes

- Move the gRPC Ping call off the GUI thread using `QtConcurrent::run` + `QFutureWatcher`
- Add a 3-second deadline on `ClientContext` to bound wait time
- Load QML before triggering the initial ping so the window appears immediately
- Expose a `ConnectionState` enum (`Disconnected` / `Connecting` / `Connected`) to QML for clear status feedback
- Enforce a minimum 300ms hold on the Connecting state to prevent visual flicker on fast responses
- Disable the Ping button while a request is in flight

## Test plan

- [ ] `just build-app` compiles cleanly
- [ ] Launch app without daemon running — window appears immediately, shows "Connecting...", transitions to "Not connected" after ~3s
- [ ] Launch app with daemon running — window appears, shows "Connecting..." briefly, transitions to "Connected to daemon v..."
- [ ] Click Ping with daemon stopped — button disables, shows "Pinging...", transitions to "Not connected"
- [ ] Click Ping with daemon running — button disables, shows "Connecting...", transitions to "Connected"

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)