### PR TITLE
feat(app): add desktop entry, icon, and install target for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ just install-mcp
 
 This builds the MCP binary and copies it to `~/.local/bin/`.
 
+### Install the desktop app
+
+```bash
+just install-app
+```
+
+This builds the Qt app, copies the `finch-app` binary to `~/.local/bin/`, installs the desktop entry to `~/.local/share/applications/`, and the icon to `~/.local/share/icons/hicolor/scalable/apps/`. Finch then appears in the desktop application launcher (e.g. KDE Plasma's Kickoff). The app connects to the daemon, so install and start the service first.
+
 ### Manual
 
 ```bash

--- a/app/finch.desktop
+++ b/app/finch.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Version=1.5
+Name=Finch
+GenericName=Personal Finance Projection
+Comment=Project and track personal finances
+Exec=finch-app
+Icon=finch
+Terminal=false
+Categories=Office;Finance;Qt;
+Keywords=finance;budget;projection;money;
+StartupNotify=true

--- a/app/finch.svg
+++ b/app/finch.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256" role="img" aria-label="Finch">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2f9e7e"/>
+      <stop offset="1" stop-color="#1f6f63"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="8" y="8" width="240" height="240" rx="56" fill="url(#bg)"/>
+
+  <!-- rising projection line (behind the bird) -->
+  <g fill="none" stroke="#ffd166" stroke-width="10" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="56,200 96,184 132,196 200,148"/>
+  </g>
+  <circle cx="200" cy="148" r="10" fill="#ffd166"/>
+
+  <!-- finch silhouette, perched and facing right -->
+  <g fill="#f7f3e3">
+    <path d="M52 150
+             C58 132 76 126 96 130
+             C98 104 122 84 150 84
+             C176 84 196 102 196 128
+             C196 154 174 174 144 174
+             C120 174 100 164 92 150
+             C80 160 64 162 52 150 Z"/>
+    <!-- beak -->
+    <path d="M194 116 l30 10 -30 12 z"/>
+    <!-- tail -->
+    <path d="M96 148 l-44 26 18 4 30 -16 z"/>
+  </g>
+
+  <!-- wing accent -->
+  <path d="M104 130 C128 124 156 128 176 140 C152 158 120 156 100 142 Z" fill="#2f9e7e"/>
+  <!-- eye -->
+  <circle cx="172" cy="116" r="7" fill="#1f6f63"/>
+</svg>

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -1,4 +1,5 @@
 #include <QApplication>
+#include <QIcon>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QUrl>
@@ -25,6 +26,10 @@ int main(int argc, char* argv[])
     QApplication app(argc, argv);
     app.setApplicationName("Finch");
     app.setApplicationVersion("0.1.0");
+    // Wayland derives a window's app_id from the desktop file name; matching it to
+    // finch.desktop is what lets the compositor resolve the taskbar/window icon.
+    app.setDesktopFileName(QStringLiteral("finch"));
+    app.setWindowIcon(QIcon::fromTheme(QStringLiteral("finch")));
 
     qmlRegisterUncreatableType<FinchClient>("Finch", 1, 0, "FinchClient",
                                             "FinchClient is not creatable from QML");

--- a/justfile
+++ b/justfile
@@ -79,6 +79,18 @@ install-mcp: build-mcp
     mkdir -p ~/.local/bin
     cp mcp/finch-mcp ~/.local/bin/finch-mcp.tmp && mv ~/.local/bin/finch-mcp.tmp ~/.local/bin/finch-mcp
 
+# Uses cp+mv atomic replacement (see install-service for rationale).
+# Install the Qt desktop app: binary, desktop entry, and icon (Linux / XDG)
+install-app: build-app
+    mkdir -p ~/.local/bin
+    cp app/build/finch-app ~/.local/bin/finch-app.tmp && mv ~/.local/bin/finch-app.tmp ~/.local/bin/finch-app
+    mkdir -p ~/.local/share/applications
+    cp app/finch.desktop ~/.local/share/applications/
+    mkdir -p ~/.local/share/icons/hicolor/scalable/apps
+    cp app/finch.svg ~/.local/share/icons/hicolor/scalable/apps/finch.svg
+    touch ~/.local/share/icons/hicolor
+    update-desktop-database ~/.local/share/applications
+
 # Install git hooks via lefthook
 hooks:
     lefthook install

--- a/justfile
+++ b/justfile
@@ -89,7 +89,8 @@ install-app: build-app
     mkdir -p ~/.local/share/icons/hicolor/scalable/apps
     cp app/finch.svg ~/.local/share/icons/hicolor/scalable/apps/finch.svg
     touch ~/.local/share/icons/hicolor
-    update-desktop-database ~/.local/share/applications
+    # desktop-file-utils may be absent on minimal systems; skip rather than fail the install
+    if command -v update-desktop-database >/dev/null 2>&1; then update-desktop-database ~/.local/share/applications; fi
 
 # Install git hooks via lefthook
 hooks:


### PR DESCRIPTION
## Overview

Finch's daemon and MCP server already install to `~/.local/bin/`, but the Qt app had only a build step — its binary stayed in the gitignored build directory with no way to reach the desktop application launcher. This adds the missing Linux desktop integration: a `just install-app` target that installs the app binary, a desktop entry, and a scalable icon to the standard per-user XDG locations, so Finch appears in the launcher (e.g. KDE Plasma's Kickoff) with its own icon in the menu, taskbar, and window.

## How it works

The app advertises its Wayland `app_id` via `setDesktopFileName("finch")`, which is how the compositor links a running window to `finch.desktop` and resolves the taskbar/window icon from `Icon=finch` — without it the `app_id` defaulted to the binary name (`finch-app`) and the icon fell back to the Wayland default. `install-app` is kept separate from the aggregate `just install` (daemon + MCP) so the headless path doesn't pull in Qt build dependencies.

Related to #31.
