### PR TITLE
feat(app): multi-account balance chart overlay

### DIFF
--- a/.claude/rules/qt-app.md
+++ b/.claude/rules/qt-app.md
@@ -14,6 +14,16 @@ When a Qt API has a deprecated form that works across all Qt6 versions and a rep
 
 Qt Quick Controls types mark many properties as FINAL. NEVER declare custom properties that shadow built-in names (e.g., `currentValue` on `ComboBox`). The QML engine will error with "Cannot override FINAL property" at runtime.
 
+## Qt Charts Gotchas
+
+**Theme on dark desktops:** ChartView's default theme renders transparent/invisible on dark desktop themes. ALWAYS set an explicit theme (e.g., `theme: ChartView.ChartThemeLight`).
+
+**Anchor series for axis initialization:** Axes declared as ChartView children without a static series may not initialize properly for dynamically created series. Include a hidden anchor `LineSeries` that references the axes (`visible: false`) to ensure they register with the chart.
+
+**Dynamic series lifecycle:** `ChartView.removeSeries()` detaches a series but does not destroy it. ALWAYS call `series.destroy()` after removal to avoid memory leaks.
+
+**`attachAxis` not available in QML:** `QAbstractSeries::attachAxis` is not exposed on `DeclarativeLineSeries`. Pass axes as arguments to `ChartView.createSeries(type, name, axisX, axisY)` instead.
+
 ## Build and Test
 
 Build: `just build-app` (or `cmake -S app -B app/build && cmake --build app/build`).

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The C++/Qt app requires system-level packages. On Ubuntu/Debian:
 
 ```bash
 sudo apt install cmake qt6-base-dev qt6-declarative-dev qml6-module-qtquick-controls \
+  qt6-charts-dev qml6-module-qtcharts \
   protobuf-compiler libprotobuf-dev libgrpc++-dev protobuf-compiler-grpc
 ```
 
@@ -32,6 +33,7 @@ sudo apt install cmake qt6-base-dev qt6-declarative-dev qml6-module-qtquick-cont
 mise install       # Install pinned tool versions
 just proto         # Generate protobuf Go code
 just all           # Build daemon and MCP server
+just build-app     # Build the Qt desktop app
 just test          # Run all Go tests
 just lint          # Run golangci-lint on all modules
 ```
@@ -45,6 +47,14 @@ just install-service
 ```
 
 This builds the daemon, copies it to `~/.local/bin/`, installs the systemd unit, and starts the service.
+
+### Install the MCP server
+
+```bash
+just install-mcp
+```
+
+This builds the MCP binary and copies it to `~/.local/bin/`.
 
 ### Manual
 

