### PR TITLE
Expose recurring rule pause, resume, and end lifecycle RPCs

### DIFF
--- a/core/recurring.go
+++ b/core/recurring.go
@@ -303,6 +303,45 @@ func (db *DB) setRecurringRulePaused(ctx context.Context, ruleID string, paused 
 	return tx.Commit()
 }
 
+// EndRecurringRule sets or updates the end date for a recurring rule.
+func (db *DB) EndRecurringRule(ctx context.Context, ruleID string, endDate time.Time) error {
+	if ruleID == "" {
+		return errors.New("rule_id must not be empty")
+	}
+	if endDate.IsZero() {
+		return errors.New("end_date must not be zero")
+	}
+
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+
+	payload, err := json.Marshal(RecurringRuleEndedPayload{
+		EndDate: endDate.Format(time.DateOnly),
+	})
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	if _, err := appendEvents(ctx, tx, aggregateTypeRecurringRule, ruleID, []NewEvent{
+		{EventType: EventRecurringRuleEnded, Payload: payload},
+	}); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("append event: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		"UPDATE recurring_rules SET end_date = ? WHERE id = ?",
+		endDate.Format(time.DateOnly), ruleID); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("update read model: %w", err)
+	}
+
+	return tx.Commit()
+}
+
 // GetRecurringRuleHistory returns the event history for a specific recurring rule.
 func (db *DB) GetRecurringRuleHistory(ctx context.Context, ruleID string) ([]Event, error) {
 	return db.LoadEvents(ctx, aggregateTypeRecurringRule, ruleID)

--- a/core/recurring.go
+++ b/core/recurring.go
@@ -286,6 +286,16 @@ func (db *DB) setRecurringRulePaused(ctx context.Context, ruleID string, paused 
 		return fmt.Errorf("begin tx: %w", err)
 	}
 
+	var exists int
+	if err := tx.QueryRowContext(ctx,
+		"SELECT 1 FROM recurring_rules WHERE id = ?", ruleID).Scan(&exists); err != nil {
+		_ = tx.Rollback()
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("recurring rule %s not found", ruleID)
+		}
+		return fmt.Errorf("check rule exists: %w", err)
+	}
+
 	payload, _ := json.Marshal(struct{}{})
 	if _, err := appendEvents(ctx, tx, aggregateTypeRecurringRule, ruleID, []NewEvent{
 		{EventType: eventType, Payload: payload},
@@ -315,6 +325,16 @@ func (db *DB) EndRecurringRule(ctx context.Context, ruleID string, endDate time.
 	tx, err := db.conn.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
+	}
+
+	var exists int
+	if err := tx.QueryRowContext(ctx,
+		"SELECT 1 FROM recurring_rules WHERE id = ?", ruleID).Scan(&exists); err != nil {
+		_ = tx.Rollback()
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("recurring rule %s not found", ruleID)
+		}
+		return fmt.Errorf("check rule exists: %w", err)
 	}
 
 	payload, err := json.Marshal(RecurringRuleEndedPayload{

--- a/core/recurring_test.go
+++ b/core/recurring_test.go
@@ -160,6 +160,102 @@ func TestPauseAndResumeRecurringRule(t *testing.T) {
 	}
 }
 
+func TestEndRecurringRule(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	acct := createTestAccount(t, db)
+
+	t.Run("sets end date on rule without one", func(t *testing.T) {
+		rule, err := db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+			AccountID:  acct.ID,
+			Name:       "Gym Membership",
+			Amount:     -5000,
+			Frequency:  core.FrequencyMonthly,
+			StartDate:  date(2025, 1, 1),
+			DayOfMonth: 15,
+		})
+		if err != nil {
+			t.Fatalf("CreateRecurringRule: %v", err)
+		}
+
+		endDate := date(2025, 6, 30)
+		if err := db.EndRecurringRule(ctx, rule.ID, endDate); err != nil {
+			t.Fatalf("EndRecurringRule: %v", err)
+		}
+
+		rules, err := db.ListRecurringRules(ctx, acct.ID)
+		if err != nil {
+			t.Fatalf("ListRecurringRules: %v", err)
+		}
+		var found bool
+		for _, r := range rules {
+			if r.ID == rule.ID {
+				found = true
+				if r.EndDate == nil {
+					t.Fatal("expected non-nil end date")
+				}
+				if !r.EndDate.Equal(endDate) {
+					t.Fatalf("expected end date %s, got %s", endDate, *r.EndDate)
+				}
+			}
+		}
+		if !found {
+			t.Fatal("rule not found in list")
+		}
+	})
+
+	t.Run("produces RecurringRuleEnded event", func(t *testing.T) {
+		rule, err := db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+			AccountID:  acct.ID,
+			Name:       "Streaming Service",
+			Amount:     -1499,
+			Frequency:  core.FrequencyMonthly,
+			StartDate:  date(2025, 1, 1),
+			DayOfMonth: 1,
+		})
+		if err != nil {
+			t.Fatalf("CreateRecurringRule: %v", err)
+		}
+
+		if err := db.EndRecurringRule(ctx, rule.ID, date(2025, 12, 31)); err != nil {
+			t.Fatalf("EndRecurringRule: %v", err)
+		}
+
+		events, err := db.GetRecurringRuleHistory(ctx, rule.ID)
+		if err != nil {
+			t.Fatalf("GetRecurringRuleHistory: %v", err)
+		}
+		if len(events) != 2 {
+			t.Fatalf("expected 2 events, got %d", len(events))
+		}
+		if events[1].EventType != "RecurringRuleEnded" {
+			t.Fatalf("expected RecurringRuleEnded, got %s", events[1].EventType)
+		}
+	})
+
+	t.Run("rejects empty rule ID", func(t *testing.T) {
+		if err := db.EndRecurringRule(ctx, "", date(2025, 6, 30)); err == nil {
+			t.Fatal("expected error for empty rule ID")
+		}
+	})
+
+	t.Run("rejects zero end date", func(t *testing.T) {
+		rule, err := db.CreateRecurringRule(ctx, core.CreateRecurringRuleParams{
+			AccountID:  acct.ID,
+			Name:       "Zero Date Test",
+			Amount:     -100,
+			Frequency:  core.FrequencyWeekly,
+			StartDate:  date(2025, 1, 1),
+		})
+		if err != nil {
+			t.Fatalf("CreateRecurringRule: %v", err)
+		}
+		if err := db.EndRecurringRule(ctx, rule.ID, time.Time{}); err == nil {
+			t.Fatal("expected error for zero end date")
+		}
+	})
+}
+
 func TestListRecurringRulesAllAccounts(t *testing.T) {
 	db := openTestDB(t)
 	ctx := context.Background()

--- a/core/recurring_test.go
+++ b/core/recurring_test.go
@@ -2,6 +2,7 @@ package core_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -236,6 +237,16 @@ func TestEndRecurringRule(t *testing.T) {
 	t.Run("rejects empty rule ID", func(t *testing.T) {
 		if err := db.EndRecurringRule(ctx, "", date(2025, 6, 30)); err == nil {
 			t.Fatal("expected error for empty rule ID")
+		}
+	})
+
+	t.Run("rejects nonexistent rule ID", func(t *testing.T) {
+		err := db.EndRecurringRule(ctx, "nonexistent-id", date(2025, 6, 30))
+		if err == nil {
+			t.Fatal("expected error for nonexistent rule ID")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Fatalf("expected 'not found' in error, got: %s", err.Error())
 		}
 	})
 

--- a/daemon/finchd/server.go
+++ b/daemon/finchd/server.go
@@ -156,7 +156,7 @@ func (s *Server) PauseRecurringRule(ctx context.Context, req *finchv1.PauseRecur
 		return nil, status.Error(codes.InvalidArgument, "rule_id must not be empty")
 	}
 	if err := s.db.PauseRecurringRule(ctx, req.RuleId); err != nil {
-		return nil, status.Errorf(codes.Internal, "pause recurring rule: %v", err)
+		return nil, ruleError("pause recurring rule", err)
 	}
 	return &finchv1.PauseRecurringRuleResponse{}, nil
 }
@@ -166,7 +166,7 @@ func (s *Server) ResumeRecurringRule(ctx context.Context, req *finchv1.ResumeRec
 		return nil, status.Error(codes.InvalidArgument, "rule_id must not be empty")
 	}
 	if err := s.db.ResumeRecurringRule(ctx, req.RuleId); err != nil {
-		return nil, status.Errorf(codes.Internal, "resume recurring rule: %v", err)
+		return nil, ruleError("resume recurring rule", err)
 	}
 	return &finchv1.ResumeRecurringRuleResponse{}, nil
 }
