### PR TITLE
docs(dx): align Copilot checks and PR template with pr-conventions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 ## Overview
 
-<!-- What is the purpose of this change? Why does it matter? -->
+<!-- The purpose: what this change accomplishes and why it matters. Lead with this. -->
 
-## Changes
+## How it works (optional)
 
-<!-- Brief summary of what changed and how. -->
+<!-- Only non-obvious mechanics a reviewer can't infer from the diff — including how the change was verified, when that isn't obvious. Delete this section if the diff speaks for itself; don't enumerate files. -->
 
-## Verification
+## Issue references
 
-<!-- How was this tested? What should reviewers check? -->
+<!-- Closing keywords for issues this fully resolves, e.g. "Closes #123, closes #456" (repeat the keyword per issue). Use "Related to #N" for partial or tangential links. -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,22 +2,23 @@
 
 ## Mandatory Checks
 
+The PR-description conventions these checks enforce live in `.claude/rules/pr-conventions.md` (the authoritative `pr-description-format` source); keep these checks aligned with it.
+
 ### Check 1: Overview Section Validation
 
-Every PR must include an **Overview** section that states:
-- The purpose of the change — why it matters
-- Whether the change is an incremental improvement or a transformative/innovative change
+Every PR must open with an **Overview** section stating the purpose of the change — what it accomplishes and why it matters.
 
 **Assessment:** Post a pass/fail comment. Fail if the Overview section is missing or lacks a clear purpose statement.
 
-### Check 2: Scope Accuracy
+### Check 2: Scope Cohesion
 
-Compare the files changed in the PR against what the PR description claims:
-- Flag files that are modified but not mentioned in the description
-- Flag files mentioned in the description but not actually changed
-- Assess whether all changes serve the stated purpose (cohesion)
+Assess whether the diff is cohesive — every change serving the PR's stated purpose:
+- Flag changes that do not serve the stated purpose (undisclosed or unrelated scope).
+- Flag claims in the description that the diff does not actually deliver.
 
-**Assessment:** Post a pass/fail comment listing any discrepancies.
+Do NOT require the description to name every changed file. `pr-conventions.md` directs PR descriptions to avoid file-by-file enumeration — the diff already shows what changed — so judge scope by cohesion and accuracy, not by whether each file is mentioned.
+
+**Assessment:** Post a pass/fail comment. Fail only on a genuine cohesion or accuracy gap, not on an unmentioned file.
 
 ### Check 3: No Private Tooling References
 


### PR DESCRIPTION
## Overview

Finch's PR-description conventions are defined authoritatively in `.claude/rules/pr-conventions.md` (the `pr-description-format` source), but two files that re-encode the same conventions had drifted from it — enough that a PR written to the convention failed the repo's own Copilot review checks. This realigns both toward `pr-conventions.md` as the single source.

## How it works

The substantive fix is the Copilot "Scope Accuracy" check: it had been operationalized as literal file-mention matching (flag any changed file not named in the description), which contradicts the convention's directive to avoid file-by-file enumeration. It's retargeted to judge scope *cohesion* — whether the changes serve the stated purpose and whether the description over-claims — and now defers to the no-enumeration rule explicitly. The Overview check's "incremental vs. transformative" requirement, which the convention never defines, is dropped (the purpose check stays). The PR template is realigned to the convention's section set, folding its standalone verification prompt into "How it works."
