### PR TITLE
Single-account balance line chart

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -1,0 +1,9 @@
+# CI Conventions
+
+## Build Verification
+
+ALWAYS build the Qt app (`just build-app`) before pushing changes to `app/` files. The CI workflow only runs a build check — catching compilation errors locally avoids a slow push-wait-fail cycle.
+
+## Go Checks
+
+ALWAYS run `just test` and `just lint` before pushing changes to Go modules (`core/`, `daemon/`, `mcp/`).

--- a/.claude/rules/qt-app.md
+++ b/.claude/rules/qt-app.md
@@ -1,0 +1,21 @@
+# Qt App Development
+
+## QApplication Required
+
+The app MUST use `QApplication`, not `QGuiApplication`. QtCharts QML types depend on QWidgets internally (`QGraphicsView`, `QGraphicsScene`). Using `QGuiApplication` causes a segfault during `ChartView` initialization.
+
+## Qt Version Parity with CI
+
+CI installs Qt from Ubuntu `apt` packages, which lags behind rolling-release or developer installs. ALWAYS check "since" version annotations in Qt docs before using newer APIs.
+
+When a Qt API has a deprecated form that works across all Qt6 versions and a replacement that requires a newer version, prefer the cross-compatible form for CI parity. A local deprecation warning is acceptable; a CI build failure is not.
+
+## QML Property Names
+
+Qt Quick Controls types mark many properties as FINAL. NEVER declare custom properties that shadow built-in names (e.g., `currentValue` on `ComboBox`). The QML engine will error with "Cannot override FINAL property" at runtime.
+
+## Build and Test
+
+Build: `just build-app` (or `cmake -S app -B app/build && cmake --build app/build`).
+
+Manual testing requires a running daemon with seed data. The daemon must be built and started separately (`just build-daemon && daemon/finch-daemon`).

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@
 Thumbs.db
 
 # Claude
-.claude/
+.claude/settings.local.json

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Quick QuickControls2 Concurrent Charts)
+find_package(Qt6 REQUIRED COMPONENTS Quick QuickControls2 Concurrent Charts Widgets)
 find_package(Protobuf REQUIRED)
 find_package(gRPC CONFIG QUIET)
 
@@ -59,6 +59,7 @@ target_link_libraries(finch-app PRIVATE
     Qt6::QuickControls2
     Qt6::Concurrent
     Qt6::Charts
+    Qt6::Widgets
     protobuf::libprotobuf
 )
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -72,5 +72,5 @@ endif()
 qt_add_qml_module(finch-app
     URI Finch
     VERSION 1.0
-    QML_FILES qml/Main.qml
+    QML_FILES qml/Main.qml qml/BalanceChart.qml
 )

--- a/app/qml/BalanceChart.qml
+++ b/app/qml/BalanceChart.qml
@@ -28,7 +28,7 @@ ColumnLayout {
         if (selectedAccountId === "")
             return
         finchClient.fetchTimeSeries(fromField.text, toField.text,
-                                    intervalBox.currentValue,
+                                    intervalBox.selectedInterval,
                                     [selectedAccountId])
     }
 
