### PR TITLE
Expose ListTransactions via API

### DIFF
--- a/daemon/finchd/server.go
+++ b/daemon/finchd/server.go
@@ -93,13 +93,13 @@ func (s *Server) CreateRecurringRule(ctx context.Context, req *finchv1.CreateRec
 	}
 
 	params := core.CreateRecurringRuleParams{
-		AccountID:              req.AccountId,
-		Name:                   req.Name,
-		Amount:                 req.Amount,
-		Frequency:              core.Frequency(req.Frequency),
-		StartDate:              startDate,
-		DayOfMonth:             int(req.DayOfMonth),
-		IsTransfer:             req.IsTransfer,
+		AccountID:               req.AccountId,
+		Name:                    req.Name,
+		Amount:                  req.Amount,
+		Frequency:               core.Frequency(req.Frequency),
+		StartDate:               startDate,
+		DayOfMonth:              int(req.DayOfMonth),
+		IsTransfer:              req.IsTransfer,
 		TransferTargetAccountID: req.TransferTargetAccountId,
 	}
 
@@ -194,6 +194,21 @@ func (s *Server) RecordTransaction(ctx context.Context, req *finchv1.RecordTrans
 	return &finchv1.RecordTransactionResponse{
 		Transaction: transactionToProto(txn),
 	}, nil
+}
+
+func (s *Server) ListTransactions(ctx context.Context, req *finchv1.ListTransactionsRequest) (*finchv1.ListTransactionsResponse, error) {
+	if strings.TrimSpace(req.AccountId) == "" {
+		return nil, status.Error(codes.InvalidArgument, "account_id must not be empty")
+	}
+	txns, err := s.db.ListTransactions(ctx, req.AccountId)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list transactions: %v", err)
+	}
+	resp := &finchv1.ListTransactionsResponse{}
+	for _, t := range txns {
+		resp.Transactions = append(resp.Transactions, transactionToProto(&t))
+	}
+	return resp, nil
 }
 
 func (s *Server) UpdateTransactionStatus(ctx context.Context, req *finchv1.UpdateTransactionStatusRequest) (*finchv1.UpdateTransactionStatusResponse, error) {
@@ -376,16 +391,16 @@ func eventsToProto(events []core.Event) *finchv1.GetAccountHistoryResponse {
 
 func recurringRuleToProto(r *core.RecurringRule) *finchv1.RecurringRule {
 	rule := &finchv1.RecurringRule{
-		Id:                       r.ID,
-		AccountId:                r.AccountID,
-		Name:                     r.Name,
-		Amount:                   r.Amount,
-		Frequency:                finchv1.Frequency(r.Frequency),
-		StartDate:                r.StartDate.Format(time.DateOnly),
-		DayOfMonth:               int32(r.DayOfMonth),
-		IsTransfer:               r.IsTransfer,
-		TransferTargetAccountId:  r.TransferTargetAccountID,
-		Paused:                   r.Paused,
+		Id:                      r.ID,
+		AccountId:               r.AccountID,
+		Name:                    r.Name,
+		Amount:                  r.Amount,
+		Frequency:               finchv1.Frequency(r.Frequency),
+		StartDate:               r.StartDate.Format(time.DateOnly),
+		DayOfMonth:              int32(r.DayOfMonth),
+		IsTransfer:              r.IsTransfer,
+		TransferTargetAccountId: r.TransferTargetAccountID,
+		Paused:                  r.Paused,
 	}
 	if r.EndDate != nil {
 		rule.EndDate = r.EndDate.Format(time.DateOnly)

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -117,6 +117,80 @@ func TestGetAccountHistoryViaGRPC(t *testing.T) {
 	}
 }
 
+func TestListTransactionsViaGRPC(t *testing.T) {
+	client := startTestServer(t)
+	ctx := context.Background()
+
+	acctResp, err := client.CreateAccount(ctx, &finchv1.CreateAccountRequest{
+		Name: "Txn List Test",
+		Type: finchv1.AccountType_ACCOUNT_TYPE_CHECKING,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	accountID := acctResp.Account.Id
+
+	// Record two transactions.
+	_, err = client.RecordTransaction(ctx, &finchv1.RecordTransactionRequest{
+		AccountId: accountID,
+		Date:      "2025-01-10",
+		Amount:    -5000,
+		Name:      "Coffee",
+		Status:    finchv1.TransactionStatus_TRANSACTION_STATUS_RECONCILED,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction 1: %v", err)
+	}
+	_, err = client.RecordTransaction(ctx, &finchv1.RecordTransactionRequest{
+		AccountId: accountID,
+		Date:      "2025-01-15",
+		Amount:    -12000,
+		Name:      "Groceries",
+		Status:    finchv1.TransactionStatus_TRANSACTION_STATUS_SCHEDULED,
+	})
+	if err != nil {
+		t.Fatalf("RecordTransaction 2: %v", err)
+	}
+
+	listResp, err := client.ListTransactions(ctx, &finchv1.ListTransactionsRequest{
+		AccountId: accountID,
+	})
+	if err != nil {
+		t.Fatalf("ListTransactions: %v", err)
+	}
+	if len(listResp.Transactions) != 2 {
+		t.Fatalf("expected 2 transactions, got %d", len(listResp.Transactions))
+	}
+
+	// Verify field mapping on first transaction.
+	found := false
+	for _, txn := range listResp.Transactions {
+		if txn.Name == "Coffee" {
+			found = true
+			if txn.Amount != -5000 {
+				t.Fatalf("expected amount -5000, got %d", txn.Amount)
+			}
+			if txn.AccountId != accountID {
+				t.Fatalf("expected account_id %q, got %q", accountID, txn.AccountId)
+			}
+			if txn.Date != "2025-01-10" {
+				t.Fatalf("expected date 2025-01-10, got %q", txn.Date)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected to find Coffee transaction")
+	}
+
+	// Empty account_id returns error.
+	_, err = client.ListTransactions(ctx, &finchv1.ListTransactionsRequest{
+		AccountId: "",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty account_id")
+	}
+}
+
 func TestProjectBalancesViaGRPC(t *testing.T) {
 	client := startTestServer(t)
 	ctx := context.Background()

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -57,6 +57,11 @@ func registerTools(server *mcp.Server, client finchv1.FinchServiceClient) {
 	}, newRecordTransactionHandler(client))
 
 	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_transactions",
+		Description: "List all recorded transactions for an account.",
+	}, newListTransactionsHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
 		Name:        "update_transaction_status",
 		Description: "Update the status of a transaction (PROJECTED → SCHEDULED → RECONCILED).",
 	}, newUpdateTransactionStatusHandler(client))
@@ -421,6 +426,31 @@ func newRecordTransactionHandler(client finchv1.FinchServiceClient) func(context
 		return nil, RecordTransactionOutput{
 			Transaction: protoTxnToInfo(resp.Transaction),
 		}, nil
+	}
+}
+
+// ListTransactions
+
+type ListTransactionsInput struct {
+	AccountID string `json:"account_id" jsonschema:"UUID of the account"`
+}
+type ListTransactionsOutput struct {
+	Transactions []TransactionInfo `json:"transactions"`
+}
+
+func newListTransactionsHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, ListTransactionsInput) (*mcp.CallToolResult, ListTransactionsOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input ListTransactionsInput) (*mcp.CallToolResult, ListTransactionsOutput, error) {
+		resp, err := client.ListTransactions(ctx, &finchv1.ListTransactionsRequest{
+			AccountId: input.AccountID,
+		})
+		if err != nil {
+			return nil, ListTransactionsOutput{}, fmt.Errorf("list transactions: %w", err)
+		}
+		txns := make([]TransactionInfo, len(resp.Transactions))
+		for i, t := range resp.Transactions {
+			txns[i] = protoTxnToInfo(t)
+		}
+		return nil, ListTransactionsOutput{Transactions: txns}, nil
 	}
 }
 

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -594,6 +594,115 @@ func TestTransactionTools(t *testing.T) {
 		})
 	})
 
