### PR TITLE
Add project-level design patterns and practices rules

### DIFF
--- a/.claude/rules/api-design.md
+++ b/.claude/rules/api-design.md
@@ -1,0 +1,32 @@
+# Proto Conventions and API Layer
+
+## Proto Message Naming
+
+Each RPC has `<Operation>Request` and `<Operation>Response` message pairs. Enums ALWAYS have `_UNSPECIFIED = 0` as the first value. Field numbers are sequential with no gaps or reuse.
+
+## Daemon Adapter Pattern
+
+Daemon server methods adapt between proto types and core domain types. Proto enums and core enums share numeric values, enabling direct type casting (e.g., `core.AccountType(req.Type)`). If numeric alignment breaks, introduce an explicit mapping function rather than renumbering either side.
+
+## gRPC Error Categorization
+
+Map domain errors to appropriate gRPC status codes:
+
+- `codes.NotFound` — aggregate does not exist
+- `codes.InvalidArgument` — validation failure (bad input from caller)
+- `codes.AlreadyExists` — duplicate creation attempt
+- `codes.Internal` — unexpected errors only (database failures, marshaling errors)
+
+NEVER use `codes.Internal` as a catch-all. Callers depend on status codes to distinguish recoverable from non-recoverable failures.
+
+## Validation at the Boundary
+
+Validate request fields in daemon handlers before calling core methods. Core methods also validate (defense in depth), but user-facing error messages originate from the API layer. This means the daemon should produce clear, specific `InvalidArgument` messages for malformed requests.
+
+## MCP Delegation Pattern
+
+Each MCP tool handler delegates to exactly one gRPC call. Define separate `*Input` and `*Output` structs per tool for schema generation. Tool handler factories return closures that capture the gRPC client.
+
+## Context Deadline Discipline
+
+Daemon handlers SHOULD set timeouts on core operations via `context.WithTimeout`. MCP handlers SHOULD propagate deadlines from the MCP framework. A slow query must not block indefinitely.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,32 @@
+# System Architecture and Boundaries
+
+## Layer Boundaries
+
+The dependency graph is strictly one-directional:
+
+- **Core** has no proto, gRPC, or MCP dependencies. It defines domain types and logic only.
+- **Daemon** imports core. It adapts core types to proto types and serves gRPC.
+- **MCP** imports the daemon's generated gRPC client. It adapts gRPC responses to MCP tool results.
+- **App** communicates exclusively via gRPC. It has no Go dependencies.
+
+NEVER introduce a dependency that violates this direction (e.g., core importing proto types, MCP importing core directly).
+
+## Module Isolation
+
+Each component is a separate Go module with its own `go.mod`. Inter-module dependencies use `replace` directives pointing to relative paths (e.g., `replace github.com/jakewan/finch/core => ../core`).
+
+## Process Isolation
+
+The daemon is the sole database owner. All other components access data through gRPC over a Unix socket. No component other than the daemon should open or reference the SQLite database.
+
+## Interface-Based Repository Boundary
+
+Core SHOULD expose interfaces defining the domain contract (e.g., per-aggregate or a unified store interface). This formalizes the boundary between domain logic and its consumers, and enables isolated testing of the daemon without requiring a real database.
+
+## Double-Entry Accounting
+
+Transfers create paired transactions: negative on source, positive on destination, plus a linking event for traceability. Both sides MUST be written in a single database transaction to maintain accounting consistency.
+
+## Projection Composition
+
+Complex projections are built by composing simpler operations: starting balance computation, recurring rule occurrence expansion, deduplication of recorded vs. projected entries, and running balance accumulation. Each step is a distinct function that can be tested independently.

