### PR TITLE
feat(app): add QtCharts dependency and ListAccounts wiring

### DIFF
--- a/.github/workflows/ci-qt.yml
+++ b/.github/workflows/ci-qt.yml
@@ -23,6 +23,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             qt6-base-dev qt6-declarative-dev qml6-module-qtquick-controls \
+            qt6-charts-dev qml6-module-qtcharts \
             protobuf-compiler libprotobuf-dev libgrpc++-dev protobuf-compiler-grpc
 
       - name: Build

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Quick QuickControls2 Concurrent)
+find_package(Qt6 REQUIRED COMPONENTS Quick QuickControls2 Concurrent Charts)
 find_package(Protobuf REQUIRED)
 find_package(gRPC CONFIG QUIET)
 
@@ -58,6 +58,7 @@ target_link_libraries(finch-app PRIVATE
     Qt6::Quick
     Qt6::QuickControls2
     Qt6::Concurrent
+    Qt6::Charts
     protobuf::libprotobuf
 )
 

--- a/app/qml/Main.qml
+++ b/app/qml/Main.qml
@@ -71,7 +71,8 @@ ApplicationWindow {
         ListView {
             anchors.fill: parent
             anchors.margins: 16
-            visible: finchClient.accounts.length > 0
+            visible: finchClient.connectionState === FinchClient.Connected
+                     && finchClient.accounts.length > 0
             model: finchClient.accounts
             spacing: 4
             delegate: ItemDelegate {

--- a/app/qml/Main.qml
+++ b/app/qml/Main.qml
@@ -41,14 +41,43 @@ ApplicationWindow {
         }
     }
 
+    Connections {
+        target: finchClient
+        function onConnectionStateChanged() {
+            if (finchClient.connectionState === FinchClient.Connected) {
+                finchClient.listAccounts()
+            }
+        }
+    }
+
     Item {
         anchors.fill: parent
 
         Label {
             anchors.centerIn: parent
-            text: "Chart view coming soon"
+            visible: !finchClient.accountsLoading && finchClient.accounts.length === 0
+            text: finchClient.connectionState === FinchClient.Connected
+                  ? "No accounts found"
+                  : "Not connected to daemon"
             font.pointSize: 12
             color: "gray"
+        }
+
+        BusyIndicator {
+            anchors.centerIn: parent
+            running: finchClient.accountsLoading
+        }
+
+        ListView {
+            anchors.fill: parent
+            anchors.margins: 16
+            visible: finchClient.accounts.length > 0
+            model: finchClient.accounts
+            spacing: 4
+            delegate: ItemDelegate {
+                width: ListView.view.width
+                text: modelData.name
+            }
         }
     }
 

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -16,13 +16,14 @@ FinchClient::FinchClient(const QString& socketPath, QObject* parent)
 
     connect(&m_pingWatcher, &QFutureWatcher<PingResult>::finished,
             this, &FinchClient::onPingFinished);
+    connect(&m_accountsWatcher, &QFutureWatcher<ListAccountsResult>::finished,
+            this, &FinchClient::onListAccountsFinished);
 }
 
 FinchClient::~FinchClient()
 {
-    // Wait for in-flight ping to complete before destroying the stub.
-    // Bounded by the 3-second gRPC deadline.
     m_pingWatcher.waitForFinished();
+    m_accountsWatcher.waitForFinished();
 }
 
 void FinchClient::ping()
@@ -53,6 +54,52 @@ void FinchClient::ping()
     });
 
     m_pingWatcher.setFuture(future);
+}
+
+void FinchClient::listAccounts()
+{
+    if (m_accountsLoading)
+        return;
+
+    m_accountsLoading = true;
+    emit accountsLoadingChanged();
+
+    auto stub = m_stub.get();
+    auto future = QtConcurrent::run([stub]() -> ListAccountsResult {
+        grpc::ClientContext context;
+        context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(5));
+
+        finch::v1::ListAccountsRequest request;
+        finch::v1::ListAccountsResponse response;
+
+        grpc::Status status = stub->ListAccounts(&context, request, &response);
+        if (!status.ok())
+            return {false, {}};
+
+        QVariantList accounts;
+        for (const auto& account : response.accounts()) {
+            QVariantMap entry;
+            entry["id"] = QString::fromStdString(account.id());
+            entry["name"] = QString::fromStdString(account.name());
+            accounts.append(entry);
+        }
+        return {true, accounts};
+    });
+
+    m_accountsWatcher.setFuture(future);
+}
+
+void FinchClient::onListAccountsFinished()
+{
+    auto result = m_accountsWatcher.result();
+
+    m_accountsLoading = false;
+    emit accountsLoadingChanged();
+
+    if (result.ok) {
+        m_accounts = result.accounts;
+        emit accountsChanged();
+    }
 }
 
 void FinchClient::onPingFinished()

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -1,6 +1,7 @@
 #include "finchclient.h"
 
 #include <QTimer>
