### PR TITLE
feat(app): view an account's transactions in the Qt app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Qt app: create accounts through a UI form (previously only via MCP tools).
+- Qt app: view an account's individual transactions on the Transactions screen — pick an account, browse its transactions in a list, and select one to see its full details (previously only the aggregated balance chart was visible).
 
 ### Changed
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -79,6 +79,7 @@ qt_add_qml_module(finch-app
         qml/CreateAccountForm.qml
         qml/NavigationShell.qml
         qml/AccountsPanel.qml
+        qml/TransactionsPanel.qml
         qml/PlaceholderScreen.qml
 )
 
@@ -154,4 +155,33 @@ target_link_libraries(tst_navigationshell PRIVATE
 add_test(NAME tst_navigationshell COMMAND tst_navigationshell)
 
 set_tests_properties(tst_navigationshell PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_CONTROLS_STYLE=Basic")
+
+# --- TransactionsPanel test ---
+add_executable(tst_transactionspanel tests/tst_transactionspanel.cpp)
+
+# A test-only module scoped to the real master-detail panel + the shared mock client. The
+# panel imports only QtQuick/Controls/Layouts (no QtCharts), so the default QGuiApplication
+# entry point is fine — the QApplication requirement is a QtCharts-only constraint.
+qt_add_qml_module(tst_transactionspanel
+    URI FinchTransactionsTest
+    VERSION 1.0
+    QML_FILES
+        qml/TransactionsPanel.qml
+        tests/MockFinchClient.qml
+)
+
+target_compile_definitions(tst_transactionspanel PRIVATE
+    QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/transactionspanel")
+
+target_link_libraries(tst_transactionspanel PRIVATE
+    Qt6::Quick
+    Qt6::QuickControls2
+    Qt6::QuickTest
+    Qt6::Qml
+)
+
+add_test(NAME tst_transactionspanel COMMAND tst_transactionspanel)
+
+set_tests_properties(tst_transactionspanel PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_CONTROLS_STYLE=Basic")

--- a/app/qml/Main.qml
+++ b/app/qml/Main.qml
@@ -93,10 +93,11 @@ ApplicationWindow {
                 createEnabled: finchClient.connectionState === FinchClient.Connected
             },
 
-            PlaceholderScreen {
+            TransactionsPanel {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-                headline: "Transactions"
+                client: finchClient
+                connected: finchClient.connectionState === FinchClient.Connected
             },
 
             PlaceholderScreen {

--- a/app/qml/TransactionsPanel.qml
+++ b/app/qml/TransactionsPanel.qml
@@ -1,0 +1,227 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// Transactions destination: a per-account master-detail view. An account selector drives a
+// per-account fetch; the master list shows one row per transaction; selecting a row fills
+// the detail pane. Like AccountsPanel it imports no Finch C++ type — the host injects the
+// client and the connection gate — so it stays instantiable without a daemon.
+//
+// Master-detail interaction is binding-driven, not click-driven: the detail pane binds to
+// the list's currentIndex, so a row "click" is just a currentIndex write. This is what lets
+// the offscreen test harness (which delivers no synthetic mouse events) drive selection.
+Item {
+    id: panel
+
+    // Injected by the host: Main.qml passes finchClient.
+    required property var client
+
+    // Whether the daemon is connected (host-gated). When false the panel shows a connect
+    // hint instead of an account dropdown the user can't populate.
+    property bool connected: true
+
+    // The account list backing the selector; the transaction list backing the master view.
+    readonly property var accounts: client ? client.accounts : []
+    readonly property var transactions: client ? client.transactions : []
+
+    // The currently selected transaction, or null when nothing valid is selected. Null-guards
+    // the detail pane against transactions[-1] / an index past the end of a shorter new list.
+    readonly property var selectedTransaction:
+        (list.currentIndex >= 0 && list.currentIndex < transactions.length)
+            ? transactions[list.currentIndex]
+            : null
+
+    // Whether the contextual state message is showing (no rows, not mid-fetch). A logical
+    // property, not an alias to the Label's `visible`: QML's visible getter returns effective
+    // visibility (ancestor- and window-dependent), which is unreliable under the offscreen
+    // test harness, so specs assert this condition directly.
+    readonly property bool stateMessageVisible:
+        list.count === 0 && !(client && client.transactionsLoading)
+
+    // Test/host surface: selection and detail field values are read back through these.
+    property alias selectedAccountIndex: accountCombo.currentIndex
+    property alias transactionList: list
+    property alias stateMessageText: stateLabel.text
+    property alias detailDateText: detailDate.text
+    property alias detailNameText: detailName.text
+    property alias detailAmountText: detailAmount.text
+    property alias detailStatusText: detailStatus.text
+    property alias detailDescriptionText: detailDescription.text
+    property alias detailRecurringRuleText: detailRecurringRule.text
+
+    // TransactionStatus enum (proto int 0-3) -> human label. No app-wide status map exists
+    // yet; defined inline here, mirroring how CreateAccountForm hardcodes its AccountType map.
+    function statusLabel(status) {
+        switch (status) {
+        case 1: return "Projected"
+        case 2: return "Scheduled"
+        case 3: return "Reconciled"
+        default: return "Unspecified"
+        }
+    }
+
+    // Signed int64 cents -> sign-correct currency. Math.abs keeps the "-" ahead of the "$"
+    // ("-$12.34", not "$-12.34").
+    // TODO: lift this (and statusLabel) into a shared helper once #38's record form needs it.
+    function formatAmount(cents) {
+        return (cents < 0 ? "-$" : "$") + Math.abs(cents / 100).toFixed(2)
+    }
+
+    function onAccountSelected() {
+        // Drop any prior detail selection: the incoming list is a different account's.
+        list.currentIndex = -1
+        if (accountCombo.currentIndex >= 0 && client) {
+            var account = accounts[accountCombo.currentIndex]
+            if (account)
+                client.listTransactions(account.id)
+        }
+    }
+
+    // New data (even for the same account) invalidates the prior row index, which could now
+    // point past the end of a shorter list. Clear it so the detail pane null-guards cleanly.
+    Connections {
+        target: panel.client
+        function onTransactionsChanged() { list.currentIndex = -1 }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 16
+        spacing: 16
+
+        ComboBox {
+            id: accountCombo
+            Layout.fillWidth: true
+            // Mirror AccountsPanel's null-guard so the panel is instantiable without a client.
+            model: panel.client ? panel.client.accounts : []
+            textRole: "name"
+            // Start unselected: index 0 of client.accounts is a REAL account (unlike a
+            // form-owned type list with a prependable sentinel), so a placeholder displayText
+            // is the only way to offer an explicit "no account chosen" state and avoid an
+            // auto-fetch on load.
+            currentIndex: -1
+            displayText: currentIndex < 0 ? "Select an account…" : currentText
+            onCurrentIndexChanged: panel.onAccountSelected()
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: 16
+
+            // Master: one row per transaction.
+            ListView {
+                id: list
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                clip: true
+                currentIndex: -1
+                model: panel.transactions
+                delegate: ItemDelegate {
+                    id: row
+                    required property int index
+                    required property var modelData
+                    width: ListView.view.width
+                    // Size height from the row's own content. The RowLayout is anchored by
+                    // width (to the fixed list width) but NOT stretched vertically, so its
+                    // implicitHeight is independent of the delegate height — without that
+                    // separation the layout feeds its size back into the delegate and Qt
+                    // aborts with "recursive rearrange".
+                    implicitHeight: rowContent.implicitHeight + 12
+                    highlighted: ListView.isCurrentItem
+                    // Production affordance only; the detail pane is driven by the
+                    // currentIndex binding, not this handler (offscreen tests can't click).
+                    onClicked: list.currentIndex = row.index
+                    RowLayout {
+                        id: rowContent
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.leftMargin: 8
+                        anchors.rightMargin: 8
+                        spacing: 12
+                        Label { text: row.modelData.date }
+                        Label {
+                            Layout.fillWidth: true
+                            elide: Text.ElideRight
+                            text: row.modelData.name
+                        }
+                        Label { text: panel.statusLabel(row.modelData.status) }
+                        Label { text: panel.formatAmount(row.modelData.amount) }
+                    }
+                }
+            }
+
+            // Detail: the selected transaction's full record, or a placeholder.
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.alignment: Qt.AlignTop
+                spacing: 8
+
+                Label {
+                    visible: panel.selectedTransaction === null
+                    text: "Select a transaction to see its details."
+                    color: "gray"
+                }
+
+                GridLayout {
+                    visible: panel.selectedTransaction !== null
+                    columns: 2
+                    columnSpacing: 12
+                    rowSpacing: 4
+
+                    Label { text: "Date"; font.bold: true }
+                    Label { id: detailDate; text: panel.selectedTransaction ? panel.selectedTransaction.date : "" }
+
+                    Label { text: "Name"; font.bold: true }
+                    Label { id: detailName; text: panel.selectedTransaction ? panel.selectedTransaction.name : "" }
+
+                    Label { text: "Amount"; font.bold: true }
+                    Label {
+                        id: detailAmount
+                        text: panel.selectedTransaction ? panel.formatAmount(panel.selectedTransaction.amount) : ""
+                    }
+
+                    Label { text: "Status"; font.bold: true }
+                    Label {
+                        id: detailStatus
+                        text: panel.selectedTransaction ? panel.statusLabel(panel.selectedTransaction.status) : ""
+                    }
+
+                    Label { text: "Description"; font.bold: true }
+                    Label {
+                        id: detailDescription
+                        Layout.fillWidth: true
+                        wrapMode: Text.WordWrap
+                        text: panel.selectedTransaction ? panel.selectedTransaction.description : ""
+                    }
+
+                    Label { text: "Recurring rule"; font.bold: true }
+                    Label {
+                        id: detailRecurringRule
+                        text: (panel.selectedTransaction && panel.selectedTransaction.recurringRuleId)
+                              ? panel.selectedTransaction.recurringRuleId
+                              : "—"
+                    }
+                }
+            }
+        }
+
+        // Single contextual message that explains an empty master view: disconnected,
+        // no account chosen, or an account with no transactions.
+        Label {
+            id: stateLabel
+            Layout.fillWidth: true
+            color: "gray"
+            visible: panel.stateMessageVisible
+            text: {
+                if (!panel.connected)
+                    return "Connect to the daemon to view transactions."
+                if (accountCombo.currentIndex < 0)
+                    return "Select an account to view its transactions."
+                return "No transactions for this account."
+            }
+        }
+    }
+}

--- a/app/qml/TransactionsPanel.qml
+++ b/app/qml/TransactionsPanel.qml
@@ -92,8 +92,10 @@ Item {
         ComboBox {
             id: accountCombo
             Layout.fillWidth: true
-            // Mirror AccountsPanel's null-guard so the panel is instantiable without a client.
-            model: panel.client ? panel.client.accounts : []
+            // panel.accounts is the single source for the account list (already client-null-
+            // guarded); onAccountSelected reads the same property, so the selector and the
+            // index->id lookup can never diverge.
+            model: panel.accounts
             textRole: "name"
             // Start unselected: index 0 of client.accounts is a REAL account (unlike a
             // form-owned type list with a prependable sentinel), so a placeholder displayText

--- a/app/qml/TransactionsPanel.qml
+++ b/app/qml/TransactionsPanel.qml
@@ -16,8 +16,9 @@ Item {
     // Injected by the host: Main.qml passes finchClient.
     required property var client
 
-    // Whether the daemon is connected (host-gated). When false the panel shows a connect
-    // hint instead of an account dropdown the user can't populate.
+    // Whether the daemon is connected (host-gated). When false the account list is empty and
+    // the selector is disabled (it can't be populated), and the state message shows a connect
+    // hint in place of any account/transaction content.
     property bool connected: true
 
     // The account list backing the selector; the transaction list backing the master view.
@@ -92,6 +93,9 @@ Item {
         ComboBox {
             id: accountCombo
             Layout.fillWidth: true
+            // Disconnected -> empty account list; disable so it doesn't read as a usable but
+            // empty dropdown. The connect hint (state message) explains the disabled state.
+            enabled: panel.connected
             // panel.accounts is the single source for the account list (already client-null-
             // guarded); onAccountSelected reads the same property, so the selector and the
             // index->id lookup can never diverge.

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -179,6 +179,12 @@ void FinchClient::startTransactionsFetch()
     m_inFlightTransactionsAccountId = m_requestedTransactionsAccountId;
     emit transactionsLoadingChanged();
 
+    // Clear immediately so the in-flight window never shows the previously loaded account's
+    // transactions under the newly selected account (the panel binds its list to this).
+    // Mirrors fetchTimeSeries clearing its data at the start of a fetch.
+    m_transactions.clear();
+    emit transactionsChanged();
+
     auto stub = m_stub.get();
     std::string id = m_inFlightTransactionsAccountId.toStdString();
     auto future = QtConcurrent::run([stub, id]() -> ListTransactionsResult {

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -27,6 +27,8 @@ FinchClient::FinchClient(const QString& socketPath, QObject* parent)
             this, &FinchClient::onListAccountsFinished);
     connect(&m_createAccountWatcher, &QFutureWatcher<CreateAccountResult>::finished,
             this, &FinchClient::onCreateAccountFinished);
+    connect(&m_transactionsWatcher, &QFutureWatcher<ListTransactionsResult>::finished,
+            this, &FinchClient::onListTransactionsFinished);
     connect(&m_timeSeriesWatcher, &QFutureWatcher<TimeSeriesResult>::finished,
             this, &FinchClient::onTimeSeriesFinished);
 }
@@ -36,6 +38,7 @@ FinchClient::~FinchClient()
     m_pingWatcher.waitForFinished();
     m_accountsWatcher.waitForFinished();
     m_createAccountWatcher.waitForFinished();
+    m_transactionsWatcher.waitForFinished();
     m_timeSeriesWatcher.waitForFinished();
 }
 
@@ -156,6 +159,49 @@ void FinchClient::createAccount(const QString& name, int accountType)
     });
 
     m_createAccountWatcher.setFuture(future);
+}
+
+void FinchClient::listTransactions(const QString& accountId)
+{
+    if (m_transactionsLoading)
+        return;
+
+    m_transactionsLoading = true;
+    emit transactionsLoadingChanged();
+
+    auto stub = m_stub.get();
+    std::string id = accountId.toStdString();
+    auto future = QtConcurrent::run([stub, id]() -> ListTransactionsResult {
+        grpc::ClientContext context;
+        context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(5));
+
+        finch::v1::ListTransactionsRequest request;
+        request.set_account_id(id);
+        finch::v1::ListTransactionsResponse response;
+
+        grpc::Status status = stub->ListTransactions(&context, request, &response);
+        if (!status.ok())
+            return {false, {}};
+
+        QVariantList transactions;
+        for (const auto& txn : response.transactions()) {
+            QVariantMap entry;
+            entry["id"] = QString::fromStdString(txn.id());
+            entry["accountId"] = QString::fromStdString(txn.account_id());
+            entry["date"] = QString::fromStdString(txn.date());
+            // Signed cents; the panel formats and applies the sign.
+            entry["amount"] = static_cast<qlonglong>(txn.amount());
+            entry["name"] = QString::fromStdString(txn.name());
+            entry["description"] = QString::fromStdString(txn.description());
+            // Raw TransactionStatus int; the panel maps it to a human label.
+            entry["status"] = static_cast<int>(txn.status());
+            entry["recurringRuleId"] = QString::fromStdString(txn.recurring_rule_id());
+            transactions.append(entry);
+        }
+        return {true, transactions};
+    });
+
+    m_transactionsWatcher.setFuture(future);
 }
 
 void FinchClient::fetchTimeSeries(const QString& fromDate, const QString& toDate,
@@ -347,6 +393,24 @@ void FinchClient::onCreateAccountFinished()
         m_accountsRefreshPending = true;
 
     emit accountCreated(result.id);
+}
+
+void FinchClient::onListTransactionsFinished()
+{
+    auto result = m_transactionsWatcher.result();
+
+    m_transactionsLoading = false;
+    emit transactionsLoadingChanged();
+
+    // #33 is read-only: no mutation can race this fetch, so no refresh-reconciliation
+    // machinery (cf. accounts). A failed fetch clears the list — the panel's empty/state
+    // message covers it; a dedicated error surface rides along with #38's write work.
+    if (result.ok) {
+        m_transactions = result.transactions;
+    } else {
+        m_transactions.clear();
+    }
+    emit transactionsChanged();
 }
 
 void FinchClient::onPingFinished()

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -163,14 +163,24 @@ void FinchClient::createAccount(const QString& name, int accountType)
 
 void FinchClient::listTransactions(const QString& accountId)
 {
+    m_requestedTransactionsAccountId = accountId;
+    // A fetch is already in flight; do not start a concurrent one (a second concurrent
+    // QtConcurrent task would no longer be waited on by the destructor and could outlive the
+    // stub). onListTransactionsFinished reconciles to the requested account once it lands.
     if (m_transactionsLoading)
         return;
 
+    startTransactionsFetch();
+}
+
+void FinchClient::startTransactionsFetch()
+{
     m_transactionsLoading = true;
+    m_inFlightTransactionsAccountId = m_requestedTransactionsAccountId;
     emit transactionsLoadingChanged();
 
     auto stub = m_stub.get();
-    std::string id = accountId.toStdString();
+    std::string id = m_inFlightTransactionsAccountId.toStdString();
     auto future = QtConcurrent::run([stub, id]() -> ListTransactionsResult {
         grpc::ClientContext context;
         context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(5));
@@ -402,9 +412,18 @@ void FinchClient::onListTransactionsFinished()
     m_transactionsLoading = false;
     emit transactionsLoadingChanged();
 
-    // #33 is read-only: no mutation can race this fetch, so no refresh-reconciliation
-    // machinery (cf. accounts). A failed fetch clears the list — the panel's empty/state
-    // message covers it; a dedicated error surface rides along with #38's write work.
+    // A newer account was selected while this fetch was in flight (a rapid account switch);
+    // its result is for the wrong account. Discard it and fetch the account now selected.
+    // This input-ordering race is independent of the read-only nature of the feature — it is
+    // about which account the user wants, not about a mutation racing the read.
+    if (m_inFlightTransactionsAccountId != m_requestedTransactionsAccountId) {
+        startTransactionsFetch();
+        return;
+    }
+
+    // A failed fetch clears the list — the panel's empty/state message covers it; a dedicated
+    // error surface rides along with the later transaction-recording work, where write
+    // failures make it load-bearing.
     if (result.ok) {
         m_transactions = result.transactions;
     } else {

--- a/app/src/finchclient.h
+++ b/app/src/finchclient.h
@@ -118,6 +118,11 @@ private slots:
     void onTimeSeriesFinished();
 
 private:
+    // Starts a transactions fetch for m_requestedTransactionsAccountId (latching it as the
+    // in-flight account). The re-entrancy guard in listTransactions and the reconciliation in
+    // onListTransactionsFinished both funnel through here.
+    void startTransactionsFetch();
+
     std::shared_ptr<grpc::Channel> m_channel;
     std::unique_ptr<finch::v1::FinchService::Stub> m_stub;
     QString m_version;
@@ -134,6 +139,13 @@ private:
     QFutureWatcher<CreateAccountResult> m_createAccountWatcher;
     QVariantList m_transactions;
     bool m_transactionsLoading = false;
+    // Single-in-flight reconciliation: the account the running fetch is for vs. the account
+    // most recently requested. When they diverge (a rapid account switch arrived mid-fetch),
+    // the stale result is discarded and the requested account re-fetched. Keyed on the
+    // account id, not a bool like the accounts path, because the correct reconciled fetch
+    // depends on which account is now selected.
+    QString m_requestedTransactionsAccountId;
+    QString m_inFlightTransactionsAccountId;
     QFutureWatcher<ListTransactionsResult> m_transactionsWatcher;
     bool m_timeSeriesLoading = false;
     QFutureWatcher<TimeSeriesResult> m_timeSeriesWatcher;

--- a/app/src/finchclient.h
+++ b/app/src/finchclient.h
@@ -31,6 +31,11 @@ struct CreateAccountResult {
     QString errorMessage;
 };
 
+struct ListTransactionsResult {
+    bool ok = false;
+    QVariantList transactions;
+};
+
 struct TimeSeriesPoint {
     qint64 msecsSinceEpoch;
     double balance;
@@ -49,6 +54,8 @@ class FinchClient : public QObject {
     Q_PROPERTY(QVariantList accounts READ accounts NOTIFY accountsChanged)
     Q_PROPERTY(bool accountsLoading READ accountsLoading NOTIFY accountsLoadingChanged)
     Q_PROPERTY(bool createAccountInProgress READ createAccountInProgress NOTIFY createAccountInProgressChanged)
+    Q_PROPERTY(QVariantList transactions READ transactions NOTIFY transactionsChanged)
+    Q_PROPERTY(bool transactionsLoading READ transactionsLoading NOTIFY transactionsLoadingChanged)
     Q_PROPERTY(bool timeSeriesLoading READ timeSeriesLoading NOTIFY timeSeriesLoadingChanged)
     Q_PROPERTY(bool timeSeriesEmpty READ timeSeriesEmpty NOTIFY timeSeriesDataChanged)
     Q_PROPERTY(QStringList timeSeriesAccountIds READ timeSeriesAccountIds NOTIFY timeSeriesDataChanged)
@@ -70,6 +77,8 @@ public:
     QVariantList accounts() const { return m_accounts; }
     bool accountsLoading() const { return m_accountsLoading; }
     bool createAccountInProgress() const { return m_createAccountInProgress; }
+    QVariantList transactions() const { return m_transactions; }
+    bool transactionsLoading() const { return m_transactionsLoading; }
     bool timeSeriesLoading() const { return m_timeSeriesLoading; }
     bool timeSeriesEmpty() const;
     QStringList timeSeriesAccountIds() const;
@@ -81,6 +90,7 @@ public:
     Q_INVOKABLE void ping();
     Q_INVOKABLE void listAccounts();
     Q_INVOKABLE void createAccount(const QString& name, int accountType);
+    Q_INVOKABLE void listTransactions(const QString& accountId);
     Q_INVOKABLE void fetchTimeSeries(const QString& fromDate, const QString& toDate,
                                      int interval, const QStringList& accountIds);
     Q_INVOKABLE void populateSeries(QObject* series, const QString& accountId);
@@ -94,6 +104,8 @@ signals:
     void createAccountInProgressChanged();
     void accountCreated(QString id);
     void accountCreateFailed(QString message);
+    void transactionsChanged();
+    void transactionsLoadingChanged();
     void timeSeriesLoadingChanged();
     void timeSeriesDataChanged();
 
@@ -102,6 +114,7 @@ private slots:
     void applyPingResult();
     void onListAccountsFinished();
     void onCreateAccountFinished();
+    void onListTransactionsFinished();
     void onTimeSeriesFinished();
 
 private:
@@ -119,6 +132,9 @@ private:
     QFutureWatcher<ListAccountsResult> m_accountsWatcher;
     bool m_createAccountInProgress = false;
     QFutureWatcher<CreateAccountResult> m_createAccountWatcher;
+    QVariantList m_transactions;
+    bool m_transactionsLoading = false;
+    QFutureWatcher<ListTransactionsResult> m_transactionsWatcher;
     bool m_timeSeriesLoading = false;
     QFutureWatcher<TimeSeriesResult> m_timeSeriesWatcher;
     TimeSeriesResult m_timeSeriesData;

--- a/app/tests/MockFinchClient.qml
+++ b/app/tests/MockFinchClient.qml
@@ -1,7 +1,7 @@
 import QtQuick
 
-// Test double for FinchClient: records createAccount calls and lets specs drive the
-// success/failure signals the form reacts to, with no daemon or gRPC involved.
+// Test double for FinchClient: records createAccount and listTransactions calls and lets
+// specs drive the resulting signals/data the components react to, with no daemon or gRPC.
 QtObject {
     property bool createAccountInProgress: false
     property string lastName: ""

--- a/app/tests/MockFinchClient.qml
+++ b/app/tests/MockFinchClient.qml
@@ -10,6 +10,14 @@ QtObject {
     // AccountsPanel binds its account list to this; default empty so the binding is clean.
     property var accounts: []
 
+    // TransactionsPanel binds its ListView model to this; default empty so the binding is
+    // clean. succeedTransactions() ASSIGNS it (not just emits) so the binding refreshes —
+    // see succeedTransactions below.
+    property var transactions: []
+    property string lastAccountId: ""
+    property int transactionsCallCount: 0
+    property bool transactionsLoading: false
+
     signal accountCreated(string id)
     signal accountCreateFailed(string message)
 
@@ -30,5 +38,19 @@ QtObject {
     function fail(message) {
         createAccountInProgress = false
         accountCreateFailed(message)
+    }
+
+    function listTransactions(accountId) {
+        lastAccountId = accountId
+        transactionsCallCount += 1
+        transactionsLoading = true
+    }
+
+    // Assigning `transactions` IS the notification the panel's model binding reacts to —
+    // exactly like the real client's transactionsChanged. A signal-only shape would leave
+    // the bound ListView stale and every render assertion failing against an empty view.
+    function succeedTransactions(list) {
+        transactionsLoading = false
+        transactions = list
     }
 }

--- a/app/tests/MockFinchClient.qml
+++ b/app/tests/MockFinchClient.qml
@@ -17,6 +17,12 @@ QtObject {
     property string lastAccountId: ""
     property int transactionsCallCount: 0
     property bool transactionsLoading: false
+    // Faithful to the real client's single-in-flight reconciliation (see listTransactions /
+    // succeedTransactions): the account the running fetch is for, vs. the account most
+    // recently requested. When they diverge, a stale completion is discarded and the
+    // requested account re-fetched — so panel specs see the real states during a rapid
+    // account switch rather than an unrealistic two-concurrent-fetch model.
+    property string inFlightAccountId: ""
 
     signal accountCreated(string id)
     signal accountCreateFailed(string message)
@@ -40,17 +46,31 @@ QtObject {
         accountCreateFailed(message)
     }
 
+    // callCount counts invocations (every call). The re-entrancy guard mirrors the real
+    // client: a second request while a fetch is in flight is recorded as the new requested
+    // account but does NOT start a concurrent fetch — it is reconciled on completion.
     function listTransactions(accountId) {
         lastAccountId = accountId
         transactionsCallCount += 1
+        if (transactionsLoading)
+            return
+        inFlightAccountId = accountId
         transactionsLoading = true
     }
 
-    // Assigning `transactions` IS the notification the panel's model binding reacts to —
-    // exactly like the real client's transactionsChanged. A signal-only shape would leave
-    // the bound ListView stale and every render assertion failing against an empty view.
+    // Models the in-flight fetch (for inFlightAccountId) completing. Assigning `transactions`
+    // IS the notification the panel's model binding reacts to — exactly like the real
+    // client's transactionsChanged; a signal-only shape would leave the bound ListView stale.
+    // If a newer account was requested meanwhile, this completion is stale: discard `list`
+    // and re-enter the in-flight state for the requested account (the spec drives the next
+    // succeedTransactions to complete that reconciled fetch).
     function succeedTransactions(list) {
         transactionsLoading = false
+        if (inFlightAccountId !== lastAccountId) {
+            inFlightAccountId = lastAccountId
+            transactionsLoading = true
+            return
+        }
         transactions = list
     }
 }

--- a/app/tests/MockFinchClient.qml
+++ b/app/tests/MockFinchClient.qml
@@ -56,6 +56,7 @@ QtObject {
             return
         inFlightAccountId = accountId
         transactionsLoading = true
+        transactions = []   // clear at fetch start, like the real client
     }
 
     // Models the in-flight fetch (for inFlightAccountId) completing. Assigning `transactions`
@@ -69,6 +70,7 @@ QtObject {
         if (inFlightAccountId !== lastAccountId) {
             inFlightAccountId = lastAccountId
             transactionsLoading = true
+            transactions = []   // re-fetch clears too, like the real client
             return
         }
         transactions = list

--- a/app/tests/transactionspanel/tst_TransactionsPanel.qml
+++ b/app/tests/transactionspanel/tst_TransactionsPanel.qml
@@ -174,6 +174,17 @@ TestCase {
         verify(ctx.panel.selectedTransaction === null)
     }
 
+    // Switching account clears the prior account's rows immediately, during the new fetch's
+    // in-flight window — the list never shows account A's transactions under account B.
+    function test_switchingAccountClearsPriorRowsWhileLoading() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleTransactions)
+        compare(ctx.panel.transactionList.count, 2)
+        ctx.panel.selectedAccountIndex = 1          // new fetch in flight, no data yet
+        verify(ctx.mock.transactionsLoading)
+        compare(ctx.panel.transactionList.count, 0) // account 0's rows are gone, not stale
+    }
+
     // Rapid account switch: selecting B while A's fetch is still in flight must end with B's
     // transactions shown, never A's. The client defers B's fetch behind A's, then on A's
     // completion discovers the selection moved on, discards A's result, and re-fetches B.

--- a/app/tests/transactionspanel/tst_TransactionsPanel.qml
+++ b/app/tests/transactionspanel/tst_TransactionsPanel.qml
@@ -174,6 +174,26 @@ TestCase {
         verify(ctx.panel.selectedTransaction === null)
     }
 
+    // Rapid account switch: selecting B while A's fetch is still in flight must end with B's
+    // transactions shown, never A's. The client defers B's fetch behind A's, then on A's
+    // completion discovers the selection moved on, discards A's result, and re-fetches B.
+    function test_midFetchSwitchReconcilesToRequestedAccount() {
+        var ctx = build()
+        ctx.panel.selectedAccountIndex = 0          // A: fetch in flight
+        verify(ctx.mock.transactionsLoading)
+        ctx.panel.selectedAccountIndex = 1          // B requested before A completes
+        compare(ctx.mock.lastAccountId, "a2")
+        // A completes — but B is now selected, so A's data must be discarded, not applied,
+        // and B re-fetched (the list passed here stands in for A's data).
+        ctx.mock.succeedTransactions(sampleTransactions)
+        verify(ctx.mock.transactionsLoading)        // reconciling: B's re-fetch in flight
+        compare(ctx.panel.transactionList.count, 0) // A's data was NOT applied
+        // B completes; its data finally lands.
+        ctx.mock.succeedTransactions([sampleTransactions[1]])
+        verify(!ctx.mock.transactionsLoading)
+        compare(ctx.panel.transactionList.count, 1)
+    }
+
     // New data for the same account also clears the prior selection (a stale index could
     // point past the end of a shorter incoming list).
     function test_newDataResetsSelection() {

--- a/app/tests/transactionspanel/tst_TransactionsPanel.qml
+++ b/app/tests/transactionspanel/tst_TransactionsPanel.qml
@@ -1,0 +1,181 @@
+import QtQuick
+import QtTest
+// FinchTransactionsTest is the test-only module (see app/CMakeLists.txt) holding the real
+// shipping TransactionsPanel and the shared MockFinchClient double — scoped to just those
+// two files so the test doesn't pull in the rest of the app's QML and its modules.
+import FinchTransactionsTest
+
+TestCase {
+    id: testCase
+    name: "TransactionsPanel"
+    when: windowShown
+    width: 640
+    height: 480
+
+    Component {
+        id: panelFactory
+        TransactionsPanel {}
+    }
+
+    Component {
+        id: mockFactory
+        MockFinchClient {}
+    }
+
+    property var currentPanel: null
+    property var currentMock: null
+
+    // Two accounts so an account-switch test has a second option to select.
+    readonly property var sampleAccounts: [
+        { id: "a1", name: "Checking" },
+        { id: "a2", name: "Savings" }
+    ]
+
+    // One reconciled credit (positive) and one projected debit (negative), so a single
+    // fixture pins both the sign-correct amount format and the status->label mapping.
+    readonly property var sampleTransactions: [
+        { id: "t1", accountId: "a1", date: "2026-01-15", amount: 5000,
+          name: "Paycheck", description: "Jan salary", status: 3, recurringRuleId: "r1" },
+        { id: "t2", accountId: "a1", date: "2026-01-20", amount: -1234,
+          name: "Coffee", description: "", status: 1, recurringRuleId: "" }
+    ]
+
+    // Returns { panel, mock }; accounts are set on the mock BEFORE the panel is built so the
+    // ComboBox model is already populated at completion — the realistic case, and the only
+    // way to prove the panel does not auto-fetch despite a non-empty account list.
+    function build(opts) {
+        opts = opts || {}
+        currentMock = mockFactory.createObject(testCase)
+        currentMock.accounts = (opts.accounts !== undefined) ? opts.accounts : sampleAccounts
+        var props = { client: currentMock }
+        props.connected = (opts.connected !== undefined) ? opts.connected : true
+        currentPanel = panelFactory.createObject(testCase, props)
+        verify(currentPanel !== null, "panel instantiated")
+        return { panel: currentPanel, mock: currentMock }
+    }
+
+    function cleanup() {
+        if (currentPanel) { currentPanel.destroy(); currentPanel = null }
+        if (currentMock) { currentMock.destroy(); currentMock = null }
+    }
+
+    // Helper: select an account and deliver a transaction list in one step.
+    function selectAccountWith(ctx, index, txns) {
+        ctx.panel.selectedAccountIndex = index
+        ctx.mock.succeedTransactions(txns)
+    }
+
+    function test_loadsAndStartsUnselected() {
+        var ctx = build()
+        compare(ctx.panel.selectedAccountIndex, -1)
+        compare(ctx.mock.transactionsCallCount, 0)
+    }
+
+    // A fresh panel with accounts present must NOT auto-fetch; the fetch fires only once a
+    // real account is chosen (the ComboBox starts at currentIndex -1, not an index-0 default).
+    function test_noFetchUntilAccountSelected() {
+        var ctx = build()
+        compare(ctx.mock.transactionsCallCount, 0)
+        ctx.panel.selectedAccountIndex = 0
+        compare(ctx.mock.transactionsCallCount, 1)
+        compare(ctx.mock.lastAccountId, "a1")
+    }
+
+    function test_selectingAccountListsThatAccount() {
+        var ctx = build()
+        ctx.panel.selectedAccountIndex = 1
+        compare(ctx.mock.transactionsCallCount, 1)
+        compare(ctx.mock.lastAccountId, "a2")
+    }
+
+    function test_changingAccountRefetches() {
+        var ctx = build()
+        ctx.panel.selectedAccountIndex = 0
+        ctx.panel.selectedAccountIndex = 1
+        compare(ctx.mock.transactionsCallCount, 2)
+        compare(ctx.mock.lastAccountId, "a2")
+    }
+
+    function test_transactionsRenderAsRows() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleTransactions)
+        compare(ctx.panel.transactionList.count, 2)
+    }
+
+    function test_selectingRowFillsDetail() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleTransactions)
+        ctx.panel.transactionList.currentIndex = 0
+        verify(ctx.panel.selectedTransaction !== null)
+        compare(ctx.panel.detailNameText, "Paycheck")
+        compare(ctx.panel.detailDateText, "2026-01-15")
+        compare(ctx.panel.detailDescriptionText, "Jan salary")
+        compare(ctx.panel.detailRecurringRuleText, "r1")
+    }
+
+    function test_positiveAmountFormatted() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleTransactions)
+        ctx.panel.transactionList.currentIndex = 0
+        compare(ctx.panel.detailAmountText, "$50.00")
+    }
+
+    // The negative row pins the sign-correct format: "-$12.34", never "$-12.34".
+    function test_negativeAmountFormattedWithSign() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleTransactions)
+        ctx.panel.transactionList.currentIndex = 1
+        compare(ctx.panel.detailAmountText, "-$12.34")
+    }
+
+    function test_statusRenderedAsLabelNotInt() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleTransactions)
+        ctx.panel.transactionList.currentIndex = 0
+        compare(ctx.panel.detailStatusText, "Reconciled")
+        ctx.panel.transactionList.currentIndex = 1
+        compare(ctx.panel.detailStatusText, "Projected")
+    }
+
+    function test_emptyResultShowsNoTransactions() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, [])
+        verify(ctx.panel.stateMessageVisible)
+        compare(ctx.panel.stateMessageText, "No transactions for this account.")
+    }
+
+    function test_noAccountSelectedShowsPrompt() {
+        var ctx = build()
+        verify(ctx.panel.stateMessageVisible)
+        compare(ctx.panel.stateMessageText, "Select an account to view its transactions.")
+    }
+
+    function test_disconnectedShowsConnectHint() {
+        var ctx = build({ connected: false, accounts: [] })
+        verify(ctx.panel.stateMessageVisible)
+        compare(ctx.panel.stateMessageText, "Connect to the daemon to view transactions.")
+    }
+
+    // Switching the selected account must drop the prior detail selection, so the detail
+    // pane never reads a row index that no longer exists in the incoming list.
+    function test_changingAccountResetsSelection() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleTransactions)
+        ctx.panel.transactionList.currentIndex = 0
+        verify(ctx.panel.selectedTransaction !== null)
+        ctx.panel.selectedAccountIndex = 1
+        compare(ctx.panel.transactionList.currentIndex, -1)
+        verify(ctx.panel.selectedTransaction === null)
+    }
+
+    // New data for the same account also clears the prior selection (a stale index could
+    // point past the end of a shorter incoming list).
+    function test_newDataResetsSelection() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleTransactions)
+        ctx.panel.transactionList.currentIndex = 1
+        ctx.mock.succeedTransactions([])
+        compare(ctx.panel.transactionList.currentIndex, -1)
+        verify(ctx.panel.selectedTransaction === null)
+    }
+}

