### PR TITLE
ci: bump paths-filter to v4 and document required-check scoping

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -12,6 +12,14 @@ Run the checks matching the files a change touches before pushing:
 
 This list is the single source of truth for the supplies below — they reference it rather than restating commands.
 
+## Path-Scoping CI Without Deadlocking Required Checks
+
+`test-and-lint` and `proto-check` (in `ci-go.yml`) are required status checks enforced by the `main` branch ruleset. A required check that never reports leaves a PR stuck "Expected" and unmergeable.
+
+This constrains how Go CI is scoped to skip unrelated changes: NEVER add an `on: paths` filter to a workflow that hosts a required check. A path-filtered workflow that doesn't match produces no check run, so the required check never reports and the PR cannot merge. Instead, keep the workflow triggering on every PR and gate the expensive jobs at the *job* level — a cheap `changes` job (using `dorny/paths-filter`) sets per-area outputs, and the required jobs use `if:` to skip when their area is untouched. A job skipped via `if:` still reports its check as passing, so unrelated PRs stay mergeable while consuming no compute. The gate job needs `pull-requests: read`, supplied by a workflow-level `permissions:` block.
+
+The Qt `build` job is NOT a required check, so `ci-qt.yml` can safely use a workflow-level `on: paths` filter.
+
 ## Pre-Merge Checks
 
 (extension point: `pre-merge-checks`)

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -32,7 +32,7 @@ jobs:
       proto: ${{ steps.filter.outputs.proto }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Overview

Two follow-ups to the CI redundancy work in #70, bundled while the context is fresh:

- The `dorny/paths-filter` action was introduced at `v3` while `v4` was already current; this bumps it. `v4.0.0` is a node20→node24 runtime change only — no API or behavior change, so the gate's filter syntax and outputs are unaffected.
- The `ci.md` rule now documents why Go CI gates jobs with a `changes` detector rather than an `on: paths` filter — so a future change doesn't reintroduce `on: paths` on a required-check workflow and deadlock merges (the trap #70's PR navigated).

Related to #70.