--- a/.claude/rules/build-and-migrations.md
+++ b/.claude/rules/build-and-migrations.md
@@ -1,0 +1,24 @@
+# Build Pipeline and Schema Evolution
+
+## Buf Pipeline
+
+`buf lint` + `buf generate` produces all proto code. NEVER use raw `protoc`. Generated code lives in `daemon/gen/` and is NOT committed to the repository — it is regenerated at build time.
+
+## Just Targets
+
+`just proto` MUST run before `just build-*`. The `just all` target runs the full dependency chain: proto → build-daemon → build-mcp. Per-module targets (`test-core`, `lint-daemon`, etc.) exist for focused development.
+
+## Embedded Migrations
+
+SQL migration files live in `core/migrations/` and are embedded in the binary via `//go:embed`. Numeric prefix determines execution order (e.g., `001_initial.sql`, `002_event_store.sql`). Migrations run automatically on `DB.Open()` and are tracked in the `schema_version` table.
+
+## Adding a Migration
+
+1. Create `NNN_descriptive_name.sql` with the next sequence number.
+2. Each migration runs in its own database transaction.
+3. Test the migration against both a fresh database and one with existing data and schema.
+4. NEVER modify an existing migration file — create a new migration instead.
+
+## Foreign Key Enforcement
+
+`PRAGMA foreign_keys = ON` is executed on every `DB.Open()`. All reference columns in the schema define explicit foreign key constraints. Referential integrity is enforced by the database, not the application.

--- a/.claude/rules/event-sourcing.md
+++ b/.claude/rules/event-sourcing.md
@@ -1,0 +1,30 @@
+# Event Sourcing and Domain Modeling
+
+## Events as Source of Truth
+
+Every domain state change MUST produce at least one event. Events are the source of truth; read model tables (`accounts`, `transactions`, `recurring_rules`) are derived views maintained for query efficiency.
+
+## Aggregate Pattern
+
+Each aggregate type (`account`, `transaction`, `recurring_rule`) has its own event stream with monotonically increasing sequence numbers. Event types are string constants defined per aggregate (e.g., `EventAccountCreated`, `EventRecurringRulePaused`). Each event type has a dedicated payload struct with JSON tags.
+
+## Transaction Boundaries
+
+Domain operations follow this sequence within a single database transaction:
+
+1. Validate input
+2. Append event(s) via `appendEvents(ctx, tx, ...)`
+3. Update the read model table
+4. Commit (or rollback on any error)
+
+NEVER append events outside a transaction. NEVER update a read model without a corresponding event.
+
+## Event Replay
+
+Read models MUST be rebuildable from the event log. Provide replay functions that reconstruct aggregate state from events. This is the recovery path if a read model diverges from the event log due to a migration bug or schema change.
+
+## Domain Error Types
+
+Define typed errors in `core` for common failure modes: not found, invalid input, conflict/duplicate. Use `errors.Is`/`errors.As` for programmatic error handling. NEVER rely on string matching to distinguish error conditions.
+
+Typed errors enable proper gRPC status code mapping in the daemon layer (see `api-design.md`).

