### PR TITLE
Add install target for MCP binary

### DIFF
--- a/justfile
+++ b/justfile
@@ -58,6 +58,9 @@ clean:
     rm -rf app/build
     rm -rf daemon/gen
 
+# Install all components
+install: install-service install-mcp
+
 # Install systemd user service
 install-service: build-daemon
     mkdir -p ~/.local/bin
@@ -66,3 +69,8 @@ install-service: build-daemon
     cp daemon/finch.service ~/.config/systemd/user/
     systemctl --user daemon-reload
     systemctl --user enable --now finch.service
+
+# Install MCP server binary
+install-mcp: build-mcp
+    mkdir -p ~/.local/bin
+    cp mcp/finch-mcp ~/.local/bin/


### PR DESCRIPTION
## Overview

The purpose of this change is to provide an install path for the MCP server binary to `~/.local/bin/`, mirroring the existing `install-service` pattern for the daemon. This is an incremental improvement — once dotfiles registers the MCP server in Claude Code's user-scoped config pointing to `~/.local/bin/finch-mcp`, this target ensures the binary can be kept current with a single command rather than manual copying.

## Changes

- Add `install-mcp` target: builds and copies `finch-mcp` to `~/.local/bin/`
- Add combined `install` target: runs both `install-service` and `install-mcp`

No systemd service for MCP — it uses stdio transport, invoked on-demand by Claude Code.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)