@@ -180,7 +180,7 @@ func (s *Server) EndRecurringRule(ctx context.Context, req *finchv1.EndRecurring
 		return nil, status.Errorf(codes.InvalidArgument, "invalid end_date: %v", err)
 	}
 	if err := s.db.EndRecurringRule(ctx, req.RuleId, endDate); err != nil {
-		return nil, status.Errorf(codes.Internal, "end recurring rule: %v", err)
+		return nil, ruleError("end recurring rule", err)
 	}
 	return &finchv1.EndRecurringRuleResponse{}, nil
 }
@@ -405,6 +405,14 @@ func (s *Server) GetBalanceTimeSeries(ctx context.Context, req *finchv1.GetBalan
 		resp.Points = append(resp.Points, tp)
 	}
 	return resp, nil
+}
+
+// ruleError maps core recurring rule errors to gRPC status codes.
+func ruleError(op string, err error) error {
+	if strings.Contains(err.Error(), "not found") {
+		return status.Errorf(codes.NotFound, "%s: %v", op, err)
+	}
+	return status.Errorf(codes.Internal, "%s: %v", op, err)
 }
 
 // Mapping helpers

--- a/daemon/finchd/server.go
+++ b/daemon/finchd/server.go
@@ -151,6 +151,40 @@ func (s *Server) UpdateRecurringRuleAmount(ctx context.Context, req *finchv1.Upd
 	return &finchv1.UpdateRecurringRuleAmountResponse{}, nil
 }
 