@@ -73,8 +73,8 @@ ColumnLayout {
         ComboBox {
             id: intervalBox
             model: ["Daily", "Weekly", "Monthly"]
-            property var values: [1, 2, 3]
-            property int currentValue: values[currentIndex]
+            property var intervalValues: [1, 2, 3]
+            property int selectedInterval: intervalValues[currentIndex]
             currentIndex: 1
         }
 

--- a/app/qml/BalanceChart.qml
+++ b/app/qml/BalanceChart.qml
@@ -117,8 +117,11 @@ ColumnLayout {
 
         Label {
             anchors.centerIn: parent
-            visible: finchClient.timeSeriesEmpty && !finchClient.timeSeriesLoading
-            text: "No data"
+            visible: !finchClient.accountsLoading && !finchClient.timeSeriesLoading
+                     && finchClient.timeSeriesEmpty
+            text: finchClient.accounts.length === 0
+                  ? "No accounts found"
+                  : "No data for selected range"
             font.pointSize: 12
             color: "gray"
         }

--- a/app/qml/BalanceChart.qml
+++ b/app/qml/BalanceChart.qml
@@ -1,0 +1,131 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtCharts
+import Finch 1.0
+
+ColumnLayout {
+    id: root
+    spacing: 8
+
+    property string selectedAccountId: {
+        if (finchClient.accounts.length > 0)
+            return finchClient.accounts[0].id
+        return ""
+    }
+
+    function defaultFromDate() {
+        return new Date().toISOString().slice(0, 10)
+    }
+
+    function defaultToDate() {
+        let d = new Date()
+        d.setMonth(d.getMonth() + 6)
+        return d.toISOString().slice(0, 10)
+    }
+
+    function fetch() {
+        if (selectedAccountId === "")
+            return
+        finchClient.fetchTimeSeries(fromField.text, toField.text,
+                                    intervalBox.currentValue,
+                                    [selectedAccountId])
+    }
+
+    Connections {
+        target: finchClient
+        function onAccountsChanged() {
+            if (finchClient.accounts.length > 0)
+                root.fetch()
+        }
+        function onTimeSeriesDataChanged() {
+            if (!finchClient.timeSeriesEmpty) {
+                finchClient.populateSeries(mainSeries, root.selectedAccountId)
+                axisX.min = new Date(finchClient.timeSeriesMinDate)
+                axisX.max = new Date(finchClient.timeSeriesMaxDate)
+                axisY.min = finchClient.timeSeriesMinBalance
+                axisY.max = finchClient.timeSeriesMaxBalance
+            }
+        }
+    }
+
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: 8
+
+        Label { text: "From:" }
+        TextField {
+            id: fromField
+            text: root.defaultFromDate()
+            placeholderText: "YYYY-MM-DD"
+            Layout.preferredWidth: 120
+        }
+
+        Label { text: "To:" }
+        TextField {
+            id: toField
+            text: root.defaultToDate()
+            placeholderText: "YYYY-MM-DD"
+            Layout.preferredWidth: 120
+        }
+
+        Label { text: "Interval:" }
+        ComboBox {
+            id: intervalBox
+            model: ["Daily", "Weekly", "Monthly"]
+            property var values: [1, 2, 3]
+            property int currentValue: values[currentIndex]
+            currentIndex: 1
+        }
+
+        Button {
+            text: finchClient.timeSeriesLoading ? "Loading…" : "Fetch"
+            enabled: !finchClient.timeSeriesLoading && root.selectedAccountId !== ""
+            onClicked: root.fetch()
+        }
+
+        Item { Layout.fillWidth: true }
+    }
+
+    Item {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+
+        ChartView {
+            id: chartView
+            anchors.fill: parent
+            visible: !finchClient.timeSeriesEmpty
+            antialiasing: true
+            legend.visible: false
+
+            DateTimeAxis {
+                id: axisX
+                format: "MMM yyyy"
+            }
+
+            ValueAxis {
+                id: axisY
+                labelFormat: "$%.0f"
+            }
+
+            LineSeries {
+                id: mainSeries
+                axisX: axisX
+                axisY: axisY
+            }
+        }
+
+        Label {
+            anchors.centerIn: parent
+            visible: finchClient.timeSeriesEmpty && !finchClient.timeSeriesLoading
+            text: "No data"
+            font.pointSize: 12
+            color: "gray"
+        }
+
+        BusyIndicator {
+            anchors.centerIn: parent
+            running: finchClient.timeSeriesLoading
+        }
+    }
+}

--- a/app/qml/Main.qml
+++ b/app/qml/Main.qml
@@ -53,32 +53,24 @@ ApplicationWindow {
     Item {
         anchors.fill: parent
 
+        BalanceChart {
+            anchors.fill: parent
+            anchors.margins: 16
+            visible: finchClient.connectionState === FinchClient.Connected
+        }
+
         Label {
             anchors.centerIn: parent
-            visible: !finchClient.accountsLoading && finchClient.accounts.length === 0
-            text: finchClient.connectionState === FinchClient.Connected
-                  ? "No accounts found"
-                  : "Not connected to daemon"
+            visible: finchClient.connectionState !== FinchClient.Connected
+                     && !finchClient.pingInProgress
+            text: "Not connected to daemon"
             font.pointSize: 12
             color: "gray"
         }
 
         BusyIndicator {
             anchors.centerIn: parent
-            running: finchClient.accountsLoading
-        }
-
-        ListView {
-            anchors.fill: parent
-            anchors.margins: 16
-            visible: finchClient.connectionState === FinchClient.Connected
-                     && finchClient.accounts.length > 0
-            model: finchClient.accounts
-            spacing: 4
-            delegate: ItemDelegate {
-                width: ListView.view.width
-                text: modelData.name
-            }
+            running: finchClient.pingInProgress
         }
     }
 

--- a/app/qml/Main.qml
+++ b/app/qml/Main.qml
@@ -57,12 +57,13 @@ ApplicationWindow {
             anchors.fill: parent
             anchors.margins: 16
             visible: finchClient.connectionState === FinchClient.Connected
+                     || !finchClient.timeSeriesEmpty
         }
 
         Label {
             anchors.centerIn: parent
-            visible: finchClient.connectionState !== FinchClient.Connected
-                     && !finchClient.pingInProgress
+            visible: finchClient.connectionState === FinchClient.Disconnected
+                     && finchClient.timeSeriesEmpty
             text: "Not connected to daemon"
             font.pointSize: 12
             color: "gray"
@@ -71,6 +72,7 @@ ApplicationWindow {
         BusyIndicator {
             anchors.centerIn: parent
             running: finchClient.pingInProgress
+                     && finchClient.timeSeriesEmpty
         }
     }
 

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -3,7 +3,6 @@
 #include <QDate>
 #include <QDateTime>
 #include <QTime>
-#include <QTimeZone>
 #include <QTimer>
 #include <QVariantMap>
 #include <QtConcurrent>
@@ -139,7 +138,7 @@ void FinchClient::fetchTimeSeries(const QString& fromDate, const QString& toDate
             QDate date = QDate::fromString(QString::fromStdString(point.date()), "yyyy-MM-dd");
             if (!date.isValid())
                 continue;
-            qint64 msec = QDateTime(date, QTime(0, 0), QTimeZone::UTC).toMSecsSinceEpoch();
+            qint64 msec = QDateTime(date, QTime(0, 0), Qt::UTC).toMSecsSinceEpoch();
 
             for (const auto& ab : point.balances()) {
                 QString accountId = QString::fromStdString(ab.account_id());

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -108,6 +108,9 @@ void FinchClient::fetchTimeSeries(const QString& fromDate, const QString& toDate
     m_timeSeriesLoading = true;
     emit timeSeriesLoadingChanged();
 
+    m_timeSeriesData = {};
+    emit timeSeriesDataChanged();
+
     auto stub = m_stub.get();
     std::string from = fromDate.toStdString();
     std::string to = toDate.toStdString();
@@ -205,30 +208,31 @@ double FinchClient::timeSeriesMaxDate() const
 double FinchClient::timeSeriesMinBalance() const
 {
     double min = std::numeric_limits<double>::max();
+    double max = std::numeric_limits<double>::lowest();
     for (const auto& points : m_timeSeriesData.seriesByAccount) {
-        for (const auto& pt : points)
+        for (const auto& pt : points) {
             min = qMin(min, pt.balance);
+            max = qMax(max, pt.balance);
+        }
     }
     if (min == std::numeric_limits<double>::max())
         return 0.0;
-    double range = timeSeriesMaxBalance() - min;
+    double range = max - min;
     return min - range * 0.05;
 }
 
 double FinchClient::timeSeriesMaxBalance() const
 {
+    double min = std::numeric_limits<double>::max();
     double max = std::numeric_limits<double>::lowest();
     for (const auto& points : m_timeSeriesData.seriesByAccount) {
-        for (const auto& pt : points)
+        for (const auto& pt : points) {
+            min = qMin(min, pt.balance);
             max = qMax(max, pt.balance);
+        }
     }
     if (max == std::numeric_limits<double>::lowest())
         return 0.0;
-    double min = std::numeric_limits<double>::max();
-    for (const auto& points : m_timeSeriesData.seriesByAccount) {
-        for (const auto& pt : points)
-            min = qMin(min, pt.balance);
-    }
     double range = max - min;
     return max + range * 0.05;
 }

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -1,10 +1,17 @@
 #include "finchclient.h"
 
+#include <QDate>
+#include <QDateTime>
+#include <QTime>
+#include <QTimeZone>
 #include <QTimer>
 #include <QVariantMap>
 #include <QtConcurrent>
+#include <QtCharts/QXYSeries>
 #include <chrono>
 #include <grpcpp/grpcpp.h>
+
+#include <limits>
 
 static constexpr int kMinConnectingMs = 300;
 
@@ -19,12 +26,15 @@ FinchClient::FinchClient(const QString& socketPath, QObject* parent)
             this, &FinchClient::onPingFinished);
     connect(&m_accountsWatcher, &QFutureWatcher<ListAccountsResult>::finished,
             this, &FinchClient::onListAccountsFinished);
+    connect(&m_timeSeriesWatcher, &QFutureWatcher<TimeSeriesResult>::finished,
+            this, &FinchClient::onTimeSeriesFinished);
 }
 
 FinchClient::~FinchClient()
 {
     m_pingWatcher.waitForFinished();
     m_accountsWatcher.waitForFinished();
+    m_timeSeriesWatcher.waitForFinished();
 }
 
 void FinchClient::ping()
@@ -90,6 +100,140 @@ void FinchClient::listAccounts()
     m_accountsWatcher.setFuture(future);
 }
 
+void FinchClient::fetchTimeSeries(const QString& fromDate, const QString& toDate,
+                                  int interval, const QStringList& accountIds)
+{
+    if (m_timeSeriesLoading)
+        return;
+
+    m_timeSeriesLoading = true;
+    emit timeSeriesLoadingChanged();
+
+    auto stub = m_stub.get();
+    std::string from = fromDate.toStdString();
+    std::string to = toDate.toStdString();
+    auto protoInterval = static_cast<finch::v1::TimeSeriesInterval>(interval);
+    std::vector<std::string> ids;
+    for (const auto& id : accountIds)
+        ids.push_back(id.toStdString());
+
+    auto future = QtConcurrent::run([stub, from, to, protoInterval, ids]() -> TimeSeriesResult {
+        grpc::ClientContext context;
+        context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(10));
+
+        finch::v1::GetBalanceTimeSeriesRequest request;
+        request.set_from_date(from);
+        request.set_to_date(to);
+        request.set_interval(protoInterval);
+        for (const auto& id : ids)
+            request.add_account_ids(id);
+
+        finch::v1::GetBalanceTimeSeriesResponse response;
+        grpc::Status status = stub->GetBalanceTimeSeries(&context, request, &response);
+        if (!status.ok())
+            return {};
+
+        TimeSeriesResult result;
+        result.ok = true;
+        for (const auto& point : response.points()) {
+            QDate date = QDate::fromString(QString::fromStdString(point.date()), "yyyy-MM-dd");
+            if (!date.isValid())
+                continue;
+            qint64 msec = QDateTime(date, QTime(0, 0), QTimeZone::UTC).toMSecsSinceEpoch();
+
+            for (const auto& ab : point.balances()) {
+                QString accountId = QString::fromStdString(ab.account_id());
+                double dollars = static_cast<double>(ab.balance()) / 100.0;
+                result.seriesByAccount[accountId].append({msec, dollars});
+            }
+        }
+        return result;
+    });
+
+    m_timeSeriesWatcher.setFuture(future);
+}
+
+void FinchClient::populateSeries(QObject* seriesObj, const QString& accountId)
+{
+    auto series = qobject_cast<QXYSeries*>(seriesObj);
+    if (!series)
+        return;
+
+    const auto it = m_timeSeriesData.seriesByAccount.find(accountId);
+    if (it == m_timeSeriesData.seriesByAccount.end()) {
+        series->clear();
+        return;
+    }
+
+    QList<QPointF> points;
+    points.reserve(it->size());
+    for (const auto& pt : *it)
+        points.append(QPointF(pt.msecsSinceEpoch, pt.balance));
+
+    series->replace(points);
+}
+
+bool FinchClient::timeSeriesEmpty() const
+{
+    return !m_timeSeriesData.ok || m_timeSeriesData.seriesByAccount.isEmpty();
+}
+
+QStringList FinchClient::timeSeriesAccountIds() const
+{
+    return m_timeSeriesData.seriesByAccount.keys();
+}
+
+double FinchClient::timeSeriesMinDate() const
+{
+    double min = std::numeric_limits<double>::max();
+    for (const auto& points : m_timeSeriesData.seriesByAccount) {
+        if (!points.isEmpty())
+            min = qMin(min, static_cast<double>(points.first().msecsSinceEpoch));
+    }
+    return min == std::numeric_limits<double>::max() ? 0.0 : min;
+}
+
+double FinchClient::timeSeriesMaxDate() const
+{
+    double max = std::numeric_limits<double>::lowest();
+    for (const auto& points : m_timeSeriesData.seriesByAccount) {
+        if (!points.isEmpty())
+            max = qMax(max, static_cast<double>(points.last().msecsSinceEpoch));
+    }
+    return max == std::numeric_limits<double>::lowest() ? 0.0 : max;
+}
+
+double FinchClient::timeSeriesMinBalance() const
+{
+    double min = std::numeric_limits<double>::max();
+    for (const auto& points : m_timeSeriesData.seriesByAccount) {
+        for (const auto& pt : points)
+            min = qMin(min, pt.balance);
+    }
+    if (min == std::numeric_limits<double>::max())
+        return 0.0;
+    double range = timeSeriesMaxBalance() - min;
+    return min - range * 0.05;
+}
+
+double FinchClient::timeSeriesMaxBalance() const
+{
+    double max = std::numeric_limits<double>::lowest();
+    for (const auto& points : m_timeSeriesData.seriesByAccount) {
+        for (const auto& pt : points)
+            max = qMax(max, pt.balance);
+    }
+    if (max == std::numeric_limits<double>::lowest())
+        return 0.0;
+    double min = std::numeric_limits<double>::max();
+    for (const auto& points : m_timeSeriesData.seriesByAccount) {
+        for (const auto& pt : points)
+            min = qMin(min, pt.balance);
+    }
+    double range = max - min;
+    return max + range * 0.05;
+}
+
 void FinchClient::onListAccountsFinished()
 {
     auto result = m_accountsWatcher.result();
@@ -132,4 +276,12 @@ void FinchClient::applyPingResult()
 
     emit daemonVersionChanged();
     emit connectionStateChanged();
+}
+
+void FinchClient::onTimeSeriesFinished()
+{
+    m_timeSeriesData = m_timeSeriesWatcher.result();
+    m_timeSeriesLoading = false;
+    emit timeSeriesLoadingChanged();
+    emit timeSeriesDataChanged();
 }

--- a/app/src/finchclient.h
+++ b/app/src/finchclient.h
@@ -3,8 +3,11 @@
 
 #include <QElapsedTimer>
 #include <QFutureWatcher>
+#include <QMap>
 #include <QObject>
+#include <QPointF>
 #include <QString>
+#include <QStringList>
 #include <QVariantList>
 #include <memory>
 
@@ -21,6 +24,16 @@ struct ListAccountsResult {
     QVariantList accounts;
 };
 
+struct TimeSeriesPoint {
+    qint64 msecsSinceEpoch;
+    double balance;
+};
+
+struct TimeSeriesResult {
+    bool ok = false;
+    QMap<QString, QList<TimeSeriesPoint>> seriesByAccount;
+};
+
 class FinchClient : public QObject {
     Q_OBJECT
     Q_PROPERTY(QString daemonVersion READ daemonVersion NOTIFY daemonVersionChanged)
@@ -28,6 +41,13 @@ class FinchClient : public QObject {
     Q_PROPERTY(bool pingInProgress READ pingInProgress NOTIFY pingInProgressChanged)
     Q_PROPERTY(QVariantList accounts READ accounts NOTIFY accountsChanged)
     Q_PROPERTY(bool accountsLoading READ accountsLoading NOTIFY accountsLoadingChanged)
+    Q_PROPERTY(bool timeSeriesLoading READ timeSeriesLoading NOTIFY timeSeriesLoadingChanged)
+    Q_PROPERTY(bool timeSeriesEmpty READ timeSeriesEmpty NOTIFY timeSeriesDataChanged)
+    Q_PROPERTY(QStringList timeSeriesAccountIds READ timeSeriesAccountIds NOTIFY timeSeriesDataChanged)
+    Q_PROPERTY(double timeSeriesMinDate READ timeSeriesMinDate NOTIFY timeSeriesDataChanged)
+    Q_PROPERTY(double timeSeriesMaxDate READ timeSeriesMaxDate NOTIFY timeSeriesDataChanged)
+    Q_PROPERTY(double timeSeriesMinBalance READ timeSeriesMinBalance NOTIFY timeSeriesDataChanged)
+    Q_PROPERTY(double timeSeriesMaxBalance READ timeSeriesMaxBalance NOTIFY timeSeriesDataChanged)
 
 public:
     enum ConnectionState { Disconnected, Connecting, Connected };
@@ -41,9 +61,19 @@ public:
     bool pingInProgress() const { return m_pingInProgress; }
     QVariantList accounts() const { return m_accounts; }
     bool accountsLoading() const { return m_accountsLoading; }
+    bool timeSeriesLoading() const { return m_timeSeriesLoading; }
+    bool timeSeriesEmpty() const;
+    QStringList timeSeriesAccountIds() const;
+    double timeSeriesMinDate() const;
+    double timeSeriesMaxDate() const;
+    double timeSeriesMinBalance() const;
+    double timeSeriesMaxBalance() const;
 
     Q_INVOKABLE void ping();
     Q_INVOKABLE void listAccounts();
+    Q_INVOKABLE void fetchTimeSeries(const QString& fromDate, const QString& toDate,
+                                     int interval, const QStringList& accountIds);
+    Q_INVOKABLE void populateSeries(QObject* series, const QString& accountId);
 
 signals:
     void daemonVersionChanged();
@@ -51,11 +81,14 @@ signals:
     void pingInProgressChanged();
     void accountsChanged();
     void accountsLoadingChanged();
+    void timeSeriesLoadingChanged();
+    void timeSeriesDataChanged();
 
 private slots:
     void onPingFinished();
     void applyPingResult();
     void onListAccountsFinished();
+    void onTimeSeriesFinished();
 
 private:
     std::shared_ptr<grpc::Channel> m_channel;
@@ -69,6 +102,9 @@ private:
     QVariantList m_accounts;
     bool m_accountsLoading = false;
     QFutureWatcher<ListAccountsResult> m_accountsWatcher;
+    bool m_timeSeriesLoading = false;
+    QFutureWatcher<TimeSeriesResult> m_timeSeriesWatcher;
+    TimeSeriesResult m_timeSeriesData;
 };
 
 #endif // FINCHCLIENT_H

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -1,4 +1,4 @@
-#include <QGuiApplication>
+#include <QApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QUrl>
@@ -22,7 +22,7 @@ static std::string socketPath()
 
 int main(int argc, char* argv[])
 {
-    QGuiApplication app(argc, argv);
+    QApplication app(argc, argv);
     app.setApplicationName("Finch");
     app.setApplicationVersion("0.1.0");
 


### PR DESCRIPTION
## Overview

The purpose of this change is to give users a visual representation of projected account balances over time, replacing the text-only account list with an interactive line chart. It represents an incremental improvement -- PR 2 of the balance projection chart work (#5), building on the `GetBalanceTimeSeries` RPC that already exists in core and daemon.

## Changes

- **FinchClient C++ (`finchclient.h/cpp`):** Added `fetchTimeSeries()` async gRPC call following the existing QFutureWatcher pattern, and `populateSeries()` bridge that uses `QXYSeries::replace(QList<QPointF>)` for efficient bulk data transfer to QML chart series. Includes axis bound properties with symmetric 5% Y-axis padding. Clears stale data on re-fetch for immediate loading state feedback.
- **BalanceChart.qml (new):** Chart component with `ChartView`, `DateTimeAxis`, `ValueAxis`, `LineSeries`, date range text fields (defaults: today to +6 months), interval selector (Daily/Weekly/Monthly), and distinct empty states ("No accounts found" vs "No data for selected range").
- **Main.qml:** Replaced `ListView` account list with `BalanceChart` component. Chart stays visible during re-ping when data is already loaded.
- **main.cpp:** Switched from `QGuiApplication` to `QApplication` — required by QtCharts QML types which depend on QWidgets internally.
- **CMakeLists.txt:** Added `Qt6::Widgets` dependency, registered `BalanceChart.qml` in QML module.
- **.gitignore:** Changed from ignoring all of `.claude/` to only `.claude/settings.local.json` — rules, commands, and shared settings are meant to be committed.
- **.claude/rules/:** Added `qt-app.md` (QApplication requirement, Qt version parity, QML FINAL properties) and `ci.md` (local build verification before push).

## Edge cases handled

- Empty data: distinct messages for "no accounts" vs "no data for selected range"
- Timezone: UTC date parsing to avoid DateTimeAxis offset issues
- Destructor: waits for in-flight time series watcher (matching ping/accounts pattern)
- Re-ping stability: chart stays visible during re-ping when data is already loaded
- Re-fetch: clears stale data immediately so loading state is visible

Closes #17
Part of #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)