### PR TITLE
feat(skills): add project management skill trilogy

### DIFF
--- a/.claude/skills/backlog-review/SKILL.md
+++ b/.claude/skills/backlog-review/SKILL.md
@@ -48,6 +48,7 @@ Use the same two-pass heuristic as `/project-summary`:
 |---|---|
 | `app-independence` | **app** |
 | `github_actions` | **infra** |
+| `developer-experience` | **dx** |
 
 If an issue matches a label rule, assign that component and skip Pass 2 for that issue.
 
@@ -75,7 +76,7 @@ Header: `## Issue Quality Audit`
 
 Evaluate all open issues against quality heuristics. Show "None" for empty categories.
 
-**Needs decomposition** — issues with 3+ checklist items (`- [ ]` or `- [x]`) or 4+ numbered list items with substantive content. These are candidates for breaking into sub-issues.
+**Needs decomposition** — issues with 3+ checklist items (`- [ ]` or `- [x]`) or 4+ numbered list items with substantive content. These are candidates for breaking into sub-issues. Exclude checklists that appear under an "Acceptance criteria" heading — those are verification steps, not work items.
 
 **Missing description** — body is null, empty, or under 30 characters. An issue without a description lacks clear purpose.
 
@@ -118,12 +119,13 @@ Build a summary table of issue distribution across components, using dependency 
 ```markdown
 | Component    | Active | % of Backlog | Signal      |
 | ------------ | ------ | ------------ | ----------- |
-| core         | 5      | 38%          |             |
-| api          | 1      | 8%           |             |
+| core         | 5      | 33%          |             |
+| api          | 1      | 7%           |             |
 | mcp          | 0      | 0%           | starved     |
-| app          | 5      | 38%          |             |
-| infra        | 1      | 8%           |             |
-| (unclassified) | 1   | 8%           | needs label |
+| app          | 5      | 33%          |             |
+| infra        | 1      | 7%           |             |
+| dx           | 2      | 13%          |             |
+| (unclassified) | 1   | 7%           | needs label |
 ```
 
 - **% of Backlog** = active count / total active count across all components

