### PR TITLE
ci: scope Go CI by path and cancel superseded runs

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -6,8 +6,55 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  # Cancel only superseded PR runs; let every main-branch run complete so each
+  # main commit keeps a finished CI record (bisect / future release tagging).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Least-privilege token. dorny/paths-filter needs pull-requests:read on PR
+# events; the rest need only contents:read for checkout. Without this, a future
+# org-wide flip to restricted default token permissions would fail the changes
+# gate job and, via needs:, block the required checks (repo-wide merge lock).
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  # Gate job: detect whether Go- or proto-relevant files changed. This runs on
+  # every PR (so the required checks below are never workflow-skipped, which
+  # would leave them stuck "Expected" and block merge). When nothing relevant
+  # changed, the jobs below are if-skipped, which reports them as passing.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+      proto: ${{ steps.filter.outputs.proto }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            go:
+              - 'core/**'
+              - 'daemon/**'
+              - 'mcp/**'
+              - 'proto/**'
+              - '**/go.mod'
+              - '**/go.sum'
+              - 'buf.yaml'
+              - 'buf.gen.yaml'
+              - '.golangci.yml'
+              - '.github/workflows/ci-go.yml'
+            proto:
+              - 'proto/**'
+              - 'buf.yaml'
+              - '.github/workflows/ci-go.yml'
+
   test-and-lint:
+    needs: changes
+    if: ${{ needs.changes.outputs.go == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -15,6 +62,10 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
+          cache-dependency-path: |
+            core/go.sum
+            daemon/go.sum
+            mcp/go.sum
 
       - uses: bufbuild/buf-action@v1
         with:
@@ -53,6 +104,8 @@ jobs:
         run: cd mcp && go test ./...
 
   proto-check:
+    needs: changes
+    if: ${{ needs.changes.outputs.proto == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-qt.yml
+++ b/.github/workflows/ci-qt.yml
@@ -6,11 +6,20 @@ on:
     paths:
       - "app/**"
       - "proto/**"
+      - ".github/workflows/ci-qt.yml"
   pull_request:
     branches: [main]
     paths:
       - "app/**"
       - "proto/**"
+      - ".github/workflows/ci-qt.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
## Overview

CI did redundant work on every PR: Go CI ran regardless of what changed (an app-only PR triggered 7 wasted Go CI runs), and neither workflow cancelled superseded in-flight runs, so iterative pushes piled up. This scopes Go CI to the changes that actually affect it, cancels superseded PR runs, and caches Go modules — without changing what any job does.

Closes #70.

## How it works

The obvious fix — an `on: paths` filter on `ci-go.yml` — would break merging here. `test-and-lint` and `proto-check` are required status checks under the active `main` ruleset, and a workflow skipped by path filtering never reports its check, so the PR stays stuck "Expected" and can never merge.

The workaround skips at the *job* level instead. A cheap `changes` job (`dorny/paths-filter`) detects whether Go- or proto-relevant files changed; `test-and-lint` and `proto-check` are gated on it with `if:`. A job skipped via `if:` still reports its check as passing, so an unrelated PR keeps the required checks green while burning no Go compute.

Supporting pieces: concurrency groups cancel superseded PR runs (but let every main run finish, so each main commit keeps a completed record); Go module caching via `setup-go`; and a least-privilege `permissions:` block, so a future restricted-default-token flip can't fail the gate job and deadlock merges. The Qt workflow gains the same concurrency group and a self-trigger path so edits to it are validated by a build.