+func (s *Server) PauseRecurringRule(ctx context.Context, req *finchv1.PauseRecurringRuleRequest) (*finchv1.PauseRecurringRuleResponse, error) {
+	if req.RuleId == "" {
+		return nil, status.Error(codes.InvalidArgument, "rule_id must not be empty")
+	}
+	if err := s.db.PauseRecurringRule(ctx, req.RuleId); err != nil {
+		return nil, status.Errorf(codes.Internal, "pause recurring rule: %v", err)
+	}
+	return &finchv1.PauseRecurringRuleResponse{}, nil
+}
+
+func (s *Server) ResumeRecurringRule(ctx context.Context, req *finchv1.ResumeRecurringRuleRequest) (*finchv1.ResumeRecurringRuleResponse, error) {
+	if req.RuleId == "" {
+		return nil, status.Error(codes.InvalidArgument, "rule_id must not be empty")
+	}
+	if err := s.db.ResumeRecurringRule(ctx, req.RuleId); err != nil {
+		return nil, status.Errorf(codes.Internal, "resume recurring rule: %v", err)
+	}
+	return &finchv1.ResumeRecurringRuleResponse{}, nil
+}
+
+func (s *Server) EndRecurringRule(ctx context.Context, req *finchv1.EndRecurringRuleRequest) (*finchv1.EndRecurringRuleResponse, error) {
+	if req.RuleId == "" {
+		return nil, status.Error(codes.InvalidArgument, "rule_id must not be empty")
+	}
+	endDate, err := time.Parse(time.DateOnly, req.EndDate)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid end_date: %v", err)
+	}
+	if err := s.db.EndRecurringRule(ctx, req.RuleId, endDate); err != nil {
+		return nil, status.Errorf(codes.Internal, "end recurring rule: %v", err)
+	}
+	return &finchv1.EndRecurringRuleResponse{}, nil
+}
+
 func (s *Server) GetRecurringRuleHistory(ctx context.Context, req *finchv1.GetRecurringRuleHistoryRequest) (*finchv1.GetRecurringRuleHistoryResponse, error) {
 	if req.RuleId == "" {
 		return nil, status.Error(codes.InvalidArgument, "rule_id must not be empty")

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -52,6 +52,21 @@ func registerTools(server *mcp.Server, client finchv1.FinchServiceClient) {
 	}, newGetRecurringRuleHistoryHandler(client))
 
 	mcp.AddTool(server, &mcp.Tool{
+		Name:        "pause_recurring_rule",
+		Description: "Pause a recurring rule so it stops generating projected transactions.",
+	}, newPauseRecurringRuleHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "resume_recurring_rule",
+		Description: "Resume a paused recurring rule so it generates projected transactions again.",
+	}, newResumeRecurringRuleHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "end_recurring_rule",
+		Description: "Set or update the end date for a recurring rule. No transactions will be projected after this date.",
+	}, newEndRecurringRuleHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
 		Name:        "record_transaction",
 		Description: "Record a financial transaction. Amount is in cents (negative for withdrawals). Status: PROJECTED, SCHEDULED, or RECONCILED.",
 	}, newRecordTransactionHandler(client))
