### PR TITLE
docs(rules): align CI/testing guidance with the Qt Quick Test harness

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -1,13 +1,13 @@
 # CI Conventions
 
-The CI workflow runs a build check (plus Go test and lint). Catching failures locally avoids a slow push-wait-fail cycle. The checks below are scoped by which part of the tree a change touches.
+The CI workflow runs build, test, and lint checks (Go test and lint, plus the Qt app build and its Quick Test suite). Catching failures locally avoids a slow push-wait-fail cycle. The checks below are scoped by which part of the tree a change touches.
 
 ## Local Checks by Change Area
 
 Run the checks matching the files a change touches before pushing:
 
 - **Go modules** (`core/`, `daemon/`, `mcp/`) — `just test` and `just lint`.
-- **Qt app** (`app/`) — `just build-app`. CI only runs a build check for the app, so a local build is the fast feedback path.
+- **Qt app** (`app/`) — `just test-app`. This builds the app *and* runs the Qt Quick Test suite, mirroring what CI runs, so it is the fast feedback path.
 - **Protobuf** (`proto/`) — `just proto` to regenerate. Generated code lives in `daemon/gen/` and is not committed, so it must regenerate cleanly.
 
 This list is the single source of truth for the supplies below — they reference it rather than restating commands.
@@ -51,4 +51,4 @@ Beyond the conflict-marker baseline, scan added lines for:
 After merging the base branch into a stale branch, run beyond the standard test/lint pass:
 
 - `just proto` then `just all` — a clean regenerate-and-build is the only signal for proto or generated-code drift the merge may have introduced (generated code is not committed).
-- `just build-app` when `app/` is touched.
+- `just test-app` when `app/` is touched — it builds the app and runs the Qt Quick Test suite (superseding a plain `just build-app`).

--- a/.claude/rules/qt-app.md
+++ b/.claude/rules/qt-app.md
@@ -1,3 +1,7 @@
+---
+paths: "app/**/*"
+---
+
 # Qt App Development
 
 ## QApplication Required
@@ -41,5 +45,11 @@ After installing or changing a desktop entry or icon, a running Plasma session m
 ## Build and Test
 
 Build: `just build-app` (or `cmake -S app -B app/build && cmake --build app/build`).
+
+Automated tests: `just test-app` configures, builds, and runs the Qt Quick Test suite via `ctest`. Conventions (defined in `app/CMakeLists.txt`):
+
+- **Test-only QML module.** Each form/view is tested through a dedicated module (e.g. `FinchFormTest`) scoped to just the real shipping component plus a mock client (`MockFinchClient.qml`). Scoping the module to those self-contained files — rather than the whole `qml/` directory — keeps the test's runtime dependencies to what the component itself imports, so it does not drag in `Main.qml`/`BalanceChart.qml` and their transitive modules (QtCharts, QtQml.WorkerScript). The component under test is the exact file the app ships, not a stub.
+- **Mock injection.** The shipping component declares `required property var client`; the app injects the real C++ `FinchClient`, tests inject `MockFinchClient`, which records calls and exposes `succeed()`/`fail()` to drive outcomes.
+- **Headless + deterministic style.** Tests run with `QT_QPA_PLATFORM=offscreen` (no display) and a pinned `QT_QUICK_CONTROLS_STYLE=Basic`, set per-test in CMake, so results are reproducible across machines and CI needn't carry other Controls styles' modules.
 
 Manual testing requires a running daemon with seed data. The daemon must be built and started separately (`just build-daemon && daemon/finch-daemon`).

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -20,4 +20,4 @@ Test domain invariants, validation boundaries, error conditions, and event produ
 
 ## Qt App
 
-Build verification (`just build-app`) is the current minimum for the Qt app. Introduce QML automated testing when the app has form-based interactions and data mutation workflows worth protecting with regression tests.
+The Qt app has a Qt Quick Test suite, run via `just test-app` (which builds the app, then runs the specs). A spec drives the real shipping component with an injected mock client and asserts on the calls that component makes — so behavior is verified, not just compilation. Build verification alone is no longer the ceiling; a form or view with input validation or data mutation earns a spec. See `qt-app.md` for the harness mechanics (test-only QML module, mock injection, headless/style settings).


### PR DESCRIPTION
## Overview

The Qt app gained an automated test harness — `just test-app` running a Qt Quick Test suite with an injectable mock client — but the agent-facing rules under `.claude/rules/` still described the pre-harness world: they listed only `just build-app` for app changes and gated QML testing as future work, under-guiding app development.

This aligns three rules with the app's actual build/test setup:

- **`ci.md`** — the app's "Local Checks" entry now runs `just test-app` (build + test), and the stale "CI only runs a build check for the app" framing is corrected.
- **`testing.md`** — the Qt App section documents the landed spec pattern instead of gating QML testing as future work.
- **`qt-app.md`** — adds the Qt Quick Test conventions (test-only QML module, mock injection, headless `offscreen` + pinned `Basic` style).

## How it works

`qt-app.md` is now path-scoped via `paths: "app/**/*"` frontmatter, so this app-only rule loads only when app code is being edited rather than in every session.

Closes #71
