### PR TITLE
feat(rules): supply PR-lifecycle conventions and adopt a changelog

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -1,9 +1,46 @@
 # CI Conventions
 
-## Build Verification
+The CI workflow runs a build check (plus Go test and lint). Catching failures locally avoids a slow push-wait-fail cycle. The checks below are scoped by which part of the tree a change touches.
 
-ALWAYS build the Qt app (`just build-app`) before pushing changes to `app/` files. The CI workflow only runs a build check — catching compilation errors locally avoids a slow push-wait-fail cycle.
+## Local Checks by Change Area
 
-## Go Checks
+Run the checks matching the files a change touches before pushing:
 
-ALWAYS run `just test` and `just lint` before pushing changes to Go modules (`core/`, `daemon/`, `mcp/`).
+- **Go modules** (`core/`, `daemon/`, `mcp/`) — `just test` and `just lint`.
+- **Qt app** (`app/`) — `just build-app`. CI only runs a build check for the app, so a local build is the fast feedback path.
+- **Protobuf** (`proto/`) — `just proto` to regenerate. Generated code lives in `daemon/gen/` and is not committed, so it must regenerate cleanly.
+
+This list is the single source of truth for the supplies below — they reference it rather than restating commands.
+
+## Pre-Merge Checks
+
+(extension point: `pre-merge-checks`)
+
+Before merging a PR, run the checks from "Local Checks by Change Area" matching the changed files. Surface any failure as a blocker and resolve it before proceeding.
+
+## Readiness Checks
+
+(extension point: `pr-readiness-checks`)
+
+When reporting PR health, run the checks from "Local Checks by Change Area" matching the changed files and report each result. Also confirm no generated code (`daemon/gen/`) is tracked in the diff.
+
+## Waste Patterns
+
+(extension point: `pr-waste-patterns`)
+
+Beyond the conflict-marker baseline, scan added lines for:
+
+- Debug output left behind — `fmt.Println` / `log.Println` used for ad-hoc tracing.
+- Unaddressed markers — `TODO`, `FIXME`, `HACK`.
+- Test shortcuts — `t.Skip(...)` or focused/disabled tests committed unintentionally.
+- `//nolint` directives without a trailing reason.
+- Committed generated code under `daemon/gen/`.
+
+## Stale-PR Smoke Tests
+
+(extension point: `stale-pr-smoke-tests`)
+
+After merging the base branch into a stale branch, run beyond the standard test/lint pass:
+
+- `just proto` then `just all` — a clean regenerate-and-build is the only signal for proto or generated-code drift the merge may have introduced (generated code is not committed).
+- `just build-app` when `app/` is touched.

--- a/.claude/rules/pr-conventions.md
+++ b/.claude/rules/pr-conventions.md
@@ -1,0 +1,73 @@
+# PR and Commit Conventions
+
+How pull requests, commits, and the changelog work in this project.
+
+## PR Descriptions
+
+(extension point: `pr-description-format`)
+
+Structure a PR body as:
+
+- **Overview** — the purpose: what the change accomplishes and why. Lead with this.
+- **How it works** (optional) — only for non-obvious mechanics a reviewer cannot infer from the diff.
+- **Issue references** — closing keywords (`Closes #N`); repeat the keyword for each issue (`Closes #1, closes #2`).
+
+Avoid:
+
+- Enumerating the diff file-by-file — the diff already shows what changed.
+- Narrating the drafting journey ("earlier this did X, then I changed it").
+- Scaffolding headers with no content under them.
+- Hard-wrapping prose at a fixed column. Write one long line per paragraph and let the renderer wrap.
+
+## Commit Messages
+
+(extension point: `squash-commit-format`)
+
+Conventional Commits: `type(scope): subject`.
+
+- **Types**: `feat`, `fix`, `refactor`, `docs`, `build`, `ci`, `test`, `chore`.
+- **Scopes** (this project's layers): `core`, `daemon`, `mcp`, `api`, `proto`, `app`, `skills`, `rules`, `ci`, `build`, `deps`.
+- **Body**: prose explaining *why* the change was made — the motivation, constraint, or problem it solves — not a restatement of the diff.
+- **Issue references**: `Closes #N` (or `Related to #N`); repeat the keyword per issue.
+
+## Changelog
+
+(extension point: `changelog-convention`)
+
+This project keeps a changelog in `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+A PR requires a changelog entry when it makes a **user-facing change**:
+
+- New, changed, or removed gRPC RPCs or MCP tools.
+- Observable behavior changes (projection results, validation, output shape).
+- Bug fixes that affect user-visible results.
+- Schema or migration changes that affect stored data.
+
+No entry is needed for: internal refactors with no observable effect, test-only changes, CI/build/tooling, documentation, or agent rules and skills.
+
+Add the entry under `## [Unreleased]` in the matching category — `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, or `Security`. Keep it concise, user-facing, and present-tense.
+
+## Post-Merge Next Work
+
+(extension point: `post-merge-next-work-suggestions`)
+
+After a merge, suggest re-orienting with the `/project-summary` skill, or `/milestone-lifecycle` when the active milestone is at or near completion.
+
+## Branch Freshness
+
+(extension point: `freshness-response-policy`)
+
+When assessing how far a branch trails its base:
+
+- **Up to date** — proceed.
+- **Modestly behind** — note it; refreshing is optional.
+- **Significantly behind, or conflicts are likely** — merge the base branch in first (this project merges, never rebases) before merging the PR.
+
+## Code-Audit Fix vs. Defer
+
+(extension point: `code-audit-practice`)
+
+When acting on review findings:
+
+- **Fix in place** when the finding is small, localized, and within the PR's stated purpose.
+- **Defer to a GitHub issue** when addressing it would expand the PR's scope or is tangential to its purpose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]


### PR DESCRIPTION
## Overview

Finch's PR-lifecycle skills are environment-agnostic: they read named project conventions ("extension points") so they run with project-accurate behavior, and fall through to generic defaults when a project supplies none. Finch supplied nothing, so its pre-merge checks, PR-description shape, commit format, and related decisions were all running on defaults. This adds the project-level supplies Finch actually exercises and adopts Keep a Changelog so user-facing changes are tracked going forward.

## How it works

Two always-loaded rule files carry the supplies. `ci.md` states the local check commands once — scoped by which part of the tree a change touches — and points the pre-merge, readiness, waste-pattern, and stale-PR-smoke-test supplies at that single list, so the commands never drift across sections. `pr-conventions.md` supplies the PR-description and commit-message shape, the changelog convention, post-merge orientation, branch-freshness handling, and code-audit fix-vs-defer criteria. A new root `CHANGELOG.md` provides the Keep a Changelog skeleton.

This change is itself rules-and-tooling, which the new changelog convention classifies as not warranting an entry — so `[Unreleased]` stays empty until the first user-facing change.