@@ -361,6 +376,65 @@ func newGetRecurringRuleHistoryHandler(client finchv1.FinchServiceClient) func(c
 			return nil, GetRecurringRuleHistoryOutput{}, fmt.Errorf("get recurring rule history: %w", err)
 		}
 		return nil, GetRecurringRuleHistoryOutput{Events: protoEventsToInfo(resp.Events)}, nil
+	}
+}
+
+// PauseRecurringRule
+
+type PauseRecurringRuleInput struct {
+	RuleID string `json:"rule_id" jsonschema:"UUID of the recurring rule to pause"`
+}
+type PauseRecurringRuleOutput struct{}
+
+func newPauseRecurringRuleHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, PauseRecurringRuleInput) (*mcp.CallToolResult, PauseRecurringRuleOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input PauseRecurringRuleInput) (*mcp.CallToolResult, PauseRecurringRuleOutput, error) {
+		_, err := client.PauseRecurringRule(ctx, &finchv1.PauseRecurringRuleRequest{
+			RuleId: input.RuleID,
+		})
+		if err != nil {
+			return nil, PauseRecurringRuleOutput{}, fmt.Errorf("pause recurring rule: %w", err)
+		}
+		return nil, PauseRecurringRuleOutput{}, nil
+	}
+}
+
+// ResumeRecurringRule
+
+type ResumeRecurringRuleInput struct {
+	RuleID string `json:"rule_id" jsonschema:"UUID of the recurring rule to resume"`
+}
+type ResumeRecurringRuleOutput struct{}
+
+func newResumeRecurringRuleHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, ResumeRecurringRuleInput) (*mcp.CallToolResult, ResumeRecurringRuleOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input ResumeRecurringRuleInput) (*mcp.CallToolResult, ResumeRecurringRuleOutput, error) {
+		_, err := client.ResumeRecurringRule(ctx, &finchv1.ResumeRecurringRuleRequest{
+			RuleId: input.RuleID,
+		})
+		if err != nil {
+			return nil, ResumeRecurringRuleOutput{}, fmt.Errorf("resume recurring rule: %w", err)
+		}
+		return nil, ResumeRecurringRuleOutput{}, nil
+	}
+}
+
+// EndRecurringRule
+
+type EndRecurringRuleInput struct {
+	RuleID  string `json:"rule_id" jsonschema:"UUID of the recurring rule to end"`
+	EndDate string `json:"end_date" jsonschema:"end date (YYYY-MM-DD), no transactions projected after this date"`
+}
+type EndRecurringRuleOutput struct{}
+
+func newEndRecurringRuleHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, EndRecurringRuleInput) (*mcp.CallToolResult, EndRecurringRuleOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input EndRecurringRuleInput) (*mcp.CallToolResult, EndRecurringRuleOutput, error) {
+		_, err := client.EndRecurringRule(ctx, &finchv1.EndRecurringRuleRequest{
+			RuleId:  input.RuleID,
+			EndDate: input.EndDate,
+		})
+		if err != nil {
+			return nil, EndRecurringRuleOutput{}, fmt.Errorf("end recurring rule: %w", err)
+		}
+		return nil, EndRecurringRuleOutput{}, nil
 	}
 }
 

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -443,6 +443,158 @@ func TestRecurringRuleTools(t *testing.T) {
 		})
 	})
 