+	t.Run("list_transactions", func(t *testing.T) {
+		handler := newListTransactionsHandler(client)
+
+		t.Run("returns_empty_list_when_no_transactions", func(t *testing.T) {
+			freshClient := startTestBackend(t)
+			emptyAcctID := createTestAccount(t, freshClient)
+			emptyHandler := newListTransactionsHandler(freshClient)
+
+			_, out, err := emptyHandler(ctx, nil, ListTransactionsInput{
+				AccountID: emptyAcctID,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(out.Transactions) != 0 {
+				t.Fatalf("expected 0 transactions, got %d", len(out.Transactions))
+			}
+		})
+
+		t.Run("returns_recorded_transactions", func(t *testing.T) {
+			recHandler := newRecordTransactionHandler(client)
+			_, _, err := recHandler(ctx, nil, RecordTransactionInput{
+				AccountID: accountID,
+				Date:      "2025-06-01",
+				Amount:    -7500,
+				Name:      "List Test Txn 1",
+				Status:    "RECONCILED",
+			})
+			if err != nil {
+				t.Fatalf("record txn 1: %v", err)
+			}
+			_, _, err = recHandler(ctx, nil, RecordTransactionInput{
+				AccountID: accountID,
+				Date:      "2025-06-02",
+				Amount:    -3000,
+				Name:      "List Test Txn 2",
+				Status:    "SCHEDULED",
+			})
+			if err != nil {
+				t.Fatalf("record txn 2: %v", err)
+			}
+
+			_, out, err := handler(ctx, nil, ListTransactionsInput{
+				AccountID: accountID,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(out.Transactions) < 2 {
+				t.Fatalf("expected at least 2 transactions, got %d", len(out.Transactions))
+			}
+		})
+
+		t.Run("maps_all_output_fields", func(t *testing.T) {
+			ruleID := createTestRule(t, client, accountID)
+			recHandler := newRecordTransactionHandler(client)
+			_, _, err := recHandler(ctx, nil, RecordTransactionInput{
+				AccountID:       accountID,
+				Date:            "2025-07-01",
+				Amount:          -150000,
+				Name:            "Mapped Txn",
+				Description:     "Full field test",
+				Status:          "RECONCILED",
+				RecurringRuleID: ruleID,
+			})
+			if err != nil {
+				t.Fatalf("record txn: %v", err)
+			}
+
+			_, out, err := handler(ctx, nil, ListTransactionsInput{
+				AccountID: accountID,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			found := false
+			for _, txn := range out.Transactions {
+				if txn.Name == "Mapped Txn" {
+					found = true
+					if txn.AccountID != accountID {
+						t.Fatalf("expected account_id %q, got %q", accountID, txn.AccountID)
+					}
+					if txn.Date != "2025-07-01" {
+						t.Fatalf("expected date 2025-07-01, got %q", txn.Date)
+					}
+					if txn.Amount != -150000 {
+						t.Fatalf("expected amount -150000, got %d", txn.Amount)
+					}
+					if txn.Description != "Full field test" {
+						t.Fatalf("expected description 'Full field test', got %q", txn.Description)
+					}
+					if txn.RecurringRuleID != ruleID {
+						t.Fatalf("expected recurring_rule_id %q, got %q", ruleID, txn.RecurringRuleID)
+					}
+					if txn.Status != "TRANSACTION_STATUS_RECONCILED" {
+						t.Fatalf("expected status TRANSACTION_STATUS_RECONCILED, got %q", txn.Status)
+					}
+					if txn.ID == "" {
+						t.Fatal("expected non-empty transaction ID")
+					}
+				}
+			}
+			if !found {
+				t.Fatal("expected to find 'Mapped Txn' in list")
+			}
+		})
+	})
+
 	t.Run("update_transaction_status", func(t *testing.T) {
 		handler := newUpdateTransactionStatusHandler(client)
 

--- a/proto/finch/v1/finch.proto
+++ b/proto/finch/v1/finch.proto
@@ -14,6 +14,7 @@ service FinchService {
   rpc UpdateRecurringRuleAmount(UpdateRecurringRuleAmountRequest) returns (UpdateRecurringRuleAmountResponse);
   rpc GetRecurringRuleHistory(GetRecurringRuleHistoryRequest) returns (GetRecurringRuleHistoryResponse);
   rpc RecordTransaction(RecordTransactionRequest) returns (RecordTransactionResponse);
+  rpc ListTransactions(ListTransactionsRequest) returns (ListTransactionsResponse);
   rpc UpdateTransactionStatus(UpdateTransactionStatusRequest) returns (UpdateTransactionStatusResponse);
   rpc CreateTransfer(CreateTransferRequest) returns (CreateTransferResponse);
   rpc ProjectBalances(ProjectBalancesRequest) returns (ProjectBalancesResponse);
@@ -178,6 +179,14 @@ message RecordTransactionRequest {
 
 message RecordTransactionResponse {
   Transaction transaction = 1;
+}
+
+message ListTransactionsRequest {
+  string account_id = 1;
+}
+
+message ListTransactionsResponse {
+  repeated Transaction transactions = 1;
 }
 
 message UpdateTransactionStatusRequest {


### PR DESCRIPTION
## Overview

The purpose of this change is to wire `core.ListTransactions` through the full API stack (proto RPC, daemon handler, MCP tool) so that transactions are directly queryable per account. This is an incremental improvement — a mechanical wiring task that exposes existing domain logic through the established API layers. It unblocks #33 (viewing individual transactions) and enables reconciliation against bank statements, which currently requires going through `ProjectBalances` indirectly.

## Changes

- **Proto:** Add `ListTransactions` RPC with `ListTransactionsRequest`/`ListTransactionsResponse` messages, reusing the existing `Transaction` message
- **Daemon:** Add `ListTransactions` handler with `account_id` validation, delegating to `core.ListTransactions` and mapping via existing `transactionToProto()` helper
- **Daemon tests:** Integration test covering happy path (create account, record 2 transactions, list and verify count + field mapping) and validation (empty `account_id` returns error)
- **MCP:** Add `list_transactions` tool with `ListTransactionsInput`/`ListTransactionsOutput` structs and handler factory, mapping via existing `protoTxnToInfo()`
- **MCP tests:** BDD-style tests covering empty list, returns recorded transactions, and maps all output fields

## Test plan

- [x] `just proto` — regenerates without errors
- [x] `just lint` — 0 issues across all modules
- [x] `just test` — all tests pass (core, daemon, mcp)
- [ ] Manual: use `list_transactions` MCP tool against running daemon with seed data

🤖 Generated with [Claude Code](https://claude.com/claude-code)