### PR TITLE
Desktop layout structure for Qt app

### DIFF
--- a/app/qml/Main.qml
+++ b/app/qml/Main.qml
@@ -1,15 +1,24 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import Qt.labs.settings
 import Finch 1.0
 
 ApplicationWindow {
+    id: window
     visible: true
     width: 1024
     height: 768
     minimumWidth: 640
     minimumHeight: 480
     title: "Finch"
+
+    Settings {
+        property alias x: window.x
+        property alias y: window.y
+        property alias width: window.width
+        property alias height: window.height
+    }
 
     header: ToolBar {
         RowLayout {

--- a/app/qml/Main.qml
+++ b/app/qml/Main.qml
@@ -1,52 +1,83 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 import Finch 1.0
 
 ApplicationWindow {
     visible: true
-    width: 640
-    height: 480
+    width: 1024
+    height: 768
+    minimumWidth: 640
+    minimumHeight: 480
     title: "Finch"
 
-    Column {
-        anchors.centerIn: parent
-        spacing: 16
+    header: ToolBar {
+        RowLayout {
+            anchors.fill: parent
+            anchors.leftMargin: 8
+            anchors.rightMargin: 8
+
+            Label {
+                text: "Finch"
+                font.pointSize: 14
+            }
+
+            Item { Layout.fillWidth: true }
+
+            Button {
+                text: finchClient.pingInProgress ? "Pinging…" : "Ping Daemon"
+                enabled: !finchClient.pingInProgress
+                onClicked: finchClient.ping()
+            }
+        }
+    }
+
+    Item {
+        anchors.fill: parent
 
         Label {
-            text: "Finch — Personal Finance"
-            font.pixelSize: 24
-            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.centerIn: parent
+            text: "Chart view coming soon"
+            font.pointSize: 12
+            color: "gray"
         }
+    }
 
-        Label {
-            text: {
-                switch (finchClient.connectionState) {
-                case FinchClient.Connecting:
-                    return "Connecting to daemon…"
-                case FinchClient.Connected:
-                    return "Connected to daemon v" + finchClient.daemonVersion
-                default:
-                    return "Not connected to daemon"
+    footer: ToolBar {
+        RowLayout {
+            anchors.fill: parent
+            anchors.leftMargin: 8
+            anchors.rightMargin: 8
+
+            Rectangle {
+                width: 8
+                height: 8
+                radius: 4
+                color: {
+                    switch (finchClient.connectionState) {
+                    case FinchClient.Connecting:
+                        return "gray"
+                    case FinchClient.Connected:
+                        return "green"
+                    default:
+                        return "red"
+                    }
                 }
             }
-            color: {
-                switch (finchClient.connectionState) {
-                case FinchClient.Connecting:
-                    return "gray"
-                case FinchClient.Connected:
-                    return "green"
-                default:
-                    return "red"
+
+            Label {
+                font.pointSize: 10
+                text: {
+                    switch (finchClient.connectionState) {
+                    case FinchClient.Connecting:
+                        return "Connecting to daemon…"
+                    case FinchClient.Connected:
+                        return "Connected to daemon v" + finchClient.daemonVersion
+                    default:
+                        return "Not connected to daemon"
+                    }
                 }
             }
-            anchors.horizontalCenter: parent.horizontalCenter
-        }
-
-        Button {
-            text: finchClient.pingInProgress ? "Pinging…" : "Ping Daemon"
-            enabled: !finchClient.pingInProgress
-            anchors.horizontalCenter: parent.horizontalCenter
-            onClicked: finchClient.ping()
         }
     }
 }


### PR DESCRIPTION
## Overview

The purpose of this change is to replace the minimal proof-of-concept centered column layout with a structured desktop application layout suitable for practical use. It represents an incremental improvement — establishing a usable layout foundation (ToolBar header, expandable content area, status footer) that the chart view (#5) will build on, while also persisting window geometry so each user only needs to resize once.

## Changes

- Restructure `Main.qml` from centered column to standard desktop layout: ToolBar header (app title + Ping button), expandable content area (placeholder for chart view), ToolBar footer (connection status with colored indicator dot)
- Default window size 1024x768, minimum 640x480
- Switch from `font.pixelSize` to `font.pointSize` for resolution independence
- Persist window position and size across launches via `Qt.labs.settings`

## Test plan

- [ ] `just build-app` compiles cleanly
- [ ] Window opens at 1024x768 on first launch
- [ ] Window cannot be resized below 640x480
- [ ] "Finch" title left-aligned in header, Ping button right-aligned
- [ ] Content area fills space between header/footer, scales with window resize
- [ ] Connection status in footer with colored indicator dot (green when connected, gray when connecting, red when disconnected)
- [ ] Ping button functions correctly
- [ ] Resize window, close, relaunch — window restores to previous size and position

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)