### PR TITLE
feat(app): add account-creation form to the Qt app

### DIFF
--- a/.github/workflows/ci-qt.yml
+++ b/.github/workflows/ci-qt.yml
@@ -23,6 +23,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             qt6-base-dev qt6-declarative-dev qml6-module-qtquick-controls \
+            qml6-module-qtquick-templates \
             qml6-module-qtquick-layouts qml6-module-qtquick-window \
             qml6-module-qtqml-workerscript qml6-module-qtqml-models \
             qt6-charts-dev qml6-module-qtcharts \

--- a/.github/workflows/ci-qt.yml
+++ b/.github/workflows/ci-qt.yml
@@ -24,6 +24,7 @@ jobs:
           sudo apt-get install -y \
             qt6-base-dev qt6-declarative-dev qml6-module-qtquick-controls \
             qml6-module-qtquick-layouts \
+            qml6-module-qtqml-workerscript qml6-module-qtqml-models \
             qt6-charts-dev qml6-module-qtcharts \
             libqt6quicktest6 qml6-module-qttest \
             protobuf-compiler libprotobuf-dev libgrpc++-dev protobuf-compiler-grpc

--- a/.github/workflows/ci-qt.yml
+++ b/.github/workflows/ci-qt.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             qt6-base-dev qt6-declarative-dev qml6-module-qtquick-controls \
-            qml6-module-qtquick-layouts qml6-module-qt-labs-settings \
+            qml6-module-qtquick-layouts \
             qt6-charts-dev qml6-module-qtcharts \
             libqt6quicktest6 qml6-module-qttest \
             protobuf-compiler libprotobuf-dev libgrpc++-dev protobuf-compiler-grpc

--- a/.github/workflows/ci-qt.yml
+++ b/.github/workflows/ci-qt.yml
@@ -23,10 +23,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             qt6-base-dev qt6-declarative-dev qml6-module-qtquick-controls \
+            qml6-module-qtquick-layouts qml6-module-qt-labs-settings \
             qt6-charts-dev qml6-module-qtcharts \
+            libqt6quicktest6 qml6-module-qttest \
             protobuf-compiler libprotobuf-dev libgrpc++-dev protobuf-compiler-grpc
 
       - name: Build
         run: |
           cmake -S app -B app/build
           cmake --build app/build
+
+      # The Qt Quick Test suite (tst_*.qml) runs headless via the offscreen platform,
+      # set on the test in CMake. qt6-declarative-dev ships the QuickTest link symlink;
+      # libqt6quicktest6 + qml6-module-qttest provide the runtime lib and QML module.
+      - name: Test
+        run: ctest --test-dir app/build --output-on-failure

--- a/.github/workflows/ci-qt.yml
+++ b/.github/workflows/ci-qt.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             qt6-base-dev qt6-declarative-dev qml6-module-qtquick-controls \
-            qml6-module-qtquick-layouts \
+            qml6-module-qtquick-layouts qml6-module-qtquick-window \
             qml6-module-qtqml-workerscript qml6-module-qtqml-models \
             qt6-charts-dev qml6-module-qtcharts \
             libqt6quicktest6 qml6-module-qttest \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- Qt app: create accounts through a UI form (previously only via MCP tools).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ sudo apt install \
   protobuf-compiler protobuf-compiler-grpc libprotobuf-dev libgrpc++-dev \
   qt6-base-dev qt6-declarative-dev qt6-charts-dev \
   libqt6quicktest6 \
-  qml6-module-qtquick-controls qml6-module-qtquick-layouts qml6-module-qtquick-window \
+  qml6-module-qtquick-controls qml6-module-qtquick-templates \
+  qml6-module-qtquick-layouts qml6-module-qtquick-window \
   qml6-module-qtqml-workerscript qml6-module-qtqml-models \
   qml6-module-qtcharts qml6-module-qt-labs-settings qml6-module-qttest
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ sudo apt install \
   protobuf-compiler protobuf-compiler-grpc libprotobuf-dev libgrpc++-dev \
   qt6-base-dev qt6-declarative-dev qt6-charts-dev \
   libqt6quicktest6 \
-  qml6-module-qtquick-controls qml6-module-qtquick-layouts \
+  qml6-module-qtquick-controls qml6-module-qtquick-layouts qml6-module-qtquick-window \
   qml6-module-qtqml-workerscript qml6-module-qtqml-models \
   qml6-module-qtcharts qml6-module-qt-labs-settings qml6-module-qttest
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ sudo apt install \
   qt6-base-dev qt6-declarative-dev qt6-charts-dev \
   libqt6quicktest6 \
   qml6-module-qtquick-controls qml6-module-qtquick-layouts \
