### PR TITLE
docs(rules): document public-surface convention for tracked files

### DIFF
--- a/.claude/rules/public-surface.md
+++ b/.claude/rules/public-surface.md
@@ -1,0 +1,23 @@
+# Public Surface Conventions
+
+finch is a public repository. Everything checked in is read by contributors and tools that do not share the maintainer's personal environment — other people's editors, review bots, and agents that load only what the repo itself ships. Tracked files must therefore stand on their own.
+
+## No Private Tooling References
+
+Do NOT name personal or environment-specific tooling in tracked files. Such a reference resolves only inside one maintainer's setup and dangles for everyone else:
+
+- Personal agent skills invoked as slash-commands (e.g. a `/personal-skill` that lives in someone's own config rather than in this repo).
+- Personal MCP servers (e.g. an external project-management backend wired up in a personal environment).
+- The maintainer's private repositories, or literal personal home paths (`/home/<user>/...`).
+
+State the intent in plain English instead. If a piece of guidance currently lives only in personal tooling, copy the load-bearing content into the repo so the repo owns it.
+
+## What's Fine
+
+- **finch's own paths.** The application's runtime and config paths — `$XDG_RUNTIME_DIR/finch/...`, `~/.local/share/finch/...`, `FINCH_DB_PATH` — describe finch's behavior, not a person. Use them freely.
+- **finch's own in-repo skills.** Skills defined under `.claude/skills/` (e.g. the `mcp-reload` skill) ship with the repo and resolve for anyone who has it. Referencing them is fine.
+- **Named convention slots.** A slot written as `(extension point: \`name\`)` names an abstract contract, not a private tool, so it is fine to declare. The guidance supplied under each slot must read as a standalone project convention — a contributor with no personal tooling should understand it on its own.
+
+## Why
+
+finch's conventions must be legible to any contributor or agent — including review bots — without the maintainer's personal setup. A reference that only resolves inside one person's environment is noise to everyone else, and silently rots when that personal tooling changes.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,17 @@ Compare the files changed in the PR against what the PR description claims:
 
 **Assessment:** Post a pass/fail comment listing any discrepancies.
 
+### Check 3: No Private Tooling References
+
+finch is a public repository; tracked files must not reference tooling that resolves only in a maintainer's personal environment. Scan the added and changed lines for:
+- Agent slash-command skills that are not defined in this repo (personal skills from someone's own config).
+- Personal MCP servers, or the maintainer's private repositories.
+- Literal personal home paths (`/home/<user>/...`).
+
+Do NOT flag finch's own references: its runtime and config paths (`$XDG_RUNTIME_DIR/finch/...`, `~/.local/share/finch/...`, `FINCH_DB_PATH`), its own in-repo skills under `.claude/skills/`, or `(extension point: name)` slot declarations.
+
+**Assessment:** Post a pass/fail comment listing any private-tooling references found.
+
 ## Architecture Context
 
 Finch has four components communicating via gRPC over Unix socket:


### PR DESCRIPTION
## Overview

finch is a public repository, but the discipline of keeping personal tooling off its checked-in surface lived only in the maintainer's personal setup — not in the repo itself. The recent PM-skill consolidation enforced it in practice (scrubbing private skill names and removing a skill that named several), but the convention stayed unwritten, so a contributor or non-personal agent reading only what finch ships had no statement of it.

This adds a project rule stating that tracked files must not name personal tooling — out-of-repo agent skills, personal MCP servers, private repositories, or literal home paths — with carve-outs so finch's own runtime paths, its in-repo skills, and abstract `(extension point: name)` slots are not caught. The rule is self-contained: it teaches the patterns with generic placeholders rather than embedding any real private reference.

It also adds a "No Private Tooling References" check to the Copilot review instructions, so a leak is flagged at PR time on the external review surface — where an outside contributor's reference would actually land.