--- a/app/qml/BalanceChart.qml
+++ b/app/qml/BalanceChart.qml
@@ -8,11 +8,13 @@ ColumnLayout {
     id: root
     spacing: 8
 
-    property string selectedAccountId: {
-        if (finchClient.accounts.length > 0)
-            return finchClient.accounts[0].id
-        return ""
-    }
+    property var selectedAccountIds: []
+
+    // D3 "tab10" palette — colorblind-considerate, widely used
+    readonly property var colorPalette: [
+        "#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd",
+        "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf"
+    ]
 
     function defaultFromDate() {
         return new Date().toISOString().slice(0, 10)
@@ -25,27 +27,68 @@ ColumnLayout {
     }
 
     function fetch() {
-        if (selectedAccountId === "")
+        if (selectedAccountIds.length === 0)
             return
         finchClient.fetchTimeSeries(fromField.text, toField.text,
                                     intervalBox.selectedInterval,
-                                    [selectedAccountId])
+                                    selectedAccountIds)
+    }
+
+    function accountColor(accountId) {
+        for (let i = 0; i < finchClient.accounts.length; i++) {
+            if (finchClient.accounts[i].id === accountId)
+                return colorPalette[i % colorPalette.length]
+        }
+        return colorPalette[0]
+    }
+
+    function rebuildSeries() {
+        chartView.removeAllSeries()
+        let ids = finchClient.timeSeriesAccountIds
+        for (let i = 0; i < ids.length; i++) {
+            let accountId = ids[i]
+            // Only show series for currently selected accounts
+            if (selectedAccountIds.indexOf(accountId) === -1)
+                continue
+            let name = accountId
+            for (let j = 0; j < finchClient.accounts.length; j++) {
+                if (finchClient.accounts[j].id === accountId) {
+                    name = finchClient.accounts[j].name
+                    break
+                }
+            }
+            let series = chartView.createSeries(ChartView.SeriesTypeLine,
+                                                 name, axisX, axisY)
+            series.color = root.accountColor(accountId)
+            finchClient.populateSeries(series, accountId)
+        }
+    }
+
+    Timer {
+        id: fetchDebounce
+        interval: 300
+        onTriggered: root.fetch()
     }
 
     Connections {
         target: finchClient
         function onAccountsChanged() {
-            if (finchClient.accounts.length > 0)
+            if (finchClient.accounts.length > 0) {
+                let ids = []
+                for (let i = 0; i < finchClient.accounts.length; i++)
+                    ids.push(finchClient.accounts[i].id)
+                root.selectedAccountIds = ids
                 root.fetch()
+            }
         }
         function onTimeSeriesDataChanged() {
             if (!finchClient.timeSeriesEmpty) {
-                finchClient.populateSeries(mainSeries, root.selectedAccountId)
                 axisX.min = new Date(finchClient.timeSeriesMinDate)
                 axisX.max = new Date(finchClient.timeSeriesMaxDate)
                 axisY.min = finchClient.timeSeriesMinBalance
                 axisY.max = finchClient.timeSeriesMaxBalance
             }
+            root.rebuildSeries()
         }
     }
 
@@ -80,55 +123,97 @@ ColumnLayout {
 
         Button {
             text: finchClient.timeSeriesLoading ? "Loading…" : "Fetch"
-            enabled: !finchClient.timeSeriesLoading && root.selectedAccountId !== ""
+            enabled: !finchClient.timeSeriesLoading
+                     && root.selectedAccountIds.length > 0
             onClicked: root.fetch()
         }
 
         Item { Layout.fillWidth: true }
     }
 
-    Item {
+    RowLayout {
         Layout.fillWidth: true
         Layout.fillHeight: true
+        spacing: 0
 
-        ChartView {
-            id: chartView
-            anchors.fill: parent
-            visible: !finchClient.timeSeriesEmpty
-            antialiasing: true
-            legend.visible: false
+        ColumnLayout {
+            Layout.preferredWidth: 180
+            Layout.fillHeight: true
+            spacing: 4
 
-            DateTimeAxis {
-                id: axisX
-                format: "MMM yyyy"
+            Label {
+                text: "Accounts"
+                font.bold: true
+                Layout.leftMargin: 8
             }
 
-            ValueAxis {
-                id: axisY
-                labelFormat: "$%.0f"
-            }
+            ScrollView {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
 
-            LineSeries {
-                id: mainSeries
-                axisX: axisX
-                axisY: axisY
+                ListView {
+                    model: finchClient.accounts
+                    delegate: CheckDelegate {
+                        width: ListView.view.width
+                        text: modelData.name
+                        checked: root.selectedAccountIds.indexOf(modelData.id) !== -1
+                        onToggled: {
+                            let ids = root.selectedAccountIds.slice()
+                            let idx = ids.indexOf(modelData.id)
+                            if (checked && idx === -1)
+                                ids.push(modelData.id)
+                            else if (!checked && idx !== -1)
+                                ids.splice(idx, 1)
+                            root.selectedAccountIds = ids
+                            fetchDebounce.restart()
+                        }
+                    }
+                }
             }
         }
 
-        Label {
-            anchors.centerIn: parent
-            visible: !finchClient.accountsLoading && !finchClient.timeSeriesLoading
-                     && finchClient.timeSeriesEmpty
-            text: finchClient.accounts.length === 0
-                  ? "No accounts found"
-                  : "No data for selected range"
-            font.pointSize: 12
-            color: "gray"
-        }
+        Item {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
 
-        BusyIndicator {
-            anchors.centerIn: parent
-            running: finchClient.timeSeriesLoading
+            ChartView {
+                id: chartView
+                anchors.fill: parent
+                visible: !finchClient.timeSeriesEmpty
+                antialiasing: true
+                legend.visible: true
+
+                DateTimeAxis {
+                    id: axisX
+                    format: "MMM yyyy"
+                }
+
+                ValueAxis {
+                    id: axisY
+                    labelFormat: "$%.0f"
+                }
+            }
+
+            Label {
+                anchors.centerIn: parent
+                visible: !finchClient.accountsLoading
+                         && !finchClient.timeSeriesLoading
+                         && finchClient.timeSeriesEmpty
+                text: {
+                    if (finchClient.accounts.length === 0)
+                        return "No accounts found"
+                    if (root.selectedAccountIds.length === 0)
+                        return "No accounts selected"
+                    return "No data for selected range"
+                }
+                font.pointSize: 12
+                color: "gray"
+            }
+
+            BusyIndicator {
+                anchors.centerIn: parent
+                running: finchClient.timeSeriesLoading
+            }
         }
     }
 }

--- a/app/qml/BalanceChart.qml
+++ b/app/qml/BalanceChart.qml
@@ -10,12 +10,17 @@ ColumnLayout {
 
     property var selectedAccountIds: []
     property var dynamicSeries: []
+    property bool pendingFetch: false
 
     // D3 "tab10" palette — colorblind-considerate, widely used
     readonly property var colorPalette: [
         "#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd",
         "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf"
     ]
+
+    // Chart is visible when there are selected accounts AND data exists
+    readonly property bool chartVisible: selectedAccountIds.length > 0
+                                         && !finchClient.timeSeriesEmpty
 
     function defaultFromDate() {
         return new Date().toISOString().slice(0, 10)
@@ -30,6 +35,10 @@ ColumnLayout {
     function fetch() {
         if (selectedAccountIds.length === 0)
             return
+        if (finchClient.timeSeriesLoading) {
+            pendingFetch = true
+            return
+        }
         finchClient.fetchTimeSeries(fromField.text, toField.text,
                                     intervalBox.selectedInterval,
                                     selectedAccountIds)
@@ -43,10 +52,16 @@ ColumnLayout {
         return colorPalette[0]
     }
 
-    function rebuildSeries() {
-        for (let i = 0; i < dynamicSeries.length; i++)
+    function clearSeries() {
+        for (let i = 0; i < dynamicSeries.length; i++) {
             chartView.removeSeries(dynamicSeries[i])
+            dynamicSeries[i].destroy()
+        }
         dynamicSeries = []
+    }
+
+    function rebuildSeries() {
+        clearSeries()
 
         let ids = finchClient.timeSeriesAccountIds
         let created = []
@@ -80,10 +95,29 @@ ColumnLayout {
         target: finchClient
         function onAccountsChanged() {
             if (finchClient.accounts.length > 0) {
-                let ids = []
-                for (let i = 0; i < finchClient.accounts.length; i++)
-                    ids.push(finchClient.accounts[i].id)
-                root.selectedAccountIds = ids
+                if (root.selectedAccountIds.length === 0) {
+                    // First load — select all accounts
+                    let ids = []
+                    for (let i = 0; i < finchClient.accounts.length; i++)
+                        ids.push(finchClient.accounts[i].id)
+                    root.selectedAccountIds = ids
+                } else {
+                    // Preserve selections that still exist, add new accounts
+                    let validIds = []
+                    let knownIds = root.selectedAccountIds
+                    for (let i = 0; i < finchClient.accounts.length; i++) {
+                        let id = finchClient.accounts[i].id
+                        if (knownIds.indexOf(id) !== -1)
+                            validIds.push(id)
+                    }
+                    // Auto-select any newly added accounts
+                    for (let i = 0; i < finchClient.accounts.length; i++) {
+                        let id = finchClient.accounts[i].id
+                        if (validIds.indexOf(id) === -1)
+                            validIds.push(id)
+                    }
+                    root.selectedAccountIds = validIds
+                }
                 root.fetch()
             }
         }
@@ -95,6 +129,12 @@ ColumnLayout {
                 axisY.max = finchClient.timeSeriesMaxBalance
             }
             root.rebuildSeries()
+        }
+        function onTimeSeriesLoadingChanged() {
+            if (!finchClient.timeSeriesLoading && root.pendingFetch) {
+                root.pendingFetch = false
+                root.fetch()
+            }
         }
     }
 
@@ -172,7 +212,10 @@ ColumnLayout {
                             else if (!checked && idx !== -1)
                                 ids.splice(idx, 1)
                             root.selectedAccountIds = ids
-                            fetchDebounce.restart()
+                            if (ids.length === 0)
+                                root.clearSeries()
+                            else
+                                fetchDebounce.restart()
                         }
                     }
                 }
@@ -186,7 +229,7 @@ ColumnLayout {
             ChartView {
                 id: chartView
                 anchors.fill: parent
-                visible: !finchClient.timeSeriesEmpty
+                visible: root.chartVisible
                 antialiasing: true
                 legend.visible: true
                 theme: ChartView.ChartThemeLight
@@ -213,7 +256,7 @@ ColumnLayout {
                 anchors.centerIn: parent
                 visible: !finchClient.accountsLoading
                          && !finchClient.timeSeriesLoading
-                         && finchClient.timeSeriesEmpty
+                         && !root.chartVisible
                 text: {
                     if (finchClient.accounts.length === 0)
                         return "No accounts found"

--- a/app/qml/BalanceChart.qml
+++ b/app/qml/BalanceChart.qml
@@ -9,6 +9,7 @@ ColumnLayout {
     spacing: 8
 
     property var selectedAccountIds: []
+    property var dynamicSeries: []
 
     // D3 "tab10" palette — colorblind-considerate, widely used
     readonly property var colorPalette: [
@@ -43,11 +44,14 @@ ColumnLayout {
     }
 
     function rebuildSeries() {
-        chartView.removeAllSeries()
+        for (let i = 0; i < dynamicSeries.length; i++)
+            chartView.removeSeries(dynamicSeries[i])
+        dynamicSeries = []
+
         let ids = finchClient.timeSeriesAccountIds
+        let created = []
         for (let i = 0; i < ids.length; i++) {
             let accountId = ids[i]
-            // Only show series for currently selected accounts
             if (selectedAccountIds.indexOf(accountId) === -1)
                 continue
             let name = accountId
@@ -61,7 +65,9 @@ ColumnLayout {
                                                  name, axisX, axisY)
             series.color = root.accountColor(accountId)
             finchClient.populateSeries(series, accountId)
+            created.push(series)
         }
+        dynamicSeries = created
     }
 
     Timer {
@@ -138,6 +144,7 @@ ColumnLayout {
 
         ColumnLayout {
             Layout.preferredWidth: 180
+            Layout.maximumWidth: 180
             Layout.fillHeight: true
             spacing: 4
 
@@ -182,6 +189,7 @@ ColumnLayout {
                 visible: !finchClient.timeSeriesEmpty
                 antialiasing: true
                 legend.visible: true
+                theme: ChartView.ChartThemeLight
 
                 DateTimeAxis {
                     id: axisX
@@ -191,6 +199,13 @@ ColumnLayout {
                 ValueAxis {
                     id: axisY
                     labelFormat: "$%.0f"
+                }
+
+                LineSeries {
+                    id: anchorSeries
+                    axisX: axisX
+                    axisY: axisY
+                    visible: false
                 }
             }
 


### PR DESCRIPTION
## Overview

The purpose of this change is to complete the balance projection chart feature (#5) by adding multi-account selection with overlaid line series. The chart previously showed only a single hard-coded account. This is an incremental improvement that extends the existing single-account chart into a multi-account overlay, with a sidebar for account selection and a legend for identification.

Closes #18

## Changes

- **BalanceChart.qml**: Replace single-account `selectedAccountId` with multi-account `selectedAccountIds` array. Add sidebar with `CheckDelegate` checkboxes per account. Create dynamic `LineSeries` via `ChartView.createSeries()` for each selected account. Use D3 "tab10" color palette (colorblind-considerate). Debounce selection changes (300ms) before re-fetching. Enable chart legend. Force `ChartThemeLight` to ensure visibility on dark desktops.
- **README.md**: Add missing `qt6-charts-dev` and `qml6-module-qtcharts` to apt install line. Add `just build-app` to Getting Started. Add `just install-mcp` section under Running Locally.

## Test plan

- [x] `just build-app` compiles successfully
- [x] `just test` and `just lint` pass (no Go changes, confirmed no regressions)
- [x] Manual testing with 3 accounts (Checking, Savings, Credit Card) and recurring rules
- [x] Verified: sidebar shows all accounts checked by default, chart shows overlaid series with distinct colors
- [x] Verified: toggling checkboxes adds/removes series after debounce
- [x] Verified: legend displays account names with matching colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)