--- a/app/tests/transactionspanel/tst_TransactionsPanel.qml
+++ b/app/tests/transactionspanel/tst_TransactionsPanel.qml
@@ -166,6 +166,12 @@ TestCase {
         ctx.panel.selectedAccountIndex = 1
         compare(ctx.panel.transactionList.currentIndex, -1)
         verify(ctx.panel.selectedTransaction === null)
+        // Follow through with the new account's (shorter) data: the selection must stay
+        // cleared once the swapped list actually arrives, not only at the synchronous reset.
+        ctx.mock.succeedTransactions([sampleTransactions[1]])
+        compare(ctx.panel.transactionList.count, 1)
+        compare(ctx.panel.transactionList.currentIndex, -1)
+        verify(ctx.panel.selectedTransaction === null)
     }
 
     // New data for the same account also clears the prior selection (a stale index could

--- a/app/tests/tst_transactionspanel.cpp
+++ b/app/tests/tst_transactionspanel.cpp
@@ -1,0 +1,6 @@
+// Qt Quick Test entry point. QUICK_TEST_MAIN scans QUICK_TEST_SOURCE_DIR (set in
+// CMake) for tst_*.qml at runtime; the specs load the panel via a directory import,
+// so no C++ type registration is needed here.
+#include <QtQuickTest/quicktest.h>
+
+QUICK_TEST_MAIN(transactionspanel)


### PR DESCRIPTION
## Overview

The Qt app could only show the aggregated balance chart; individual transaction records were invisible without going through the MCP tools, so reconciling against a bank statement or verifying a recurring rule's output had no in-app path. This adds a per-account Transactions screen: pick an account, browse its transactions in a master list, and select one to see its full details (date, name, amount, status, description, and recurring-rule association). The screen is master-detail — a deliberate step up from the flat Accounts list, justified by transactions' richer per-record data.

## How it works

The account selector starts unselected, so a fresh screen fetches nothing until a real account is chosen. Amounts are signed cents formatted sign-correct, and the transaction status maps to a human label rather than a raw enum value.

Rapid account switching is reconciled in the client: if you select a second account while the first account's fetch is still in flight, the client defers the second request, then on completion discards the now-stale result and re-fetches the account you actually have selected — so the list can never show one account's transactions under another's selector. Error surfacing is intentionally left to the later transaction-recording work, where write failures make it load-bearing; this screen covers loading, empty, and disconnected states only.

Closes #33
