### PR TITLE
Expose RenameAccount and UpdateAccountType RPCs with DX improvements

### DIFF
--- a/.claude/skills/mcp-reload/SKILL.md
+++ b/.claude/skills/mcp-reload/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: mcp-reload
+description: Rebuild, install, and guide session resume for the Finch MCP server after code changes
+---
+
+# Reload Finch MCP Server
+
+## Background
+
+The Finch MCP server is a user-scoped stdio server (`finch-mcp` binary on PATH, installed to `~/.local/bin/`). Claude Code spawns a fresh process at session start — there is no in-session reload mechanism. After installing an updated binary, the user must exit and resume the session with `claude --continue` to pick up changes while preserving conversation context.
+
+## Workflow
+
+1. **Determine scope of changes** — check which files have been modified:
+
+   - **MCP-only** — only `mcp/` files changed
+   - **Full stack** — any of `proto/`, `core/`, or `daemon/` files also changed
+
+2. **Build and install:**
+
+   MCP-only changes:
+   ```bash
+   just build-mcp && just install-mcp
+   ```
+
+   Full stack changes (proto, core, or daemon involved):
+   ```bash
+   just all && just install && systemctl --user restart finch.service
+   ```
+
+3. **Instruct the user** to exit the session and resume:
+
+   > To pick up the updated MCP server, please exit this session and resume with `claude --continue`.
+
+4. **After the user resumes**, verify connectivity by calling the `mcp__finch__ping` tool. If ping fails, check daemon status with `systemctl --user status finch.service`.