+	t.Run("pause_recurring_rule", func(t *testing.T) {
+		pauseHandler := newPauseRecurringRuleHandler(client)
+		listHandler := newListRecurringRulesHandler(client)
+
+		t.Run("pauses_an_active_rule", func(t *testing.T) {
+			ruleID := createTestRule(t, client, accountID)
+
+			_, _, err := pauseHandler(ctx, nil, PauseRecurringRuleInput{RuleID: ruleID})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			_, out, err := listHandler(ctx, nil, ListRecurringRulesInput{AccountID: accountID})
+			if err != nil {
+				t.Fatalf("list rules: %v", err)
+			}
+			for _, r := range out.Rules {
+				if r.ID == ruleID {
+					if !r.Paused {
+						t.Fatal("expected rule to be paused")
+					}
+					return
+				}
+			}
+			t.Fatal("rule not found in list")
+		})
+	})
+
+	t.Run("resume_recurring_rule", func(t *testing.T) {
+		pauseHandler := newPauseRecurringRuleHandler(client)
+		resumeHandler := newResumeRecurringRuleHandler(client)
+		listHandler := newListRecurringRulesHandler(client)
+
+		t.Run("resumes_a_paused_rule", func(t *testing.T) {
+			ruleID := createTestRule(t, client, accountID)
+
+			_, _, err := pauseHandler(ctx, nil, PauseRecurringRuleInput{RuleID: ruleID})
+			if err != nil {
+				t.Fatalf("pause: %v", err)
+			}
+
+			_, _, err = resumeHandler(ctx, nil, ResumeRecurringRuleInput{RuleID: ruleID})
+			if err != nil {
+				t.Fatalf("resume: %v", err)
+			}
+
+			_, out, err := listHandler(ctx, nil, ListRecurringRulesInput{AccountID: accountID})
+			if err != nil {
+				t.Fatalf("list rules: %v", err)
+			}
+			for _, r := range out.Rules {
+				if r.ID == ruleID {
+					if r.Paused {
+						t.Fatal("expected rule to be resumed")
+					}
+					return
+				}
+			}
+			t.Fatal("rule not found in list")
+		})
+	})
+
+	t.Run("end_recurring_rule", func(t *testing.T) {
+		endHandler := newEndRecurringRuleHandler(client)
+		listHandler := newListRecurringRulesHandler(client)
+
+		t.Run("sets_end_date_on_rule", func(t *testing.T) {
+			ruleID := createTestRule(t, client, accountID)
+
+			_, _, err := endHandler(ctx, nil, EndRecurringRuleInput{
+				RuleID:  ruleID,
+				EndDate: "2025-06-30",
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			_, out, err := listHandler(ctx, nil, ListRecurringRulesInput{AccountID: accountID})
+			if err != nil {
+				t.Fatalf("list rules: %v", err)
+			}
+			for _, r := range out.Rules {
+				if r.ID == ruleID {
+					if r.EndDate != "2025-06-30" {
+						t.Fatalf("expected end_date 2025-06-30, got %q", r.EndDate)
+					}
+					return
+				}
+			}
+			t.Fatal("rule not found in list")
+		})
+
+		t.Run("ended_rule_stops_projections_after_end_date", func(t *testing.T) {
+			freshClient := startTestBackend(t)
+			freshAcctID := createTestAccount(t, freshClient)
+
+			// Seed opening balance.
+			recHandler := newRecordTransactionHandler(freshClient)
+			_, _, err := recHandler(ctx, nil, RecordTransactionInput{
+				AccountID: freshAcctID,
+				Date:      "2025-01-01",
+				Amount:    500000,
+				Name:      "Opening Balance",
+				Status:    "RECONCILED",
+			})
+			if err != nil {
+				t.Fatalf("seed opening balance: %v", err)
+			}
+
+			// Create rule starting Jan 1, then end it on Mar 31.
+			ruleResp, err := freshClient.CreateRecurringRule(ctx, &finchv1.CreateRecurringRuleRequest{
+				AccountId:  freshAcctID,
+				Name:       "Ending Rule",
+				Amount:     -100000,
+				Frequency:  finchv1.Frequency_FREQUENCY_MONTHLY,
+				StartDate:  "2025-01-01",
+				DayOfMonth: 1,
+			})
+			if err != nil {
+				t.Fatalf("create rule: %v", err)
+			}
+
+			freshEndHandler := newEndRecurringRuleHandler(freshClient)
+			_, _, err = freshEndHandler(ctx, nil, EndRecurringRuleInput{
+				RuleID:  ruleResp.Rule.Id,
+				EndDate: "2025-03-31",
+			})
+			if err != nil {
+				t.Fatalf("end rule: %v", err)
+			}
+
+			// Project through June — should see no transactions after March.
+			projHandler := newProjectBalancesHandler(freshClient)
+			_, projOut, err := projHandler(ctx, nil, ProjectBalancesInput{
+				FromDate:   "2025-01-01",
+				ToDate:     "2025-06-30",
+				AccountIDs: []string{freshAcctID},
+			})
+			if err != nil {
+				t.Fatalf("project balances: %v", err)
+			}
+
+			for _, b := range projOut.Balances {
+				for _, txn := range b.Transactions {
+					if txn.RecurringRuleID == ruleResp.Rule.Id && txn.Date > "2025-03-31" {
+						t.Fatalf("found projected transaction after end date: %s on %s", txn.Name, txn.Date)
+					}
+				}
+			}
+		})
+	})
+
 	t.Run("get_recurring_rule_history", func(t *testing.T) {
 		handler := newGetRecurringRuleHistoryHandler(client)
 		ruleID := createTestRule(t, client, accountID)

--- a/proto/finch/v1/finch.proto
+++ b/proto/finch/v1/finch.proto
@@ -13,6 +13,9 @@ service FinchService {
   rpc ListRecurringRules(ListRecurringRulesRequest) returns (ListRecurringRulesResponse);
   rpc UpdateRecurringRuleAmount(UpdateRecurringRuleAmountRequest) returns (UpdateRecurringRuleAmountResponse);
   rpc GetRecurringRuleHistory(GetRecurringRuleHistoryRequest) returns (GetRecurringRuleHistoryResponse);
+  rpc PauseRecurringRule(PauseRecurringRuleRequest) returns (PauseRecurringRuleResponse);
+  rpc ResumeRecurringRule(ResumeRecurringRuleRequest) returns (ResumeRecurringRuleResponse);
+  rpc EndRecurringRule(EndRecurringRuleRequest) returns (EndRecurringRuleResponse);
   rpc RecordTransaction(RecordTransactionRequest) returns (RecordTransactionResponse);
   rpc ListTransactions(ListTransactionsRequest) returns (ListTransactionsResponse);
   rpc UpdateTransactionStatus(UpdateTransactionStatusRequest) returns (UpdateTransactionStatusResponse);
@@ -153,6 +156,25 @@ message GetRecurringRuleHistoryRequest {
 message GetRecurringRuleHistoryResponse {
   repeated AccountEvent events = 1;
 }
+
+message PauseRecurringRuleRequest {
+  string rule_id = 1;
+}
+
+message PauseRecurringRuleResponse {}
+
+message ResumeRecurringRuleRequest {
+  string rule_id = 1;
+}
+
+message ResumeRecurringRuleResponse {}
+
+message EndRecurringRuleRequest {
+  string rule_id = 1;
+  string end_date = 2;
+}
+
+message EndRecurringRuleResponse {}
 
 // Transactions
 


### PR DESCRIPTION
## Overview

The purpose of this change is to complete the recurring rule lifecycle API so users can pause, resume, and end rules through MCP (and eventually the Qt app). It represents an incremental improvement -- several core domain capabilities already existed (pause/resume in core, ended event type defined) but were inaccessible outside the core package. This PR threads them through proto RPCs, daemon handlers, and MCP tools to close that gap.

## Changes

- **Core:** Add `EndRecurringRule` method following the event-sourced pattern (validate, begin tx, append `RecurringRuleEnded` event, update read model, commit)
- **Proto:** Add `PauseRecurringRule`, `ResumeRecurringRule`, and `EndRecurringRule` RPCs with request/response messages
- **Daemon:** Add 3 handler methods with input validation and gRPC error mapping
- **MCP:** Add 3 tools (`pause_recurring_rule`, `resume_recurring_rule`, `end_recurring_rule`) with Input/Output structs and handler factories
- **Tests:** Core unit tests for `EndRecurringRule` (happy path, event production, validation). MCP BDD-style tests for all 3 tools including a projection integration test verifying ended rules stop generating transactions after the end date.

Closes #28, closes #29

## Test plan

- [x] `just test` — all Go tests pass (core, daemon, mcp)
- [x] `just lint` — all linters clean
- [x] `just all` — full build succeeds (proto, daemon, mcp)
- [ ] Manual: start daemon, use MCP tools to pause/resume/end a rule, verify projections reflect the change


🤖 Generated with [Claude Code](https://claude.com/claude-code)