--- a/.claude/skills/backlog-review/SKILL.md
+++ b/.claude/skills/backlog-review/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: backlog-review
+description: >-
+  Deep backlog health analysis — issue quality, staleness, component balance,
+  overlap detection, and milestone candidates. Use for dedicated grooming
+  sessions, not quick orientation (use /project-summary for that).
+---
+
+# Backlog Review
+
+Comprehensive backlog health analysis for dedicated grooming sessions. Produces a structured report for discussion, then transitions to collaborative decision-making.
+
+## Step 1: Gather Data
+
+Run these four commands in parallel:
+
+**Command A** — all open issues with full metadata:
+
+```bash
+gh issue list --state open --limit 200 --json number,title,labels,milestone,updatedAt,createdAt,body,comments
+```
+
+**Command B** — recently closed issues (for overlap detection and trajectory):
+
+```bash
+gh issue list --state closed --limit 50 --json number,title,labels,closedAt,stateReason
+```
+
+**Command C** — active milestone progress:
+
+```bash
+gh api repos/{owner}/{repo}/milestones --jq '.[] | select(.state == "open") | {title, open: .open_issues, closed: .closed_issues, number: .number, description}'
+```
+
+**Command D** — label inventory:
+
+```bash
+gh label list --limit 50 --json name,description
+```
+
+## Step 2: Classify Each Issue by Component
+
+Use the same two-pass heuristic as `/project-summary`:
+
+### Pass 1: Label match (takes precedence)
+
+| Label | Component |
+|---|---|
+| `app-independence` | **app** |
+| `github_actions` | **infra** |
+
+If an issue matches a label rule, assign that component and skip Pass 2 for that issue.
+
+### Pass 2: Title keyword heuristic (case-insensitive)
+
+For remaining issues, match title keywords in this priority order (first match wins):
+
+| Component | Title keywords |
+|---|---|
+| **core** | core, domain, event, migration, database, sqlite, accounting, account, transaction, transfer, balance, recurring, debt, interest |
+| **api** | proto, grpc, rpc, api, daemon, handler, reflection |
+| **mcp** | mcp |
+| **app** | app, qt, qml, ui, chart, visual, cash flow |
+| **infra** | ci, build, install, action, workflow, recipe |
+
+Issues matching none are **unclassified**.
+
+Also extract for each issue:
+- **Last substantive activity**: the most recent of (a) last comment `createdAt`, or (b) issue `createdAt` if no comments. This is the primary staleness signal — `updatedAt` is unreliable because triage operations (labeling, milestone assignment) bump it without meaningful engagement.
+- **Body quality**: body length, presence of checklists, acceptance criteria language
+
+## Step 3: Present Issue Quality Audit
+
+Header: `## Issue Quality Audit`
+
+Evaluate all open issues against quality heuristics. Show "None" for empty categories.
+
+**Needs decomposition** — issues with 3+ checklist items (`- [ ]` or `- [x]`) or 4+ numbered list items with substantive content. These are candidates for breaking into sub-issues.
+
+**Missing description** — body is null, empty, or under 30 characters. An issue without a description lacks clear purpose.
+
+**Missing acceptance criteria** — non-milestone issues labeled `enhancement` whose body doesn't contain structured requirements (checklist markers, `## ` section headers, or acceptance language like "accept", "criteria", "done when", "verify", "should").
+
+**Unclassified issues** — open issues that matched no component heuristic (from Step 2).
+
+**Unlabeled issues** — open issues with no labels at all.
+
+Format each group as a list of `#number - title` with a brief note. If a group is empty, show "None."
+
+## Step 4: Present Staleness Analysis
+
+Header: `## Staleness Analysis`
+
+Use **last substantive activity** (last comment date, or issue creation date if no comments) as the primary staleness signal — NOT `updatedAt`.
+
+```markdown
+**Stale (60+ days since last substantive activity, no milestone)**
+
+- #23 - Title — last comment YYYY-MM-DD (N days), last updated YYYY-MM-DD
+
+**Stale (60+ days since last substantive activity, has milestone)**
+
+- #45 - Title — in "milestone name", last comment YYYY-MM-DD (noted but lower concern)
+
+**Aging (30-60 days since last substantive activity, no milestone)**
+
+- #67 - Title — created YYYY-MM-DD, no comments
+```
+
+If no issues match any category: "Backlog is fresh — no staleness concerns."
+
+## Step 5: Present Component Balance
+
+Header: `## Component Balance`
+
+Build a summary table of issue distribution across components, using dependency order:
+
+```markdown
+| Component    | Active | % of Backlog | Signal      |
+| ------------ | ------ | ------------ | ----------- |
+| core         | 5      | 38%          |             |
+| api          | 1      | 8%           |             |
+| mcp          | 0      | 0%           | starved     |
+| app          | 5      | 38%          |             |
+| infra        | 1      | 8%           |             |
+| (unclassified) | 1   | 8%           | needs label |
+```
+
+- **% of Backlog** = active count / total active count across all components
+- **Overloaded**: Flag non-gating components that exceed 2x the average of other non-gating components
+- **Starved**: Flag components with zero issues
+- **Needs label**: Flag the unclassified bucket if non-empty
+
+Follow the table with 2-3 observation sentences about the distribution.
+
+## Step 6: Present Overlap Detection
+
+Header: `## Possible Overlaps`
+
+Apply conservative heuristics — present candidates for human judgment, never declare duplicates unilaterally.
+
+**Title similarity**: Flag pairs of open issues whose titles share 3+ significant words (excluding common words: "add", "fix", "update", "support", "implement", "the", "for", "and", "in", "to", "a", "an", "no", "way").
+
+**Cross-reference clustering**: Issues whose bodies contain `#N` references to other _open_ issues. Group into clusters only when 3+ open issues form a mutual reference web. Briefly assess whether each cluster represents coordinated work (good — note it and move on) or duplicated scope (needs attention — explain why).
+
+**Open-vs-closed overlap**: Open issues whose titles closely match recently closed issues from Command B — possible "was this already resolved?" situations.
+
+Format:
+
+```markdown
+**May address similar concerns:**
+
+- #42 "Title A" ↔ #87 "Title B" — both touch [shared concern]; verify scope boundaries
+
+**Cross-referenced clusters:**
+
+- Cluster: #23, #45, #67 — coordinated work around [topic]; no action needed
+- Cluster: #88, #90 — possible duplicated scope: both describe [overlapping concern]
+
+**Possibly resolved:**
+
+- #89 "Title" — may overlap with closed #124 (closed YYYY-MM-DD, reason: completed)
+```
+
+If no overlaps are detected: "No obvious overlaps detected — backlog has good clarity."
+
+## Step 7: Present Milestone Candidates
+
+Header: `## Milestone Candidates`
+
+Filter to issues that are: open and not assigned to any milestone. Rank by readiness.
+
+**If an active milestone exists**: State the milestone's theme (from its description in Command C) before ranking. Candidates that advance the milestone's purpose rank higher.
+
+- **High confidence** — issues that directly advance the active milestone's theme, OR bugs in the gating component, OR issues referenced by current milestone issues (dependencies of active work)
+- **Medium confidence** — well-defined issues in the gating component that don't directly advance the milestone theme but are good next-milestone candidates
+- **Good work, different planning unit** — well-defined issues outside the gating component; note which component and future planning unit they'd belong to
+- **Needs refinement first** — issues with quality problems identified in Step 3; note: "Fix quality first, then consider for milestone"
+
+**If no active milestones exist (cold start)**: Rank purely by component dependency order (core first) and issue quality. Note that `/milestone-lifecycle` can help propose the first milestone.
+
+Format: `- #number - title — component, [readiness rationale]`
+
+## Step 8: Present Backlog Trajectory
+
+Header: `## Backlog Trajectory`
+
+Using Command A (open issues) and Command B (recently closed issues), assess net change over 30 days:
+
+- Count issues **created in the last 30 days** (from Command A's `createdAt`)
+- Count issues **closed in the last 30 days** (from Command B's `closedAt`)
+- Calculate net change: `created - closed`
+
+Present as:
+
+```markdown
+**Last 30 days**: N created, M closed (net +/- K)
+```
+
+Add a one-sentence interpretation:
+
+- Net positive: "Backlog is growing — new work is being identified faster than it's being resolved."
+- Net zero: "Backlog is stable — roughly matching creation and completion rates."
+- Net negative: "Backlog is shrinking — closing faster than creating. Good momentum."
+
+## Step 9: Present Key Findings & Discussion
+
+Header: `## Key Findings`
+
+Synthesize the most important findings from all previous sections into 3-5 bullet points, each with a concrete recommended action. These should be the items that actually warrant grooming attention — not a summary of every section.
+
+Prioritize findings by strategic significance:
+
+1. Gate status changes (a component layer cleared, unblocking downstream)
+2. Stale issues with no engagement (potential backlog rot)
+3. Component imbalances that suggest misallocated effort
+4. Milestone candidates ready to pull in
+5. Overlap clusters that need scope clarification
+
+After the key findings, transition to discussion:
+
+```markdown
+---
+
+This is a read-only analysis — no issues were modified. To act on findings:
+
+- **Decompose an oversized issue**: discuss breakdown strategy
+- **Add to milestone**: discuss which candidates to pull in
+- **Close stale issues**: discuss which have lost relevance
+- **Resolve overlaps**: discuss whether to merge, clarify scope, or close duplicates
+
+Which area would you like to discuss first?
+```
+
+## Rules
+
+- **Read-only**: Never relabel, close, or modify issues autonomously
+- **Four API calls**: All grouping and analysis happens client-side from Step 1 results
+- **Conservative overlap detection**: Present possible overlaps for human judgment; never declare duplicates unilaterally
+- **Complements /project-summary**: This skill goes deeper on backlog health; `/project-summary` is for quick session orientation
+- **Substantive activity over metadata**: Always prefer comment timestamps and creation dates over `updatedAt` for staleness analysis. Triage touches are not engagement.

--- a/.claude/skills/milestone-lifecycle/SKILL.md
+++ b/.claude/skills/milestone-lifecycle/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: milestone-lifecycle
+description: >-
+  Structure the transition between planning units — assess milestone completion,
+  evaluate critical-path gates, and propose the next milestone with an initial
+  issue set. Most valuable when a milestone is complete or near-complete; for
+  mid-milestone orientation, /project-summary is lighter weight.
+---
+
+# Milestone Lifecycle
+
+Structured planning transitions for milestone lifecycle management. Assesses whether the active planning unit is complete, checks critical-path gates, and proposes the next planning unit with an initial issue set. All mutating actions require user approval.
+
+| Layer        | Skill                      | Role                        |
+| ------------ | -------------------------- | --------------------------- |
+| Orientation  | `/project-summary`         | Where are we now?           |
+| Analysis     | `/backlog-review`          | What's in the backlog?      |
+| **Planning** | **`/milestone-lifecycle`** | **What should we do next?** |
+
+## Step 1: Gather Data
+
+Run these three commands in parallel (no additional API calls after this):
+
+**Command A** — open milestones with descriptions:
+
+```bash
+gh api 'repos/{owner}/{repo}/milestones?state=open' --jq '.[] | {number, title, description, open_issues, closed_issues}'
+```
+
+**Note**: The URL must be single-quoted to prevent zsh from interpreting `?` as a glob character.
+
+**Command B** — all open issues with metadata:
+
+```bash
+gh issue list --state open --limit 200 --json number,title,labels,milestone,body,createdAt,updatedAt
+```
+
+**Command C** — recently closed issues (for completion assessment):
+
+```bash
+gh issue list --state closed --limit 50 --json number,title,labels,milestone,closedAt,stateReason
+```
+
+## Step 2: Classify Issues and Determine Mode
+
+### Classify issues by component
+
+Use the same two-pass heuristic as `/project-summary` and `/backlog-review`:
+
+#### Pass 1: Label match (takes precedence)
+
+| Label | Component |
+|---|---|
+| `app-independence` | **app** |
+| `github_actions` | **infra** |
+| `developer-experience` | **dx** |
+
+If an issue matches a label rule, assign that component and skip Pass 2 for that issue.
+
+#### Pass 2: Title keyword heuristic (case-insensitive)
+
+For remaining issues, match title keywords in this priority order (first match wins):
+
+| Component | Title keywords |
+|---|---|
+| **core** | core, domain, event, migration, database, sqlite, accounting, account, transaction, transfer, balance, recurring, debt, interest |
+| **api** | proto, grpc, rpc, api, daemon, handler, reflection |
+| **mcp** | mcp |
+| **app** | app, qt, qml, ui, chart, visual, cash flow |
+| **infra** | ci, build, install, action, workflow, recipe |
+
+Issues matching none are **unclassified**.
+
+### Determine operating mode
+
+Based on Command A results. **Important**: Command A's `open_issues`/`closed_issues` counts can be stale — always use Command B (the issue list) as the authoritative source for actual issue counts in a milestone.
+
+- **No open milestones** → **Cold-start mode**. Skip Steps 3–4, proceed to Step 5 with cold-start framing.
+- **One open milestone** → Use it as the active milestone. Proceed to Step 3.
+- **Multiple open milestones** → Present a numbered list with progress counts and ask the user which milestone to evaluate. Proceed to Step 3 with the chosen milestone.
+
+Present the mode determination:
+
+```markdown
+## Operating Mode
+
+**Active milestone**: "Core — Foundation" (3 open / 7 closed)
+**Mode**: Completion assessment
+```
+
+Or for cold start:
+
+```markdown
+## Operating Mode
+
+**No active milestones found.**
+**Mode**: Cold start — proposing first planning unit
+```
+
+## Step 3: Completion Assessment
+
+Header: `## Completion Assessment`
+
+Skip if cold-start mode.
+
+Assess the active milestone's state by categorizing it:
+
+- **Complete**: Zero open issues in the milestone. All work is done.
+- **Near-complete**: 1–2 open issues remain, none in the current gating component (see Step 4). These may be non-blocking follow-ups or minor items that can carry forward.
+- **In-progress**: 3+ open issues remain, or any issues in the gating component remain open.
+
+Present as:
+
+```markdown
+**"Core — Foundation"**: [Complete / Near-complete / In-progress]
+
+- N issues closed, M remaining
+- [If near-complete] Remaining: #42 - Title (non-blocking), #87 - Title (non-blocking)
+- [If in-progress] Gating component issues: #132 - Title
+```
+
+For **Complete** or **Near-complete**: proceed to Step 4 (gate assessment) and Step 5 (transition proposal).
+
+For **In-progress**: present the remaining issues grouped by component, and end with:
+
+```markdown
+The active planning unit still has open work. To proceed with transition planning anyway, say "continue." Otherwise, focus on the remaining issues.
+```
+
+Wait for user confirmation before proceeding past an in-progress milestone.
+
+## Step 4: Gate Assessment
+
+Header: `## Critical-Path Gate`
+
+Finch's dependency graph: **core → api → mcp / app**
+
+Non-gated components (run in parallel, not blocked by the dependency chain): **dx**
+
+From Command B, find all open issues grouped by component. Determine the current gate:
+
+- Find the earliest component (in dependency order: core → api → mcp/app) that has open issues. That is the "current gate."
+- If no issues remain in core, api, mcp, or app, state "All gates cleared."
+
+Present:
+
+```markdown
+**Current gate**: core
+**Open issues in gating component**: N
+
+- #132 - Title
+- #178 - Title
+
+**Downstream components blocked**: api, mcp, app
+**Non-gated components (unaffected)**: dx
+```
+
+Or if a gate has cleared:
+
+```markdown
+**Gate cleared**: core has zero open issues.
+**Newly unblocked**: api (next in dependency order)
+
+This is a significant planning signal — the next milestone could shift focus downstream.
+```
+
+If the gate assessment reveals a newly unblocked downstream component, recommend running `/backlog-review` for a full readiness assessment if one hasn't been run recently.
+
+## Step 5: Transition Proposal
+
+Header: `## Transition Proposal`
+
+This step synthesizes a proposal for the next planning unit.
+
+### 5a. Milestone Recap
+
+State the completed/completing milestone's purpose (from its description field in Command A). One sentence acknowledging what was accomplished.
+
+For cold-start mode: skip this subsection.
+
+### 5b. Component Focus
+
+Based on gate assessment: which component should the next planning unit focus on?
+
+- If the current component's gate is **not yet cleared**, the next planning unit likely stays in the same component.
+- If the gate **cleared**, the next planning unit could shift to the newly unblocked downstream component, or could continue deepening the current component.
+
+State the recommendation with rationale.
+
+### 5c. Backlog Scan for Candidates
+
+From Command B, filter open issues that are:
+
+- Not assigned to any milestone
+
+Group by relevance to the proposed component:
+
+**Direct continuation** — issues in the target component that advance its goals.
+
+**Newly unblocked** — issues in a downstream component that was just unblocked by a gate clearing. Only present this group if a gate cleared in Step 4.
+
+**Cross-component candidates** — well-defined issues in other components that could be pulled in if the planning unit has capacity.
+
+## Step 6: Next Planning Unit Proposal
+
+Header: `## Proposed: Next Planning Unit`
+
+Synthesize the transition proposal into a concrete milestone.
+
+**Title**: Follow the naming convention `"{Component} — {Unit Name}"` with an em-dash (—). Use the component name mapping from the Rules section.
+
+**Purpose statement**: Draft a 1–2 sentence description for the milestone's description field. This should state the planning unit's purpose and what success looks like.
+
+**Initial issue set**: List the proposed issues with rationale for each inclusion.
+
+**Scope check**: Note the issue count. If more than 8–10 issues, flag as potentially too large for a single planning unit and suggest splitting.
+
+Present:
+
+```markdown
+### "Core — Foundation"
+
+**Purpose**: [Draft description — e.g., "Establish typed domain errors and complete the core domain surface area needed for reliable API exposure."]
+
+**Proposed issues** (N total):
+
+- #47 - Title — [rationale]
+- #40 - Title — [rationale]
+
+**Scope assessment**: N issues. [Within range / Consider splitting — more than 10 issues suggests this could be two planning units.]
+```
+
+For **cold-start mode**: frame the proposal as "first" rather than "next." Use the gate assessment to identify which component should get the first planning unit. Draw from the full open backlog for candidates.
+
+## Step 7: Execution Commands
+
+Header: `## Proposed Commands`
+
+Generate the `gh` CLI commands needed to execute the transition. Present them in execution order, each with an explicit approval gate. **Never auto-execute — wait for user confirmation at each phase.**
+
+### Phase 1: Close completed milestone
+
+Skip if cold-start mode or milestone is in-progress.
+
+```markdown
+### Phase 1: Close completed milestone
+
+\`\`\`bash
+gh api repos/{owner}/{repo}/milestones/{number} -X PATCH -f state=closed
+\`\`\`
+
+**Approve Phase 1?** (yes / no / skip)
+```
+
+### Phase 2: Handle near-complete stragglers
+
+Only present if the milestone was near-complete with remaining issues. Surface each remaining issue and ask the user to decide: carry forward to new milestone or close.
+
+```markdown
+### Phase 2: Carry forward remaining issues
+
+These issues were open in the completed milestone. How should each be handled?
+
+- #42 - Title — carry forward / close?
+- #87 - Title — carry forward / close?
+```
+
+### Phase 3: Create new milestone
+
+```markdown
+### Phase 3: Create new milestone
+
+\`\`\`bash
+gh api repos/{owner}/{repo}/milestones -X POST -f title="Core — Foundation" -f description="[purpose statement]"
+\`\`\`
+
+**Approve Phase 3?** (yes / no / edit title / edit description)
+```
+
+### Phase 4: Assign issues to new milestone
+
+```markdown
+### Phase 4: Assign issues
+
+\`\`\`bash
+gh issue edit 47 --milestone "Core — Foundation"
+gh issue edit 40 --milestone "Core — Foundation"
+\`\`\`
+
+**Approve Phase 4?** (yes / no / modify list)
+```
+
+## Step 8: Closing
+
+```markdown
+---
+
+All proposed commands require your approval. This skill does not modify any GitHub state autonomously.
+
+**Related skills:**
+
+- Run `/backlog-review` for deeper backlog health analysis before planning transitions
+- Run `/project-summary` for a quick orientation after the transition is complete
+```
+
+## Rules
+
+- **User approval required**: Every `gh` command that modifies GitHub state is proposed, never auto-executed. Wait for explicit user confirmation at each phase gate.
+- **Three API calls**: All analysis is derived from Step 1 data. No additional API calls during analysis steps.
+- **Read-only analysis, proposed-only execution**: The skill's analysis steps (2–6) never modify state. Execution commands in Step 7 are proposals presented for approval.
+- **Component name mapping for milestone titles**: core → "Core", api → "API", mcp → "MCP", app → "App", infra → "Infrastructure", dx → "DX". Always use the format `"{Component} — {Unit Name}"` with an em-dash (—).
+- **Complements, does not replace**: This skill structures the planning transition decision. `/project-summary` provides orientation, `/backlog-review` provides analysis depth. Each skill has a distinct role.

--- a/.claude/skills/milestone-lifecycle/SKILL.md
+++ b/.claude/skills/milestone-lifecycle/SKILL.md
@@ -75,7 +75,7 @@ Issues matching none are **unclassified**.
 
 Based on Command A results. **Important**: Command A's `open_issues`/`closed_issues` counts can be stale — always use Command B (the issue list) as the authoritative source for actual issue counts in a milestone.
 
-- **No open milestones** → **Cold-start mode**. Skip Steps 3–4, proceed to Step 5 with cold-start framing.
+- **No open milestones** → **Cold-start mode**. Skip Step 3, proceed to Step 4 (gate assessment applies regardless of milestone state).
 - **One open milestone** → Use it as the active milestone. Proceed to Step 3.
 - **Multiple open milestones** → Present a numbered list with progress counts and ask the user which milestone to evaluate. Proceed to Step 3 with the chosen milestone.
 

--- a/.claude/skills/project-summary/SKILL.md
+++ b/.claude/skills/project-summary/SKILL.md
@@ -33,17 +33,29 @@ gh pr list --state open --json number,title,headRefName,statusCheckRollup,update
 
 ## Step 2: Classify Each Issue by Component
 
-For each issue from Command A, assign a component using this heuristic (case-insensitive match on title):
+For each issue from Command A, assign a component in two passes:
 
-| Component | Title keywords | Label match |
-|---|---|---|
-| **core** | core, domain, event, migration, database, sqlite, accounting, transaction, transfer, balance, recurring | — |
-| **api** | proto, grpc, rpc, api, daemon, handler | — |
-| **mcp** | mcp, tool | — |
-| **app** | app, qt, qml, ui, chart, visual | `app-independence` label |
-| **infra** | ci, build, install, action, workflow | `github_actions` label |
+### Pass 1: Label match (takes precedence)
 
-- Match in priority order (core first). An issue matching multiple components goes to the first match.
+| Label | Component |
+|---|---|
+| `app-independence` | **app** |
+| `github_actions` | **infra** |
+
+If an issue matches a label rule, assign that component and skip Pass 2 for that issue.
+
+### Pass 2: Title keyword heuristic (case-insensitive)
+
+For remaining issues, match title keywords in this priority order (first match wins):
+
+| Component | Title keywords |
+|---|---|
+| **core** | core, domain, event, migration, database, sqlite, accounting, account, transaction, transfer, balance, recurring, debt, interest |
+| **api** | proto, grpc, rpc, api, daemon, handler, reflection |
+| **mcp** | mcp |
+| **app** | app, qt, qml, ui, chart, visual, cash flow |
+| **infra** | ci, build, install, action, workflow, recipe |
+
 - Issues matching none are **unclassified** (surfaced in hygiene signals).
 - This heuristic can be replaced with `component:*` labels if adopted later.
 

--- a/.claude/skills/project-summary/SKILL.md
+++ b/.claude/skills/project-summary/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: project-summary
+description: >-
+  Surface component inventory, critical-path gate status, and issue hygiene
+  for session orientation
+---
+
+# Project Summary
+
+Structured overview of project state for session orientation. Replaces manual `gh issue list` queries with a single skill invocation that surfaces what matters most.
+
+## Step 1: Gather Data
+
+Run these three commands in parallel (no additional API calls after this):
+
+**Command A** — all open issues with metadata:
+
+```bash
+gh issue list --state open --limit 200 --json number,title,labels,milestone,updatedAt,createdAt,body
+```
+
+**Command B** — active milestone progress:
+
+```bash
+gh api repos/{owner}/{repo}/milestones --jq '.[] | select(.state == "open") | {title, open: .open_issues, closed: .closed_issues}'
+```
+
+**Command C** — open PRs with CI status:
+
+```bash
+gh pr list --state open --json number,title,headRefName,statusCheckRollup,updatedAt
+```
+
+## Step 2: Classify Each Issue by Component
+
+For each issue from Command A, assign a component using this heuristic (case-insensitive match on title):
+
+| Component | Title keywords | Label match |
+|---|---|---|
+| **core** | core, domain, event, migration, database, sqlite, accounting, transaction, transfer, balance, recurring | — |
+| **api** | proto, grpc, rpc, api, daemon, handler | — |
+| **mcp** | mcp, tool | — |
+| **app** | app, qt, qml, ui, chart, visual | `app-independence` label |
+| **infra** | ci, build, install, action, workflow | `github_actions` label |
+
+- Match in priority order (core first). An issue matching multiple components goes to the first match.
+- Issues matching none are **unclassified** (surfaced in hygiene signals).
+- This heuristic can be replaced with `component:*` labels if adopted later.
+
+Also extract for each issue:
+- **Milestone**: assigned milestone title, or none
+- **Days since last update**: `today - updatedAt`
+- **Days since creation**: `today - createdAt`
+- **Has description**: body is non-empty and at least 20 characters
+
+## Step 3: Present Critical-Path Gate Status
+
+Header: `## Critical-Path Gate`
+
+Finch's dependency graph is: **core → api → mcp / app**
+
+Determine the current gate by checking which layer in dependency order has open issues:
+
+1. If **core** has open issues → "Core has N open issues. Core changes gate API, MCP, and App layers."
+2. Else if **api** has open issues → "API has N open issues. API changes gate MCP and App layers. Core is clear."
+3. Else → "All upstream layers are clear. MCP and App work is unblocked."
+
+List the open issues in the gating layer: `- #number - title`
+
+## Step 4: Present Active Milestone Progress
+
+Header: `## Active Milestones`
+
+For each open milestone (from Command B), show:
+
+```markdown
+**milestone title**: X open / Y closed
+```
+
+List the open issues assigned to that milestone (from Command A): `- #number - title`
+
+If no open milestones exist, state: "No active milestones."
+
+## Step 5: Present Component Inventory
+
+Header: `## Component Inventory`
+
+For each component in dependency order (`core`, `api`, `mcp`, `app`, `infra`):
+
+```markdown
+### component — N open
+
+- #number - title
+```
+
+If a component has zero open issues, show: `### component — clear`
+
+## Step 6: Present Open PRs
+
+Header: `## Open PRs`
+
+For each open PR (from Command C), show:
+
+```markdown
+- #number - title (branch: `headRefName`, CI: status)
+```
+
+Where status is derived from `statusCheckRollup`: "passing", "failing", "pending", or "no checks".
+
+If no open PRs exist, state: "No open PRs."
+
+## Step 7: Present Hygiene Signals
+
+Header: `## Hygiene Signals`
+
+Run four checks. Show "None" for empty categories (confirms the check ran):
+
+1. **Unlabeled issues** — open issues with no labels at all
+2. **Unclassified issues** — open issues that matched no component heuristic (from Step 2)
+3. **Unmilestoned backlog (>30 days)** — issues older than 30 days (by `createdAt`) with no milestone. If the count exceeds 10, append: *Consider running /backlog-review for milestone triage.*
+4. **Stale issues** — issues with no update in 30+ days (by `updatedAt`)
+5. **Missing descriptions** — issues whose body is empty or under 20 characters
+
+Format each as:
+
+```markdown
+**Unlabeled issues**: None
+**Unclassified issues**: #42, #87
+**Unmilestoned backlog (>30 days)**: #15 - title
+**Stale issues**: #15 - title (last updated YYYY-MM-DD)
+**Missing descriptions**: None
+```
+
+## Step 8: Present Recommendations
+
+Header: `## What's Next`
+
+Produce 3-5 ranked recommendations using this priority. Every recommendation must reference specific issue numbers — no meta-process suggestions.
+
+1. **Critical-path gate issues** in the earliest gating layer — "These gate all downstream work"
+2. **Active milestone issues** not yet started — "Current planning unit has open work"
+3. **Bugs** (`bug` label) not in a milestone — "Bugs accumulate friction"
+4. **High-value labels** (`budget-critical`, `app-independence`) not in a milestone — "Labeled priorities without a planning home"
+5. **Earliest-component backlog** without milestones — "Candidates for the next planning unit"
+
+Each recommendation: one sentence with specific issue numbers.
+
+## Step 9: Closing Note
+
+End with: "This is a read-only summary. To act on any item, discuss it explicitly."
+
+## Rules
+
+- **Read-only**: Never relabel, close, or modify issues autonomously
+- **Three API calls only**: All grouping and analysis happens client-side from Step 1 results
+- **Critical-path first**: The most important constraint always surfaces at the top
+- **No auto-invocation**: Never invoke other skills (e.g., `/backlog-review`) from within this skill. Suggestions to run other skills are text recommendations for the user to act on

--- a/.claude/skills/project-summary/SKILL.md
+++ b/.claude/skills/project-summary/SKILL.md
@@ -41,6 +41,7 @@ For each issue from Command A, assign a component in two passes:
 |---|---|
 | `app-independence` | **app** |
 | `github_actions` | **infra** |
+| `developer-experience` | **dx** |
 
 If an issue matches a label rule, assign that component and skip Pass 2 for that issue.
 
@@ -97,7 +98,7 @@ If no open milestones exist, state: "No active milestones."
 
 Header: `## Component Inventory`
 
-For each component in dependency order (`core`, `api`, `mcp`, `app`, `infra`):
+For each component in dependency order (`core`, `api`, `mcp`, `app`, `infra`, `dx`):
 
 ```markdown
 ### component — N open


### PR DESCRIPTION
## Overview

The purpose of this change is to add three Claude Code skills that provide structured project management — session orientation, backlog grooming, and milestone planning. This represents an incremental improvement that replaces ad-hoc `gh issue list` exploration with repeatable, layered workflows adapted from the emergent-sports project's skill hierarchy.

| Layer | Skill | Role |
|---|---|---|
| Orientation | `/project-summary` | Where are we now? |
| Analysis | `/backlog-review` | What's in the backlog? |
| Planning | `/milestone-lifecycle` | What should we do next? |

All three skills share a two-pass component classification heuristic (label match first, then title keywords) that maps issues to Finch's architectural layers (core, api, mcp, app, infra, dx). Each was tested by invocation during development, with refinements applied based on observed classification accuracy and structural gaps.

### Key design decisions

- **Label-first classification**: Labels (`app-independence`, `github_actions`, `developer-experience`) take precedence over title keyword matching to prevent misclassification when titles mention cross-cutting terms
- **Dependency graph gate logic**: Uses Finch's core → api → mcp/app dependency chain instead of explicit `critical-path` labels
- **No deferred/tracking-issue concepts**: Omitted features that depend on labels Finch doesn't have (`deferred`, `epic`, `handoff`)
- **Generic terminology**: Avoids craft discipline vocabulary in public repo files
- **Phased approval gates**: `/milestone-lifecycle` proposes `gh` commands but never auto-executes — every mutation requires explicit user confirmation

Closes #49
Closes #50
Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)