### PR TITLE
build(dx): add just tidy recipe to reconcile all Go modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ just test-mcp     # MCP server only
 
 ## Go Module Dependencies
 
-The daemon and mcp modules depend on core via `replace` directives pointing to `../core`.
+The daemon and mcp modules depend on core via `replace` directives pointing to `../core`. Because they resolve core's full dependency graph through those directives, a dependency change that shifts core's transitive versions (e.g. a Dependabot bump) leaves their `go.sum` stale. Run `just tidy` to reconcile all three modules after any such change.
 
 ## CI Notes
 

--- a/justfile
+++ b/justfile
@@ -52,6 +52,12 @@ fmt:
     cd daemon && go fmt ./...
     cd mcp && go fmt ./...
 
+# Reconcile go.mod/go.sum across all Go modules (run after a dependency change)
+tidy:
+    cd core && go mod tidy
+    cd daemon && go mod tidy
+    cd mcp && go mod tidy
+
 # Remove build artifacts
 clean:
     rm -f daemon/finch-daemon mcp/finch-mcp


### PR DESCRIPTION
## Overview

Finishing a Dependabot bump to a `core` dependency (#60) exposed a recurring cost. Because `daemon` and `mcp` resolve core's full dependency graph through their `replace ../core` directives, a change that shifts core's transitive versions leaves their `go.sum` stale and breaks CI — surfacing as an opaque `no go files to analyze` lint failure that doesn't point at the cause. Completing such a bump means remembering to run `go mod tidy` in each dependent module by hand.

This adds a `just tidy` recipe that runs `go mod tidy` across all three modules — core first, so each dependent reconciles against a settled upstream — making the fix one command. A pointer in CLAUDE.md's Go Module Dependencies section routes the next maintainer to it at the point of cause, so the recipe is discoverable rather than forgotten.