+  qml6-module-qtqml-workerscript qml6-module-qtqml-models \
   qml6-module-qtcharts qml6-module-qt-labs-settings qml6-module-qttest
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ packages are loaded at **runtime** — both to run the app and to run its Qt Qui
 (`just test-app`). A build can succeed but the app or tests fail to start if a runtime QML
 module is missing. `libqt6quicktest6` is the Qt Quick Test runtime library (its build-time
 link symlink ships in `qt6-declarative-dev`); `qml6-module-qttest` is the matching QML module.
-When you change a build or runtime dependency, update both this list and the apt packages in
-`.github/workflows/ci-qt.yml` (CI installs the same Qt/protobuf packages; `cmake` is
-preinstalled on the GitHub runner, so it is not in CI's apt list).
+CI (`.github/workflows/ci-qt.yml`) builds the app and runs the headless test suite, so it
+installs the build- and test-time subset of this list — it omits the modules only a full app
+launch needs (e.g. `qml6-module-qt-labs-settings`), and `cmake` is preinstalled on the GitHub
+runner. When you change a dependency, update this list and CI's apt list as the change
+warrants.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,23 @@ mise install
 The C++/Qt app requires system-level packages. On Ubuntu/Debian:
 
 ```bash
-sudo apt install cmake qt6-base-dev qt6-declarative-dev qml6-module-qtquick-controls \
-  qt6-charts-dev qml6-module-qtcharts \
-  protobuf-compiler libprotobuf-dev libgrpc++-dev protobuf-compiler-grpc
+sudo apt install \
+  cmake \
+  protobuf-compiler protobuf-compiler-grpc libprotobuf-dev libgrpc++-dev \
+  qt6-base-dev qt6-declarative-dev qt6-charts-dev \
+  libqt6quicktest6 \
+  qml6-module-qtquick-controls qml6-module-qtquick-layouts \
+  qml6-module-qtcharts qml6-module-qt-labs-settings qml6-module-qttest
 ```
+
+The split matters: the `*-dev` packages are needed to **build**, while the `qml6-module-*`
+packages are loaded at **runtime** — both to run the app and to run its Qt Quick Test suite
+(`just test-app`). A build can succeed but the app or tests fail to start if a runtime QML
+module is missing. `libqt6quicktest6` is the Qt Quick Test runtime library (its build-time
+link symlink ships in `qt6-declarative-dev`); `qml6-module-qttest` is the matching QML module.
+When you change a build or runtime dependency, update both this list and the apt packages in
+`.github/workflows/ci-qt.yml` (CI installs the same Qt/protobuf packages; `cmake` is
+preinstalled on the GitHub runner, so it is not in CI's apt list).
 
 ## Getting Started
 
@@ -44,6 +57,7 @@ just proto         # Generate protobuf Go code
 just all           # Build daemon and MCP server
 just build-app     # Build the Qt desktop app
 just test          # Run all Go tests
+just test-app      # Build and run the Qt app's Qt Quick Test suite
 just lint          # Run golangci-lint on all modules
 ```
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -84,9 +84,21 @@ enable_testing()
 
 add_executable(tst_createaccountform tests/tst_createaccountform.cpp)
 
-# QUICK_TEST_MAIN scans this directory for tst_*.qml at runtime. The specs load
-# the real form via a directory import ("../qml"), so the component under test is
-# the exact file the app ships — not a stub.
+# A test-only QML module holding just the real shipping form and the mock client.
+# Scoping the module to these two self-contained files (rather than importing the whole
+# qml/ directory) keeps the test's runtime module dependencies down to what the form
+# itself imports — it does not drag in Main.qml/BalanceChart.qml and their transitive
+# modules (QtCharts, Qt.labs.settings, QtQml.WorkerScript). CreateAccountForm.qml is the
+# exact file the app ships, so the component under test is real, not a stub.
+qt_add_qml_module(tst_createaccountform
+    URI FinchFormTest
+    VERSION 1.0
+    QML_FILES
+        qml/CreateAccountForm.qml
+        tests/MockFinchClient.qml
+)
+
+# QUICK_TEST_MAIN scans this directory for tst_*.qml at runtime.
 target_compile_definitions(tst_createaccountform PRIVATE
     QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests")
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -111,6 +111,7 @@ target_link_libraries(tst_createaccountform PRIVATE
 
 add_test(NAME tst_createaccountform COMMAND tst_createaccountform)
 
-# Run headless so the suite works in CI and over SSH (no display required).
+# Run headless (no display required) and pin the dependency-light Basic Controls style,
+# so the test is deterministic across machines and CI needn't carry other styles' modules.
 set_tests_properties(tst_createaccountform PROPERTIES
-    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_CONTROLS_STYLE=Basic")

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -73,5 +73,32 @@ endif()
 qt_add_qml_module(finch-app
     URI Finch
     VERSION 1.0
-    QML_FILES qml/Main.qml qml/BalanceChart.qml
+    QML_FILES qml/Main.qml qml/BalanceChart.qml qml/CreateAccountForm.qml
 )
+
+# --- Qt Quick Test ---------------------------------------------------------
+# Kept in its own find_package so the production app build above does not depend
+# on the test toolchain being installed.
+find_package(Qt6 REQUIRED COMPONENTS QuickTest)
+enable_testing()
+
+add_executable(tst_createaccountform tests/tst_createaccountform.cpp)
+
+# QUICK_TEST_MAIN scans this directory for tst_*.qml at runtime. The specs load
+# the real form via a directory import ("../qml"), so the component under test is
+# the exact file the app ships — not a stub.
+target_compile_definitions(tst_createaccountform PRIVATE
+    QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests")
+
+target_link_libraries(tst_createaccountform PRIVATE
+    Qt6::Quick
+    Qt6::QuickControls2
+    Qt6::QuickTest
+    Qt6::Qml
+)
+
+add_test(NAME tst_createaccountform COMMAND tst_createaccountform)
+
+# Run headless so the suite works in CI and over SSH (no display required).
+set_tests_properties(tst_createaccountform PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -77,8 +77,10 @@ qt_add_qml_module(finch-app
 )
 
 # --- Qt Quick Test ---------------------------------------------------------
-# Kept in its own find_package so the production app build above does not depend
-# on the test toolchain being installed.
+# QuickTest has its own find_package so Qt6::QuickTest is linked only into the
+# test target below, never into finch-app. Configuring the project does still
+# require the test toolchain (the README lists the packages); the test target is
+# always built — `just build-app` limits itself to the finch-app target.
 find_package(Qt6 REQUIRED COMPONENTS QuickTest)
 enable_testing()
 

--- a/app/qml/CreateAccountForm.qml
+++ b/app/qml/CreateAccountForm.qml
@@ -1,0 +1,107 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// Self-contained account-creation form. It depends only on an injected `client`
+// exposing createAccount(name, type), a createAccountInProgress property, and
+// accountCreated/accountCreateFailed signals — the production FinchClient in the app,
+// a mock in tests. Deliberately importing no Finch C++ type keeps it instantiable by
+// the Qt Quick Test harness with a mock client and no daemon.
+Item {
+    id: form
+
+    // Injected by the host: Main.qml passes finchClient; tests pass a mock.
+    required property var client
+
+    // Public, test-facing surface — specs drive the form through these rather than
+    // reaching into private control ids.
+    property alias nameText: nameField.text
+    property alias typeIndex: typeCombo.currentIndex
+    readonly property int selectedType: typeCombo.currentValue
+    property alias errorText: errorLabel.text
+
+    // canSubmit is the single validation predicate the button and the specs share.
+    // selectedType > 0 rejects the UNSPECIFIED sentinel (index 0).
+    readonly property bool canSubmit:
+        nameField.text.trim().length > 0
+        && selectedType > 0
+        && !(client && client.createAccountInProgress)
+
+    // Emitted once the daemon confirms creation; the host closes the dialog on it.
+    signal created(string id)
+
+    implicitWidth: 360
+    implicitHeight: layout.implicitHeight
+
+    function submit() {
+        if (!canSubmit)
+            return
+        errorLabel.text = ""
+        client.createAccount(nameField.text.trim(), selectedType)
+    }
+
+    Connections {
+        target: form.client
+        function onAccountCreated(id) {
+            nameField.text = ""
+            typeCombo.currentIndex = 0
+            errorLabel.text = ""
+            form.created(id)
+        }
+        function onAccountCreateFailed(message) {
+            errorLabel.text = message
+        }
+    }
+
+    ColumnLayout {
+        id: layout
+        anchors.fill: parent
+        spacing: 12
+
+        Label { text: "Account name" }
+        TextField {
+            id: nameField
+            Layout.fillWidth: true
+            placeholderText: "e.g. Everyday Checking"
+            // Drop a stale error the moment the user edits the name.
+            onTextChanged: errorLabel.text = ""
+        }
+
+        Label { text: "Account type" }
+        ComboBox {
+            id: typeCombo
+            Layout.fillWidth: true
+            textRole: "label"
+            valueRole: "value"
+            // Index 0 is an unselected sentinel (value 0 == UNSPECIFIED) so the form
+            // starts invalid until the user picks a real type. Values mirror the proto
+            // AccountType enum (Checking=1 … Brokerage=7).
+            model: [
+                { label: "Select type…",  value: 0 },
+                { label: "Checking",       value: 1 },
+                { label: "Savings",        value: 2 },
+                { label: "Credit Card",    value: 3 },
+                { label: "Auto Loan",      value: 4 },
+                { label: "Personal Loan",  value: 5 },
+                { label: "Line of Credit", value: 6 },
+                { label: "Brokerage",      value: 7 }
+            ]
+        }
+
+        Label {
+            id: errorLabel
+            Layout.fillWidth: true
+            color: "#c0392b"
+            wrapMode: Text.WordWrap
+            visible: text.length > 0
+        }
+
+        Button {
+            id: submitButton
+            text: (form.client && form.client.createAccountInProgress)
+                  ? "Creating…" : "Create account"
+            enabled: form.canSubmit
+            onClicked: form.submit()
+        }
+    }
+}

--- a/app/qml/Main.qml
+++ b/app/qml/Main.qml
@@ -34,6 +34,13 @@ ApplicationWindow {
             Item { Layout.fillWidth: true }
 
             Button {
+                text: "New Account"
+                // Account creation needs a live daemon to write to.
+                enabled: finchClient.connectionState === FinchClient.Connected
+                onClicked: createAccountDialog.open()
+            }
+
+            Button {
                 text: finchClient.pingInProgress ? "Pinging…" : "Ping Daemon"
                 enabled: !finchClient.pingInProgress
                 onClicked: finchClient.ping()
@@ -73,6 +80,30 @@ ApplicationWindow {
             anchors.centerIn: parent
             running: finchClient.pingInProgress
                      && finchClient.timeSeriesEmpty
+        }
+    }
+
+    Dialog {
+        id: createAccountDialog
+        title: "New Account"
+        anchors.centerIn: Overlay.overlay
+        modal: true
+        width: 420
+        // The embedded form carries its own Create button; no dialog standard buttons.
+        standardButtons: Dialog.NoButton
+
+        CreateAccountForm {
+            id: createAccountForm
+            width: parent.width
+            client: finchClient
+            onCreated: createAccountDialog.close()
+        }
+
+        // Start each opening from a clean slate.
+        onOpened: {
+            createAccountForm.nameText = ""
+            createAccountForm.typeIndex = 0
+            createAccountForm.errorText = ""
         }
     }
 

--- a/app/qml/Main.qml
+++ b/app/qml/Main.qml
@@ -91,6 +91,11 @@ ApplicationWindow {
         width: 420
         // The embedded form carries its own Create button; no dialog standard buttons.
         standardButtons: Dialog.NoButton
+        // Don't let Escape/click-outside dismiss the dialog mid-create — a failure's
+        // error is shown inside the form, so closing it would swallow that feedback.
+        closePolicy: finchClient.createAccountInProgress
+                     ? Popup.NoAutoClose
+                     : (Popup.CloseOnEscape | Popup.CloseOnPressOutside)
 
         CreateAccountForm {
             id: createAccountForm

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -25,6 +25,8 @@ FinchClient::FinchClient(const QString& socketPath, QObject* parent)
             this, &FinchClient::onPingFinished);
     connect(&m_accountsWatcher, &QFutureWatcher<ListAccountsResult>::finished,
             this, &FinchClient::onListAccountsFinished);
+    connect(&m_createAccountWatcher, &QFutureWatcher<CreateAccountResult>::finished,
+            this, &FinchClient::onCreateAccountFinished);
     connect(&m_timeSeriesWatcher, &QFutureWatcher<TimeSeriesResult>::finished,
             this, &FinchClient::onTimeSeriesFinished);
 }
@@ -33,6 +35,7 @@ FinchClient::~FinchClient()
 {
     m_pingWatcher.waitForFinished();
     m_accountsWatcher.waitForFinished();
+    m_createAccountWatcher.waitForFinished();
     m_timeSeriesWatcher.waitForFinished();
 }
 
@@ -97,6 +100,62 @@ void FinchClient::listAccounts()
     });
 
     m_accountsWatcher.setFuture(future);
+}
+
+void FinchClient::createAccount(const QString& name, int accountType)
+{
+    // Authoritative re-entrancy guard: the QML submit-disable is cosmetic, so without
+    // this a rapid double-click could fire two CreateAccount RPCs (the daemon does not
+    // prevent duplicate names) and create two accounts.
+    if (m_createAccountInProgress)
+        return;
+
+    m_createAccountInProgress = true;
+    emit createAccountInProgressChanged();
+
+    auto stub = m_stub.get();
+    std::string accountName = name.toStdString();
+    auto future = QtConcurrent::run([stub, accountName, accountType]() -> CreateAccountResult {
+        grpc::ClientContext context;
+        context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(5));
+
+        finch::v1::CreateAccountRequest request;
+        request.set_name(accountName);
+        request.set_type(static_cast<finch::v1::AccountType>(accountType));
+
+        finch::v1::CreateAccountResponse response;
+        grpc::Status status = stub->CreateAccount(&context, request, &response);
+
+        CreateAccountResult result;
+        if (status.ok()) {
+            result.ok = true;
+            result.id = QString::fromStdString(response.account().id());
+            result.name = QString::fromStdString(response.account().name());
+            return result;
+        }
+
+        // Surface the daemon's validation message verbatim (it is user-facing and
+        // specific); for everything else show a generic message rather than a raw
+        // low-level gRPC string. status only lives on this worker thread, so the
+        // message is copied into the result and emitted from the GUI-thread slot.
+        switch (status.error_code()) {
+        case grpc::StatusCode::INVALID_ARGUMENT:
+            result.errorMessage = QString::fromStdString(status.error_message());
+            break;
+        case grpc::StatusCode::UNAVAILABLE:
+            result.errorMessage = QStringLiteral("Could not reach the daemon.");
+            break;
+        case grpc::StatusCode::DEADLINE_EXCEEDED:
+            result.errorMessage = QStringLiteral("The request timed out. Please try again.");
+            break;
+        default:
+            result.errorMessage = QStringLiteral("Could not create the account. Please try again.");
+            break;
+        }
+        return result;
+    });
+
+    m_createAccountWatcher.setFuture(future);
 }
 
 void FinchClient::fetchTimeSeries(const QString& fromDate, const QString& toDate,
@@ -250,6 +309,30 @@ void FinchClient::onListAccountsFinished()
         m_accounts.clear();
     }
     emit accountsChanged();
+}
+
+void FinchClient::onCreateAccountFinished()
+{
+    auto result = m_createAccountWatcher.result();
+
+    m_createAccountInProgress = false;
+    emit createAccountInProgressChanged();
+
+    if (!result.ok) {
+        emit accountCreateFailed(result.errorMessage);
+        return;
+    }
+
+    // Append the created account to the model directly rather than refreshing via
+    // listAccounts(): that method's own in-progress guard would silently drop a refresh
+    // issued while a list is already in flight, leaving a successful create invisible.
+    QVariantMap entry;
+    entry["id"] = result.id;
+    entry["name"] = result.name;
+    m_accounts.append(entry);
+    emit accountsChanged();
+
+    emit accountCreated(result.id);
 }
 
 void FinchClient::onPingFinished()

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -303,6 +303,15 @@ void FinchClient::onListAccountsFinished()
     m_accountsLoading = false;
     emit accountsLoadingChanged();
 
+    // A create completed while this fetch was in flight, so this result predates the new
+    // account and would clobber the entry appended in onCreateAccountFinished. Discard the
+    // stale list and re-fetch the authoritative one (which now includes the new account).
+    if (m_accountsRefreshPending) {
+        m_accountsRefreshPending = false;
+        listAccounts();
+        return;
+    }
+
     if (result.ok) {
         m_accounts = result.accounts;
     } else {
@@ -331,6 +340,11 @@ void FinchClient::onCreateAccountFinished()
     entry["name"] = result.name;
     m_accounts.append(entry);
     emit accountsChanged();
+
+    // If a listAccounts() is in flight, its result predates this create and would
+    // overwrite the appended entry; flag it so onListAccountsFinished reconciles.
+    if (m_accountsLoading)
+        m_accountsRefreshPending = true;
 
     emit accountCreated(result.id);
 }

--- a/app/src/finchclient.h
+++ b/app/src/finchclient.h
@@ -115,6 +115,7 @@ private:
     PingResult m_pendingResult;
     QVariantList m_accounts;
     bool m_accountsLoading = false;
+    bool m_accountsRefreshPending = false;
     QFutureWatcher<ListAccountsResult> m_accountsWatcher;
     bool m_createAccountInProgress = false;
     QFutureWatcher<CreateAccountResult> m_createAccountWatcher;

--- a/app/src/finchclient.h
+++ b/app/src/finchclient.h
@@ -24,6 +24,13 @@ struct ListAccountsResult {
     QVariantList accounts;
 };
 
+struct CreateAccountResult {
+    bool ok = false;
+    QString id;
+    QString name;
+    QString errorMessage;
+};
+
 struct TimeSeriesPoint {
     qint64 msecsSinceEpoch;
     double balance;
@@ -41,6 +48,7 @@ class FinchClient : public QObject {
     Q_PROPERTY(bool pingInProgress READ pingInProgress NOTIFY pingInProgressChanged)
     Q_PROPERTY(QVariantList accounts READ accounts NOTIFY accountsChanged)
     Q_PROPERTY(bool accountsLoading READ accountsLoading NOTIFY accountsLoadingChanged)
+    Q_PROPERTY(bool createAccountInProgress READ createAccountInProgress NOTIFY createAccountInProgressChanged)
     Q_PROPERTY(bool timeSeriesLoading READ timeSeriesLoading NOTIFY timeSeriesLoadingChanged)
     Q_PROPERTY(bool timeSeriesEmpty READ timeSeriesEmpty NOTIFY timeSeriesDataChanged)
     Q_PROPERTY(QStringList timeSeriesAccountIds READ timeSeriesAccountIds NOTIFY timeSeriesDataChanged)
@@ -61,6 +69,7 @@ public:
     bool pingInProgress() const { return m_pingInProgress; }
     QVariantList accounts() const { return m_accounts; }
     bool accountsLoading() const { return m_accountsLoading; }
+    bool createAccountInProgress() const { return m_createAccountInProgress; }
     bool timeSeriesLoading() const { return m_timeSeriesLoading; }
     bool timeSeriesEmpty() const;
     QStringList timeSeriesAccountIds() const;
@@ -71,6 +80,7 @@ public:
 
     Q_INVOKABLE void ping();
     Q_INVOKABLE void listAccounts();
+    Q_INVOKABLE void createAccount(const QString& name, int accountType);
     Q_INVOKABLE void fetchTimeSeries(const QString& fromDate, const QString& toDate,
                                      int interval, const QStringList& accountIds);
     Q_INVOKABLE void populateSeries(QObject* series, const QString& accountId);
@@ -81,6 +91,9 @@ signals:
     void pingInProgressChanged();
     void accountsChanged();
     void accountsLoadingChanged();
+    void createAccountInProgressChanged();
+    void accountCreated(QString id);
+    void accountCreateFailed(QString message);
     void timeSeriesLoadingChanged();
     void timeSeriesDataChanged();
 
@@ -88,6 +101,7 @@ private slots:
     void onPingFinished();
     void applyPingResult();
     void onListAccountsFinished();
+    void onCreateAccountFinished();
     void onTimeSeriesFinished();
 
 private:
@@ -102,6 +116,8 @@ private:
     QVariantList m_accounts;
     bool m_accountsLoading = false;
     QFutureWatcher<ListAccountsResult> m_accountsWatcher;
+    bool m_createAccountInProgress = false;
+    QFutureWatcher<CreateAccountResult> m_createAccountWatcher;
     bool m_timeSeriesLoading = false;
     QFutureWatcher<TimeSeriesResult> m_timeSeriesWatcher;
     TimeSeriesResult m_timeSeriesData;

--- a/app/tests/MockFinchClient.qml
+++ b/app/tests/MockFinchClient.qml
@@ -1,0 +1,32 @@
+import QtQuick
+
+// Test double for FinchClient: records createAccount calls and lets specs drive the
+// success/failure signals the form reacts to, with no daemon or gRPC involved.
+QtObject {
+    property bool createAccountInProgress: false
+    property string lastName: ""
+    property int lastType: -1
+    property int callCount: 0
+
+    signal accountCreated(string id)
+    signal accountCreateFailed(string message)
+
+    // Mirror the real client's observable lifecycle: in-progress latches true on the
+    // call and clears when the test drives a terminal outcome via succeed()/fail().
+    function createAccount(name, type) {
+        lastName = name
+        lastType = type
+        callCount += 1
+        createAccountInProgress = true
+    }
+
+    function succeed(id) {
+        createAccountInProgress = false
+        accountCreated(id)
+    }
+
+    function fail(message) {
+        createAccountInProgress = false
+        accountCreateFailed(message)
+    }
+}

--- a/app/tests/tst_CreateAccountForm.qml
+++ b/app/tests/tst_CreateAccountForm.qml
@@ -1,0 +1,137 @@
+import QtQuick
+import QtTest
+// Load the real shipping form by directory import, so the component under test is the
+// exact file the app uses — not a stub. MockFinchClient sits in this directory and is
+// available unqualified.
+import "../qml"
+
+TestCase {
+    id: testCase
+    name: "CreateAccountForm"
+    when: windowShown
+
+    Component {
+        id: formFactory
+        CreateAccountForm {}
+    }
+
+    Component {
+        id: mockFactory
+        MockFinchClient {}
+    }
+
+    SignalSpy {
+        id: createdSpy
+        signalName: "created"
+    }
+
+    // Returns { form, mock }; each test destroys them via teardown().
+    function build() {
+        var mock = mockFactory.createObject(testCase)
+        var form = formFactory.createObject(testCase, { client: mock })
+        verify(form !== null, "form instantiated")
+        return { form: form, mock: mock }
+    }
+
+    function teardown(ctx) {
+        ctx.form.destroy()
+        ctx.mock.destroy()
+    }
+
+    // C1 load-smoke: the real component instantiates and a known property reads back.
+    function test_loadsAndStartsInvalid() {
+        var ctx = build()
+        compare(ctx.form.canSubmit, false)
+        teardown(ctx)
+    }
+
+    function test_disabledWhenNameEmpty() {
+        var ctx = build()
+        ctx.form.typeIndex = 1 // Checking
+        compare(ctx.form.nameText, "")
+        compare(ctx.form.canSubmit, false)
+        teardown(ctx)
+    }
+
+    function test_disabledWhenNoType() {
+        var ctx = build()
+        ctx.form.nameText = "Everyday"
+        compare(ctx.form.selectedType, 0)
+        compare(ctx.form.canSubmit, false)
+        teardown(ctx)
+    }
+
+    function test_enabledWhenNameAndTypeValid() {
+        var ctx = build()
+        ctx.form.nameText = "Everyday"
+        ctx.form.typeIndex = 1
+        compare(ctx.form.canSubmit, true)
+        teardown(ctx)
+    }
+
+    function test_submitSendsTrimmedNameAndSelectedType() {
+        var ctx = build()
+        ctx.form.nameText = "  Rainy Day  "
+        ctx.form.typeIndex = 2 // Savings -> value 2
+        ctx.form.submit()
+        compare(ctx.mock.callCount, 1)
+        compare(ctx.mock.lastName, "Rainy Day")
+        compare(ctx.mock.lastType, 2)
+        teardown(ctx)
+    }
+
+    function test_submitIgnoredWhenInvalid() {
+        var ctx = build()
+        ctx.form.nameText = "   " // whitespace only
+        ctx.form.typeIndex = 1
+        ctx.form.submit()
+        compare(ctx.mock.callCount, 0)
+        teardown(ctx)
+    }
+
+    function test_disabledWhileCreateInProgress() {
+        var ctx = build()
+        ctx.form.nameText = "Everyday"
+        ctx.form.typeIndex = 1
+        verify(ctx.form.canSubmit) // enabled before submit
+        ctx.form.submit() // mock latches createAccountInProgress
+        compare(ctx.mock.createAccountInProgress, true)
+        compare(ctx.form.canSubmit, false) // form disables while a create is in flight
+        teardown(ctx)
+    }
+
+    function test_doubleSubmitSendsOnlyOne() {
+        var ctx = build()
+        ctx.form.nameText = "Everyday"
+        ctx.form.typeIndex = 1
+        ctx.form.submit()
+        ctx.form.submit() // second is gated by canSubmit (in-progress)
+        compare(ctx.mock.callCount, 1)
+        teardown(ctx)
+    }
+
+    function test_successClearsFormAndSignalsCreated() {
+        var ctx = build()
+        createdSpy.target = ctx.form
+        createdSpy.clear()
+        ctx.form.nameText = "Everyday"
+        ctx.form.typeIndex = 1
+        ctx.form.submit()
+        ctx.mock.succeed("acct-123")
+        compare(createdSpy.count, 1)
+        compare(ctx.form.nameText, "")
+        compare(ctx.form.selectedType, 0)
+        createdSpy.target = null
+        teardown(ctx)
+    }
+
+    function test_failureShowsErrorMessage() {
+        var ctx = build()
+        ctx.form.nameText = "Everyday"
+        ctx.form.typeIndex = 1
+        ctx.form.submit()
+        ctx.mock.fail("could not reach the daemon")
+        compare(ctx.form.errorText, "could not reach the daemon")
+        teardown(ctx)
+    }
+}

--- a/app/tests/tst_CreateAccountForm.qml
+++ b/app/tests/tst_CreateAccountForm.qml
@@ -1,9 +1,9 @@
 import QtQuick
 import QtTest
-// Load the real shipping form by directory import, so the component under test is the
-// exact file the app uses — not a stub. MockFinchClient sits in this directory and is
-// available unqualified.
-import "../qml"
+// FinchFormTest is the test-only module (see app/CMakeLists.txt) holding the real
+// shipping CreateAccountForm and the MockFinchClient double — scoped to just these two
+// files so the test doesn't pull in the rest of the app's QML and its modules.
+import FinchFormTest
 
 TestCase {
     id: testCase

--- a/app/tests/tst_CreateAccountForm.qml
+++ b/app/tests/tst_CreateAccountForm.qml
@@ -25,24 +25,29 @@ TestCase {
         signalName: "created"
     }
 
-    // Returns { form, mock }; each test destroys them via teardown().
+    property var currentForm: null
+    property var currentMock: null
+
+    // Returns { form, mock }; cleanup() destroys them after each test — even on an
+    // assertion failure, which aborts the test function before any manual teardown runs.
     function build() {
-        var mock = mockFactory.createObject(testCase)
-        var form = formFactory.createObject(testCase, { client: mock })
-        verify(form !== null, "form instantiated")
-        return { form: form, mock: mock }
+        currentMock = mockFactory.createObject(testCase)
+        currentForm = formFactory.createObject(testCase, { client: currentMock })
+        verify(currentForm !== null, "form instantiated")
+        return { form: currentForm, mock: currentMock }
     }
 
-    function teardown(ctx) {
-        ctx.form.destroy()
-        ctx.mock.destroy()
+    // cleanup() is the Qt Quick Test per-test teardown hook; it always runs.
+    function cleanup() {
+        createdSpy.target = null
+        if (currentForm) { currentForm.destroy(); currentForm = null }
+        if (currentMock) { currentMock.destroy(); currentMock = null }
     }
 
     // C1 load-smoke: the real component instantiates and a known property reads back.
     function test_loadsAndStartsInvalid() {
         var ctx = build()
         compare(ctx.form.canSubmit, false)
-        teardown(ctx)
     }
 
     function test_disabledWhenNameEmpty() {
@@ -50,7 +55,6 @@ TestCase {
         ctx.form.typeIndex = 1 // Checking
         compare(ctx.form.nameText, "")
         compare(ctx.form.canSubmit, false)
-        teardown(ctx)
     }
 
     function test_disabledWhenNoType() {
@@ -58,7 +62,6 @@ TestCase {
         ctx.form.nameText = "Everyday"
         compare(ctx.form.selectedType, 0)
         compare(ctx.form.canSubmit, false)
-        teardown(ctx)
     }
 
     function test_enabledWhenNameAndTypeValid() {
@@ -66,7 +69,6 @@ TestCase {
         ctx.form.nameText = "Everyday"
         ctx.form.typeIndex = 1
         compare(ctx.form.canSubmit, true)
-        teardown(ctx)
     }
 
     function test_submitSendsTrimmedNameAndSelectedType() {
@@ -77,7 +79,6 @@ TestCase {
         compare(ctx.mock.callCount, 1)
         compare(ctx.mock.lastName, "Rainy Day")
         compare(ctx.mock.lastType, 2)
-        teardown(ctx)
     }
 
     function test_submitIgnoredWhenInvalid() {
@@ -86,7 +87,6 @@ TestCase {
         ctx.form.typeIndex = 1
         ctx.form.submit()
         compare(ctx.mock.callCount, 0)
-        teardown(ctx)
     }
 
     function test_disabledWhileCreateInProgress() {
@@ -97,7 +97,6 @@ TestCase {
         ctx.form.submit() // mock latches createAccountInProgress
         compare(ctx.mock.createAccountInProgress, true)
         compare(ctx.form.canSubmit, false) // form disables while a create is in flight
-        teardown(ctx)
     }
 
     function test_doubleSubmitSendsOnlyOne() {
@@ -107,7 +106,6 @@ TestCase {
         ctx.form.submit()
         ctx.form.submit() // second is gated by canSubmit (in-progress)
         compare(ctx.mock.callCount, 1)
-        teardown(ctx)
     }
 
     function test_successClearsFormAndSignalsCreated() {
@@ -122,7 +120,6 @@ TestCase {
         compare(ctx.form.nameText, "")
         compare(ctx.form.selectedType, 0)
         createdSpy.target = null
-        teardown(ctx)
     }
 
     function test_failureShowsErrorMessage() {
@@ -132,6 +129,5 @@ TestCase {
         ctx.form.submit()
         ctx.mock.fail("could not reach the daemon")
         compare(ctx.form.errorText, "could not reach the daemon")
-        teardown(ctx)
     }
 }

--- a/app/tests/tst_createaccountform.cpp
+++ b/app/tests/tst_createaccountform.cpp
@@ -1,0 +1,6 @@
+// Qt Quick Test entry point. QUICK_TEST_MAIN scans QUICK_TEST_SOURCE_DIR (set in
+// CMake) for tst_*.qml at runtime; the specs load the form via a directory import,
+// so no C++ type registration is needed here.
+#include <QtQuickTest/quicktest.h>
+
+QUICK_TEST_MAIN(createaccountform)

--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ build-mcp:
 # Build the Qt app
 build-app:
     cmake -S app -B app/build
-    cmake --build app/build
+    cmake --build app/build --target finch-app
 
 # Build and run the Qt app's Qt Quick Test suite (kept separate from `test`,
 # which is Go-only — folding it in would force a Qt/C++ build in Go-only environments)

--- a/justfile
+++ b/justfile
@@ -19,6 +19,13 @@ build-app:
     cmake -S app -B app/build
     cmake --build app/build
 
+# Build and run the Qt app's Qt Quick Test suite (kept separate from `test`,
+# which is Go-only — folding it in would force a Qt/C++ build in Go-only environments)
+test-app:
+    cmake -S app -B app/build
+    cmake --build app/build
+    ctest --test-dir app/build --output-on-failure
+
 # Run all Go tests
 test: test-core test-daemon test-mcp
 


### PR DESCRIPTION
## Overview

The Qt app could show accounts and balances but couldn't create them — every write went through the MCP tools and Claude. This adds a "New Account" form so a user can create an account (name + type) directly in the app: the first data-mutation feature on the path to making the desktop app usable without an AI intermediary, and the app's first user-facing write feedback (reads previously failed silently).

It also introduces the app's first Qt Quick Test harness, run headless locally via `just test-app` and in CI.

## How it works

- `CreateAccountForm` takes an injected `client`, so the same component is driven by the real `FinchClient` in the app and by a mock in the specs. `FinchClient::createAccount` mirrors the existing async gRPC pattern, guards against double-submit, and appends the created account to the model directly — a `listAccounts` refresh would be dropped by that method's in-progress guard.
- The Qt build and runtime dependencies (including the Qt Quick Test packages) are now documented in the README alongside the CI install list.

Closes #36