--- a/.claude/skills/mcp-reload/SKILL.md
+++ b/.claude/skills/mcp-reload/SKILL.md
@@ -16,7 +16,7 @@ The Finch MCP server is a user-scoped stdio server (`finch-mcp` binary on PATH, 
    - **MCP-only** — only `mcp/` files changed
    - **Full stack** — any of `proto/`, `core/`, or `daemon/` files also changed
 
-2. **Build and install:**
+2. **Build, install, and restart** — the install targets use atomic replacement (`cp` + `mv`), so they succeed even while binaries are running:
 
    MCP-only changes:
    ```bash

--- a/core/account.go
+++ b/core/account.go
@@ -129,6 +129,119 @@ func (db *DB) ListAccounts(ctx context.Context) ([]Account, error) {
 	return scanAccounts(rows)
 }
 
+// RenameAccount changes the name of an existing account.
+func (db *DB) RenameAccount(ctx context.Context, accountID, newName string) error {
+	if accountID == "" {
+		return errors.New("account_id must not be empty")
+	}
+	newName = strings.TrimSpace(newName)
+	if newName == "" {
+		return errors.New("account name must not be empty")
+	}
+
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+
+	var oldName string
+	var acctType int
+	if err := tx.QueryRowContext(ctx,
+		"SELECT name, type FROM accounts WHERE id = ?", accountID).Scan(&oldName, &acctType); err != nil {
+		_ = tx.Rollback()
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("account %s not found", accountID)
+		}
+		return fmt.Errorf("check account exists: %w", err)
+	}
+
+	if oldName == newName {
+		_ = tx.Rollback()
+		return errors.New("new name is the same as the current name")
+	}
+
+	payload, err := json.Marshal(AccountRenamedPayload{
+		OldName: oldName,
+		NewName: newName,
+	})
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	if _, err := appendEvents(ctx, tx, aggregateTypeAccount, accountID, []NewEvent{
+		{EventType: EventAccountRenamed, Payload: payload},
+	}); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("append event: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		"UPDATE accounts SET name = ?, updated_at = ? WHERE id = ?",
+		newName, time.Now().UTC().Unix(), accountID); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("update read model: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// UpdateAccountType changes the type of an existing account.
+func (db *DB) UpdateAccountType(ctx context.Context, accountID string, newType AccountType) error {
+	if accountID == "" {
+		return errors.New("account_id must not be empty")
+	}
+	if !ValidAccountType(newType) {
+		return fmt.Errorf("invalid account type: %d", newType)
+	}
+
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+
+	var name string
+	var oldType int
+	if err := tx.QueryRowContext(ctx,
+		"SELECT name, type FROM accounts WHERE id = ?", accountID).Scan(&name, &oldType); err != nil {
+		_ = tx.Rollback()
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("account %s not found", accountID)
+		}
+		return fmt.Errorf("check account exists: %w", err)
+	}
+
+	if AccountType(oldType) == newType {
+		_ = tx.Rollback()
+		return errors.New("new type is the same as the current type")
+	}
+
+	payload, err := json.Marshal(AccountTypeChangedPayload{
+		OldType: oldType,
+		NewType: int(newType),
+	})
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	if _, err := appendEvents(ctx, tx, aggregateTypeAccount, accountID, []NewEvent{
+		{EventType: EventAccountTypeChanged, Payload: payload},
+	}); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("append event: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		"UPDATE accounts SET type = ?, updated_at = ? WHERE id = ?",
+		int(newType), time.Now().UTC().Unix(), accountID); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("update read model: %w", err)
+	}
+
+	return tx.Commit()
+}
+
 // GetAccountHistory returns the event history for a specific account.
 func (db *DB) GetAccountHistory(ctx context.Context, accountID string) ([]Event, error) {
 	return db.LoadEvents(ctx, aggregateTypeAccount, accountID)

--- a/core/account.go
+++ b/core/account.go
@@ -60,6 +60,10 @@ type AccountTypeChangedPayload struct {
 	NewType int `json:"new_type"`
 }
 
+// ErrNoChange indicates that an update was requested but the new value
+// matches the current value.
+var ErrNoChange = errors.New("no change")
+
 func ValidAccountType(t AccountType) bool {
 	return t >= AccountTypeChecking && t <= AccountTypeBrokerage
 }
@@ -157,7 +161,7 @@ func (db *DB) RenameAccount(ctx context.Context, accountID, newName string) erro
 
 	if oldName == newName {
 		_ = tx.Rollback()
-		return errors.New("new name is the same as the current name")
+		return fmt.Errorf("new name is the same as the current name: %w", ErrNoChange)
 	}
 
 	payload, err := json.Marshal(AccountRenamedPayload{
@@ -213,7 +217,7 @@ func (db *DB) UpdateAccountType(ctx context.Context, accountID string, newType A
 
 	if AccountType(oldType) == newType {
 		_ = tx.Rollback()
-		return errors.New("new type is the same as the current type")
+		return fmt.Errorf("new type is the same as the current type: %w", ErrNoChange)
 	}
 
 	payload, err := json.Marshal(AccountTypeChangedPayload{

--- a/core/account.go
+++ b/core/account.go
@@ -149,9 +149,8 @@ func (db *DB) RenameAccount(ctx context.Context, accountID, newName string) erro
 	}
 
 	var oldName string
-	var acctType int
 	if err := tx.QueryRowContext(ctx,
-		"SELECT name, type FROM accounts WHERE id = ?", accountID).Scan(&oldName, &acctType); err != nil {
+		"SELECT name FROM accounts WHERE id = ?", accountID).Scan(&oldName); err != nil {
 		_ = tx.Rollback()
 		if errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("account %s not found", accountID)
@@ -204,10 +203,9 @@ func (db *DB) UpdateAccountType(ctx context.Context, accountID string, newType A
 		return fmt.Errorf("begin tx: %w", err)
 	}
 
-	var name string
 	var oldType int
 	if err := tx.QueryRowContext(ctx,
-		"SELECT name, type FROM accounts WHERE id = ?", accountID).Scan(&name, &oldType); err != nil {
+		"SELECT type FROM accounts WHERE id = ?", accountID).Scan(&oldType); err != nil {
 		_ = tx.Rollback()
 		if errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("account %s not found", accountID)

--- a/core/account_test.go
+++ b/core/account_test.go
@@ -99,6 +99,146 @@ func TestCreateAccountStoresEvent(t *testing.T) {
 	}
 }
 
+func TestRenameAccount(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	acct, err := db.CreateAccount(ctx, "Old Name", core.AccountTypeChecking)
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	if err := db.RenameAccount(ctx, acct.ID, "New Name"); err != nil {
+		t.Fatalf("RenameAccount: %v", err)
+	}
+
+	accounts, err := db.ListAccounts(ctx)
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(accounts))
+	}
+	if accounts[0].Name != "New Name" {
+		t.Fatalf("expected name 'New Name', got %q", accounts[0].Name)
+	}
+
+	events, err := db.GetAccountHistory(ctx, acct.ID)
+	if err != nil {
+		t.Fatalf("GetAccountHistory: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[1].EventType != "AccountRenamed" {
+		t.Fatalf("expected AccountRenamed, got %s", events[1].EventType)
+	}
+
+	var payload core.AccountRenamedPayload
+	if err := json.Unmarshal(events[1].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.OldName != "Old Name" || payload.NewName != "New Name" {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+}
+
+func TestRenameAccountValidation(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	acct, err := db.CreateAccount(ctx, "Test", core.AccountTypeChecking)
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	if err := db.RenameAccount(ctx, "", "New"); err == nil {
+		t.Fatal("expected error for empty ID")
+	}
+	if err := db.RenameAccount(ctx, acct.ID, ""); err == nil {
+		t.Fatal("expected error for empty name")
+	}
+	if err := db.RenameAccount(ctx, acct.ID, "   "); err == nil {
+		t.Fatal("expected error for whitespace-only name")
+	}
+	if err := db.RenameAccount(ctx, "nonexistent-id", "New"); err == nil {
+		t.Fatal("expected error for nonexistent account")
+	}
+	if err := db.RenameAccount(ctx, acct.ID, "Test"); err == nil {
+		t.Fatal("expected error for same name")
+	}
+}
+
+func TestUpdateAccountType(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	acct, err := db.CreateAccount(ctx, "Test", core.AccountTypeChecking)
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	if err := db.UpdateAccountType(ctx, acct.ID, core.AccountTypeSavings); err != nil {
+		t.Fatalf("UpdateAccountType: %v", err)
+	}
+
+	accounts, err := db.ListAccounts(ctx)
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(accounts))
+	}
+	if accounts[0].Type != core.AccountTypeSavings {
+		t.Fatalf("expected type Savings, got %d", accounts[0].Type)
+	}
+
+	events, err := db.GetAccountHistory(ctx, acct.ID)
+	if err != nil {
+		t.Fatalf("GetAccountHistory: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[1].EventType != "AccountTypeChanged" {
+		t.Fatalf("expected AccountTypeChanged, got %s", events[1].EventType)
+	}
+
+	var payload core.AccountTypeChangedPayload
+	if err := json.Unmarshal(events[1].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.OldType != int(core.AccountTypeChecking) || payload.NewType != int(core.AccountTypeSavings) {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+}
+
+func TestUpdateAccountTypeValidation(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	acct, err := db.CreateAccount(ctx, "Test", core.AccountTypeChecking)
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	if err := db.UpdateAccountType(ctx, "", core.AccountTypeSavings); err == nil {
+		t.Fatal("expected error for empty ID")
+	}
+	if err := db.UpdateAccountType(ctx, acct.ID, core.AccountTypeUnspecified); err == nil {
+		t.Fatal("expected error for unspecified type")
+	}
+	if err := db.UpdateAccountType(ctx, acct.ID, core.AccountType(99)); err == nil {
+		t.Fatal("expected error for invalid type")
+	}
+	if err := db.UpdateAccountType(ctx, "nonexistent-id", core.AccountTypeSavings); err == nil {
+		t.Fatal("expected error for nonexistent account")
+	}
+	if err := db.UpdateAccountType(ctx, acct.ID, core.AccountTypeChecking); err == nil {
+		t.Fatal("expected error for same type")
+	}
+}
+
 func TestGetAccountHistoryEmpty(t *testing.T) {
 	db := openTestDB(t)
 	ctx := context.Background()

--- a/core/account_test.go
+++ b/core/account_test.go
@@ -3,6 +3,7 @@ package core_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/jakewan/finch/core"
@@ -166,6 +167,8 @@ func TestRenameAccountValidation(t *testing.T) {
 	}
 	if err := db.RenameAccount(ctx, acct.ID, "Test"); err == nil {
 		t.Fatal("expected error for same name")
+	} else if !errors.Is(err, core.ErrNoChange) {
+		t.Fatalf("expected ErrNoChange, got: %v", err)
 	}
 }
 
@@ -236,6 +239,8 @@ func TestUpdateAccountTypeValidation(t *testing.T) {
 	}
 	if err := db.UpdateAccountType(ctx, acct.ID, core.AccountTypeChecking); err == nil {
 		t.Fatal("expected error for same type")
+	} else if !errors.Is(err, core.ErrNoChange) {
+		t.Fatalf("expected ErrNoChange, got: %v", err)
 	}
 }
 

--- a/daemon/finchd/server.go
+++ b/daemon/finchd/server.go
@@ -76,6 +76,32 @@ func (s *Server) GetAccountHistory(ctx context.Context, req *finchv1.GetAccountH
 	return eventsToProto(events), nil
 }
 
+func (s *Server) RenameAccount(ctx context.Context, req *finchv1.RenameAccountRequest) (*finchv1.RenameAccountResponse, error) {
+	if strings.TrimSpace(req.AccountId) == "" {
+		return nil, status.Error(codes.InvalidArgument, "account_id must not be empty")
+	}
+	if strings.TrimSpace(req.NewName) == "" {
+		return nil, status.Error(codes.InvalidArgument, "new_name must not be empty")
+	}
+	if err := s.db.RenameAccount(ctx, req.AccountId, req.NewName); err != nil {
+		return nil, accountError("rename account", err)
+	}
+	return &finchv1.RenameAccountResponse{}, nil
+}
+
+func (s *Server) UpdateAccountType(ctx context.Context, req *finchv1.UpdateAccountTypeRequest) (*finchv1.UpdateAccountTypeResponse, error) {
+	if strings.TrimSpace(req.AccountId) == "" {
+		return nil, status.Error(codes.InvalidArgument, "account_id must not be empty")
+	}
+	if req.NewType == finchv1.AccountType_ACCOUNT_TYPE_UNSPECIFIED {
+		return nil, status.Error(codes.InvalidArgument, "new_type must be specified")
+	}
+	if err := s.db.UpdateAccountType(ctx, req.AccountId, core.AccountType(req.NewType)); err != nil {
+		return nil, accountError("update account type", err)
+	}
+	return &finchv1.UpdateAccountTypeResponse{}, nil
+}
+
 func (s *Server) CreateRecurringRule(ctx context.Context, req *finchv1.CreateRecurringRuleRequest) (*finchv1.CreateRecurringRuleResponse, error) {
 	if strings.TrimSpace(req.Name) == "" {
 		return nil, status.Error(codes.InvalidArgument, "name must not be empty")
@@ -405,6 +431,14 @@ func (s *Server) GetBalanceTimeSeries(ctx context.Context, req *finchv1.GetBalan
 		resp.Points = append(resp.Points, tp)
 	}
 	return resp, nil
+}
+
+// accountError maps core account errors to gRPC status codes.
+func accountError(op string, err error) error {
+	if strings.Contains(err.Error(), "not found") {
+		return status.Errorf(codes.NotFound, "%s: %v", op, err)
+	}
+	return status.Errorf(codes.Internal, "%s: %v", op, err)
 }
 
 // ruleError maps core recurring rule errors to gRPC status codes.

--- a/daemon/finchd/server.go
+++ b/daemon/finchd/server.go
@@ -2,6 +2,7 @@ package finchd
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -437,6 +438,9 @@ func (s *Server) GetBalanceTimeSeries(ctx context.Context, req *finchv1.GetBalan
 func accountError(op string, err error) error {
 	if strings.Contains(err.Error(), "not found") {
 		return status.Errorf(codes.NotFound, "%s: %v", op, err)
+	}
+	if errors.Is(err, core.ErrNoChange) {
+		return status.Errorf(codes.InvalidArgument, "%s: %v", op, err)
 	}
 	return status.Errorf(codes.Internal, "%s: %v", op, err)
 }

--- a/justfile
+++ b/justfile
@@ -62,18 +62,22 @@ clean:
 install: install-service install-mcp
 
 # Install systemd user service
+# Uses cp+mv (atomic replacement) so the install succeeds even while the
+# daemon binary is running — Linux prevents overwriting a running binary
+# with cp alone ("text file busy"), but mv replaces the directory entry
+# while the running process retains its file descriptor to the old inode.
 install-service: build-daemon
     mkdir -p ~/.local/bin
-    cp daemon/finch-daemon ~/.local/bin/
+    cp daemon/finch-daemon ~/.local/bin/finch-daemon.tmp && mv ~/.local/bin/finch-daemon.tmp ~/.local/bin/finch-daemon
     mkdir -p ~/.config/systemd/user
     cp daemon/finch.service ~/.config/systemd/user/
     systemctl --user daemon-reload
     systemctl --user enable --now finch.service
 
-# Install MCP server binary
+# Install MCP server binary (see install-service for cp+mv rationale)
 install-mcp: build-mcp
     mkdir -p ~/.local/bin
-    cp mcp/finch-mcp ~/.local/bin/
+    cp mcp/finch-mcp ~/.local/bin/finch-mcp.tmp && mv ~/.local/bin/finch-mcp.tmp ~/.local/bin/finch-mcp
 
 # Install git hooks via lefthook
 hooks:

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -32,6 +32,16 @@ func registerTools(server *mcp.Server, client finchv1.FinchServiceClient) {
 	}, newGetAccountHistoryHandler(client))
 
 	mcp.AddTool(server, &mcp.Tool{
+		Name:        "rename_account",
+		Description: "Rename an existing financial account.",
+	}, newRenameAccountHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "update_account_type",
+		Description: "Change the type of an existing financial account.",
+	}, newUpdateAccountTypeHandler(client))
+
+	mcp.AddTool(server, &mcp.Tool{
 		Name:        "create_recurring_rule",
 		Description: "Create a recurring transaction rule (template). Amount is in cents. Frequency: WEEKLY, BIWEEKLY, SEMI_MONTHLY, MONTHLY, YEARLY.",
 	}, newCreateRecurringRuleHandler(client))
@@ -230,6 +240,59 @@ func newGetAccountHistoryHandler(client finchv1.FinchServiceClient) func(context
 			return nil, GetAccountHistoryOutput{}, fmt.Errorf("get account history: %w", err)
 		}
 		return nil, GetAccountHistoryOutput{Events: protoEventsToInfo(resp.Events)}, nil
+	}
+}
+
+// RenameAccount
+
+type RenameAccountInput struct {
+	AccountID string `json:"account_id" jsonschema:"the UUID of the account to rename"`
+	NewName   string `json:"new_name" jsonschema:"the new name for the account"`
+}
+type RenameAccountOutput struct{}
+
+func newRenameAccountHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, RenameAccountInput) (*mcp.CallToolResult, RenameAccountOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input RenameAccountInput) (*mcp.CallToolResult, RenameAccountOutput, error) {
+		_, err := client.RenameAccount(ctx, &finchv1.RenameAccountRequest{
+			AccountId: input.AccountID,
+			NewName:   input.NewName,
+		})
+		if err != nil {
+			return nil, RenameAccountOutput{}, fmt.Errorf("rename account: %w", err)
+		}
+		return nil, RenameAccountOutput{}, nil
+	}
+}
+
+// UpdateAccountType
+
+type UpdateAccountTypeInput struct {
+	AccountID string `json:"account_id" jsonschema:"the UUID of the account"`
+	NewType   string `json:"new_type" jsonschema:"account type: CHECKING, SAVINGS, CREDIT_CARD, AUTO_LOAN, PERSONAL_LOAN, LINE_OF_CREDIT, or BROKERAGE"`
+}
+type UpdateAccountTypeOutput struct{}
+
+func newUpdateAccountTypeHandler(client finchv1.FinchServiceClient) func(context.Context, *mcp.CallToolRequest, UpdateAccountTypeInput) (*mcp.CallToolResult, UpdateAccountTypeOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input UpdateAccountTypeInput) (*mcp.CallToolResult, UpdateAccountTypeOutput, error) {
+		normalized := strings.ToUpper(strings.TrimSpace(input.NewType))
+		normalized = strings.TrimPrefix(normalized, "ACCOUNT_TYPE_")
+		acctType, ok := accountTypeMap[normalized]
+		if !ok {
+			valid := make([]string, 0, len(accountTypeMap))
+			for k := range accountTypeMap {
+				valid = append(valid, k)
+			}
+			slices.Sort(valid)
+			return nil, UpdateAccountTypeOutput{}, fmt.Errorf("unknown account type %q; valid types: %s", input.NewType, strings.Join(valid, ", "))
+		}
+		_, err := client.UpdateAccountType(ctx, &finchv1.UpdateAccountTypeRequest{
+			AccountId: input.AccountID,
+			NewType:   acctType,
+		})
+		if err != nil {
+			return nil, UpdateAccountTypeOutput{}, fmt.Errorf("update account type: %w", err)
+		}
+		return nil, UpdateAccountTypeOutput{}, nil
 	}
 }
 

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -249,6 +249,147 @@ func TestAccountTools(t *testing.T) {
 	})
 }
 
+// --- Account Mutation Tools ---
+
+func TestAccountMutationTools(t *testing.T) {
+	client := startTestBackend(t)
+	ctx := context.Background()
+
+	t.Run("rename_account", func(t *testing.T) {
+		renameHandler := newRenameAccountHandler(client)
+		listHandler := newListAccountsHandler(client)
+
+		t.Run("renames_account_successfully", func(t *testing.T) {
+			freshClient := startTestBackend(t)
+			createHandler := newCreateAccountHandler(freshClient)
+			renameH := newRenameAccountHandler(freshClient)
+			listH := newListAccountsHandler(freshClient)
+
+			_, created, err := createHandler(ctx, nil, CreateAccountInput{Name: "Old Name", Type: "CHECKING"})
+			if err != nil {
+				t.Fatalf("create: %v", err)
+			}
+
+			_, _, err = renameH(ctx, nil, RenameAccountInput{AccountID: created.Account.ID, NewName: "New Name"})
+			if err != nil {
+				t.Fatalf("rename: %v", err)
+			}
+
+			_, listed, err := listH(ctx, nil, ListAccountsInput{})
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			if len(listed.Accounts) != 1 || listed.Accounts[0].Name != "New Name" {
+				t.Fatalf("expected renamed account 'New Name', got %+v", listed.Accounts)
+			}
+		})
+
+		t.Run("rejects_empty_name", func(t *testing.T) {
+			accountID := createTestAccount(t, client)
+			_, _, err := renameHandler(ctx, nil, RenameAccountInput{AccountID: accountID, NewName: ""})
+			if err == nil {
+				t.Fatal("expected error for empty name")
+			}
+		})
+
+		t.Run("verifies_event_history", func(t *testing.T) {
+			freshClient := startTestBackend(t)
+			createHandler := newCreateAccountHandler(freshClient)
+			renameH := newRenameAccountHandler(freshClient)
+			historyH := newGetAccountHistoryHandler(freshClient)
+
+			_, created, err := createHandler(ctx, nil, CreateAccountInput{Name: "Before", Type: "SAVINGS"})
+			if err != nil {
+				t.Fatalf("create: %v", err)
+			}
+
+			_, _, err = renameH(ctx, nil, RenameAccountInput{AccountID: created.Account.ID, NewName: "After"})
+			if err != nil {
+				t.Fatalf("rename: %v", err)
+			}
+
+			_, history, err := historyH(ctx, nil, GetAccountHistoryInput{AccountID: created.Account.ID})
+			if err != nil {
+				t.Fatalf("history: %v", err)
+			}
+			if len(history.Events) != 2 {
+				t.Fatalf("expected 2 events, got %d", len(history.Events))
+			}
+			if history.Events[1].EventType != "AccountRenamed" {
+				t.Fatalf("expected AccountRenamed, got %q", history.Events[1].EventType)
+			}
+		})
+
+		_ = listHandler
+	})
+
+	t.Run("update_account_type", func(t *testing.T) {
+		updateHandler := newUpdateAccountTypeHandler(client)
+		listHandler := newListAccountsHandler(client)
+
+		t.Run("changes_type_successfully", func(t *testing.T) {
+			freshClient := startTestBackend(t)
+			createHandler := newCreateAccountHandler(freshClient)
+			updateH := newUpdateAccountTypeHandler(freshClient)
+			listH := newListAccountsHandler(freshClient)
+
+			_, created, err := createHandler(ctx, nil, CreateAccountInput{Name: "My Account", Type: "CHECKING"})
+			if err != nil {
+				t.Fatalf("create: %v", err)
+			}
+
+			_, _, err = updateH(ctx, nil, UpdateAccountTypeInput{AccountID: created.Account.ID, NewType: "SAVINGS"})
+			if err != nil {
+				t.Fatalf("update type: %v", err)
+			}
+
+			_, listed, err := listH(ctx, nil, ListAccountsInput{})
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			if len(listed.Accounts) != 1 || !strings.Contains(listed.Accounts[0].Type, "SAVINGS") {
+				t.Fatalf("expected SAVINGS type, got %+v", listed.Accounts)
+			}
+		})
+
+		t.Run("normalizes_input", func(t *testing.T) {
+			cases := []string{"savings", "ACCOUNT_TYPE_SAVINGS", "  SAVINGS  "}
+			for _, input := range cases {
+				t.Run(input, func(t *testing.T) {
+					fc := startTestBackend(t)
+					createH := newCreateAccountHandler(fc)
+					updateH := newUpdateAccountTypeHandler(fc)
+
+					_, created, err := createH(ctx, nil, CreateAccountInput{Name: "Norm Test", Type: "CHECKING"})
+					if err != nil {
+						t.Fatalf("create: %v", err)
+					}
+					_, _, err = updateH(ctx, nil, UpdateAccountTypeInput{AccountID: created.Account.ID, NewType: input})
+					if err != nil {
+						t.Fatalf("input %q: unexpected error: %v", input, err)
+					}
+				})
+			}
+		})
+
+		t.Run("rejects_unknown_type_with_valid_options", func(t *testing.T) {
+			accountID := createTestAccount(t, client)
+			_, _, err := updateHandler(ctx, nil, UpdateAccountTypeInput{AccountID: accountID, NewType: "INVALID"})
+			if err == nil {
+				t.Fatal("expected error for unknown type")
+			}
+			if !strings.Contains(err.Error(), "unknown account type") {
+				t.Fatalf("expected 'unknown account type' in error, got: %s", err.Error())
+			}
+			if !strings.Contains(err.Error(), "CHECKING") {
+				t.Fatalf("expected valid options in error, got: %s", err.Error())
+			}
+		})
+
+		_ = listHandler
+	})
+}
+
 // --- Recurring Rule Tools ---
 
 func TestRecurringRuleTools(t *testing.T) {

--- a/proto/finch/v1/finch.proto
+++ b/proto/finch/v1/finch.proto
@@ -9,6 +9,8 @@ service FinchService {
   rpc ListAccounts(ListAccountsRequest) returns (ListAccountsResponse);
   rpc CreateAccount(CreateAccountRequest) returns (CreateAccountResponse);
   rpc GetAccountHistory(GetAccountHistoryRequest) returns (GetAccountHistoryResponse);
+  rpc RenameAccount(RenameAccountRequest) returns (RenameAccountResponse);
+  rpc UpdateAccountType(UpdateAccountTypeRequest) returns (UpdateAccountTypeResponse);
   rpc CreateRecurringRule(CreateRecurringRuleRequest) returns (CreateRecurringRuleResponse);
   rpc ListRecurringRules(ListRecurringRulesRequest) returns (ListRecurringRulesResponse);
   rpc UpdateRecurringRuleAmount(UpdateRecurringRuleAmountRequest) returns (UpdateRecurringRuleAmountResponse);
@@ -81,6 +83,20 @@ message AccountEvent {
 message GetAccountHistoryResponse {
   repeated AccountEvent events = 1;
 }
+
+message RenameAccountRequest {
+  string account_id = 1;
+  string new_name = 2;
+}
+
+message RenameAccountResponse {}
+
+message UpdateAccountTypeRequest {
+  string account_id = 1;
+  AccountType new_type = 2;
+}
+
+message UpdateAccountTypeResponse {}
 
 // Recurring rules
 


### PR DESCRIPTION
## Overview

This change adds two new account mutation RPCs (RenameAccount and UpdateAccountType) across the full stack — proto definition, core domain logic with event sourcing, daemon gRPC handlers, and MCP tool wrappers. It represents an incremental improvement, extending the existing account management API surface to support operations that were previously only possible by recreating accounts.

Along the way, this PR addresses two DX pain points discovered during development: binary installs now use atomic replacement to avoid "text file busy" errors when updating running binaries, and a new `/mcp-reload` skill documents the MCP server development iteration cycle (build, install, exit, resume).

A `core.ErrNoChange` sentinel error was introduced so the daemon correctly maps "same value" validation failures to `codes.InvalidArgument` instead of `codes.Internal`.

## Changes

- **proto**: Add `RenameAccount` and `UpdateAccountType` RPC definitions with request/response messages
- **core**: Implement `RenameAccount` and `UpdateAccountType` with event sourcing, validation, and `ErrNoChange` sentinel
- **daemon**: Add gRPC handlers with input validation and `ErrNoChange` → `InvalidArgument` mapping in `accountError`
- **mcp**: Add `rename_account` and `update_account_type` tool handlers with input normalization
- **justfile**: Use atomic replacement (`cp` + `mv`) for binary installs to avoid "text file busy" errors
- **skill**: Add `/mcp-reload` skill for MCP development iteration workflow

## Test plan

- [x] Core unit tests verify rename, type change, event production, and `ErrNoChange` sentinel
- [x] MCP BDD tests cover happy path, validation, event history, and input normalization
- [x] Manual verification via MCP tools (`rename_account`, `update_account_type`, `list_accounts`, `ping`)
- [x] `just test` and `just lint` pass
- [x] Pre-push hooks pass (proto, go-lint, go-test, qt-build)
- [x] Atomic install verified: `just all && just install` succeeds while daemon and MCP server are running

🤖 Generated with [Claude Code](https://claude.com/claude-code)