--- a/.claude/rules/go-practices.md
+++ b/.claude/rules/go-practices.md
@@ -1,0 +1,46 @@
+# Go Idioms and Conventions
+
+## Error Wrapping
+
+ALWAYS use `fmt.Errorf("context: %w", err)`. Each call site adds human-readable context describing what operation failed. Errors MUST be unwrappable via `errors.Is`/`errors.As`.
+
+## Resource Cleanup
+
+ALWAYS defer cleanup for closeable resources:
+
+```go
+defer func() { _ = resource.Close() }()
+```
+
+This applies to DB connections, gRPC connections, SQL rows, and network listeners. The `_ =` suppresses linter warnings about unchecked close errors.
+
+## Enum Validation
+
+Unspecified/zero enum values are always invalid. Validation functions check range (e.g., `freq >= FrequencyWeekly && freq <= FrequencyYearly`), not exhaustive match against every value. This ensures new enum values are valid by default if they fall within the range.
+
+## Time Handling
+
+- UTC everywhere. NEVER store or compare times in local zones.
+- `time.DateOnly` format (`"2006-01-02"`) for date strings in JSON, proto, and SQL.
+- Unix timestamps (`INTEGER`) for database storage of full timestamps.
+- Use `time.Parse(time.DateOnly, s)` and `t.Format(time.DateOnly)` consistently.
+
+## Params Structs
+
+Complex operations (3+ parameters, optional fields) use dedicated parameter structs. Optional fields use pointer types (`*string`, `*time.Time`). This is clearer than long argument lists and enables named-field initialization.
+
+## Scanner Helpers
+
+Each entity type has a dedicated `scan*()` function that iterates `*sql.Rows`, handles null columns via `sql.NullString`, defers `rows.Close()`, and returns a typed slice. Scanner functions are the single point of truth for column-to-field mapping.
+
+## Nullable Columns
+
+Optional fields use `sql.NullString`/`sql.NullInt64` for scanning, `*string`/`*time.Time` in domain types, and `nilIfEmpty()` helpers for conversion between representations.
+
+## Input Sanitization
+
+Trim whitespace from string inputs before validation. A name that is whitespace-only MUST fail the non-empty check. Enforce reasonable length limits on user-provided strings (names, descriptions).
+
+## Graceful Shutdown
+
+Signal handling (SIGINT/SIGTERM) runs in a separate goroutine. Use `GracefulStop()` (not `Stop()`) to allow in-flight operations to complete. Defer cleanup for all resources opened during initialization.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,23 @@
+# Testing Strategy and Conventions
+
+## Test Isolation
+
+Each test gets its own in-memory SQLite database via `openTestDB(t)`. Tests NEVER share database state. This eliminates ordering dependencies and enables parallel execution.
+
+## Per-Component Strategy
+
+- **Core:** Table-driven unit tests for domain logic, edge cases, and validation boundaries. Test event production (correct event types and payloads), not just read model state.
+- **Daemon:** Integration tests against a real (in-memory) database via gRPC. These verify the full request path: proto deserialization → validation → core call → response serialization.
+- **MCP:** BDD-style tests verifying tool behavior end-to-end. Each tool's test describes the behavior from the user's perspective.
+
+## Test Helpers
+
+Shared helpers (`openTestDB`, `createTestAccount`, `date()`) live in `*_test.go` files within the package under test. Keep helpers minimal and focused — a helper that does too much obscures what the test is actually verifying.
+
+## What to Test
+
+Test domain invariants, validation boundaries, error conditions, and event production. Do NOT test framework plumbing, generated code, or trivial getters/setters. A test earns its keep by catching regressions in behavior that matters.
+
+## Qt App
+
+Build verification (`just build-app`) is the current minimum for the Qt app. Introduce QML automated testing when the app has form-based interactions and data mutation workflows worth protecting with regression tests.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -2,7 +2,7 @@
 
 ## Test Isolation
 
-Each test gets its own in-memory SQLite database via `openTestDB(t)`. Tests NEVER share database state. This eliminates ordering dependencies and enables parallel execution.
+Each test gets its own temporary on-disk SQLite database via `openTestDB(t)` (which uses `t.TempDir()` for automatic cleanup). Tests NEVER share database state. This eliminates ordering dependencies and enables parallel execution.
 
 ## Per-Component Strategy
 


### PR DESCRIPTION
## Overview

The purpose of this change is to codify the design patterns and engineering practices that define what correct Finch code looks like. It represents an incremental improvement -- making implicit conventions explicit so that every future session (human or AI) starts with a shared understanding of how the codebase works and where it's headed.

The rules describe both established patterns already in the code and target-state practices the codebase should converge toward incrementally. There is no distinction between the two -- the rules define the standard, and the code moves toward it through normal development.

## Changes

Six new rule files in `.claude/rules/`:

- **event-sourcing.md** — Event sourcing, aggregate pattern, transaction boundaries, domain error types, event replay
- **api-design.md** — Proto conventions, daemon adapter pattern, gRPC error categorization, MCP delegation, context deadlines
- **architecture.md** — Layer boundaries, module isolation, process isolation, interface-based repository boundary, double-entry accounting
- **go-practices.md** — Error wrapping, resource cleanup, enum validation, time handling, params structs, input sanitization
- **testing.md** — Test isolation, per-component strategy, test helpers, what to test
- **build-and-migrations.md** — Buf pipeline, just targets, embedded migrations, foreign key enforcement

Existing rule files (`ci.md`, `qt-app.md`) are unchanged.

## Test plan

- [x] Pre-push hooks pass (lint, test, proto)
- [ ] Review each rule file for accuracy against current codebase
- [ ] Verify no contradictions with existing `ci.md` and `qt-app.md` rules


🤖 Generated with [Claude Code](https://claude.com/claude-code)