+#include <QVariantMap>
 #include <QtConcurrent>
 #include <chrono>
 #include <grpcpp/grpcpp.h>
@@ -98,8 +99,10 @@ void FinchClient::onListAccountsFinished()
 
     if (result.ok) {
         m_accounts = result.accounts;
-        emit accountsChanged();
+    } else {
+        m_accounts.clear();
     }
+    emit accountsChanged();
 }
 
 void FinchClient::onPingFinished()

--- a/app/src/finchclient.h
+++ b/app/src/finchclient.h
@@ -5,6 +5,7 @@
 #include <QFutureWatcher>
 #include <QObject>
 #include <QString>
+#include <QVariantList>
 #include <memory>
 
 #include <grpcpp/grpcpp.h>
@@ -15,11 +16,18 @@ struct PingResult {
     QString version;
 };
 
+struct ListAccountsResult {
+    bool ok;
+    QVariantList accounts;
+};
+
 class FinchClient : public QObject {
     Q_OBJECT
     Q_PROPERTY(QString daemonVersion READ daemonVersion NOTIFY daemonVersionChanged)
     Q_PROPERTY(ConnectionState connectionState READ connectionState NOTIFY connectionStateChanged)
     Q_PROPERTY(bool pingInProgress READ pingInProgress NOTIFY pingInProgressChanged)
+    Q_PROPERTY(QVariantList accounts READ accounts NOTIFY accountsChanged)
+    Q_PROPERTY(bool accountsLoading READ accountsLoading NOTIFY accountsLoadingChanged)
 
 public:
     enum ConnectionState { Disconnected, Connecting, Connected };
@@ -31,17 +39,23 @@ public:
     QString daemonVersion() const { return m_version; }
     ConnectionState connectionState() const { return m_connectionState; }
     bool pingInProgress() const { return m_pingInProgress; }
+    QVariantList accounts() const { return m_accounts; }
+    bool accountsLoading() const { return m_accountsLoading; }
 
     Q_INVOKABLE void ping();
+    Q_INVOKABLE void listAccounts();
 
 signals:
     void daemonVersionChanged();
     void connectionStateChanged();
     void pingInProgressChanged();
+    void accountsChanged();
+    void accountsLoadingChanged();
 
 private slots:
     void onPingFinished();
     void applyPingResult();
+    void onListAccountsFinished();
 
 private:
     std::shared_ptr<grpc::Channel> m_channel;
@@ -52,6 +66,9 @@ private:
     QFutureWatcher<PingResult> m_pingWatcher;
     QElapsedTimer m_connectingTimer;
     PingResult m_pendingResult;
+    QVariantList m_accounts;
+    bool m_accountsLoading = false;
+    QFutureWatcher<ListAccountsResult> m_accountsWatcher;
 };
 
 #endif // FINCHCLIENT_H


### PR DESCRIPTION
## Overview

The purpose of this change is to establish the build system and data plumbing foundation for the balance projection chart (GH #5, PR 1 of 3). It represents an incremental improvement — adding the QtCharts dependency and the first new RPC call (`ListAccounts`) in the UI, following the existing async pattern established by `ping()`.

## Changes

- **Build system:** Add `Qt6::Charts` to `find_package` and `target_link_libraries` in CMakeLists.txt
- **CI:** Add `qt6-charts-dev` and `qml6-module-qtcharts` to the apt install step in `ci-qt.yml`
- **`FinchClient`:** Implement `listAccounts()` async RPC with `QFutureWatcher`, matching the `ping()` pattern (loading guard, 5s deadline, `QtConcurrent::run()`)
- **`Main.qml`:** Replace placeholder text with account list view, busy indicator, and empty-state messaging; auto-call `listAccounts()` when connection state becomes `Connected`

## Test plan

- [x] `just build-app` succeeds locally
- [x] Launch app with daemon running — verified "No accounts found" displays correctly (empty DB)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)