### PR TITLE
feat(app): record a manual transaction from the Transactions screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Qt app: create accounts through a UI form (previously only via MCP tools).
 - Qt app: view an account's individual transactions on the Transactions screen — pick an account, browse its transactions in a list, and select one to see its full details (previously only the aggregated balance chart was visible).
+- Qt app: record a manual transaction against an account from the Transactions screen — enter a name, amount, and Expense/Income, with a live signed-amount preview and the date defaulting to today (previously only via MCP tools).
 
 ### Changed
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -80,6 +80,8 @@ qt_add_qml_module(finch-app
         qml/NavigationShell.qml
         qml/AccountsPanel.qml
         qml/TransactionsPanel.qml
+        qml/RecordTransactionForm.qml
+        qml/txformat.js
         qml/PlaceholderScreen.qml
 )
 
@@ -168,6 +170,8 @@ qt_add_qml_module(tst_transactionspanel
     VERSION 1.0
     QML_FILES
         qml/TransactionsPanel.qml
+        qml/RecordTransactionForm.qml
+        qml/txformat.js
         tests/MockFinchClient.qml
 )
 
@@ -184,4 +188,35 @@ target_link_libraries(tst_transactionspanel PRIVATE
 add_test(NAME tst_transactionspanel COMMAND tst_transactionspanel)
 
 set_tests_properties(tst_transactionspanel PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_CONTROLS_STYLE=Basic")
+
+# --- RecordTransactionForm test ---
+add_executable(tst_recordtransactionform tests/tst_recordtransactionform.cpp)
+
+# A test-only module scoped to the real record form, the txformat.js helper it imports, and
+# the shared mock client. The relative `import "txformat.js"` resolves only because the helper
+# is listed in the SAME module as the importing form — the module-membership invariant that
+# also applies to the main module and the transactionspanel module.
+qt_add_qml_module(tst_recordtransactionform
+    URI FinchRecordTest
+    VERSION 1.0
+    QML_FILES
+        qml/RecordTransactionForm.qml
+        qml/txformat.js
+        tests/MockFinchClient.qml
+)
+
+target_compile_definitions(tst_recordtransactionform PRIVATE
+    QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/recordtransactionform")
+
+target_link_libraries(tst_recordtransactionform PRIVATE
+    Qt6::Quick
+    Qt6::QuickControls2
+    Qt6::QuickTest
+    Qt6::Qml
+)
+
+add_test(NAME tst_recordtransactionform COMMAND tst_recordtransactionform)
+
+set_tests_properties(tst_recordtransactionform PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_CONTROLS_STYLE=Basic")

--- a/app/qml/RecordTransactionForm.qml
+++ b/app/qml/RecordTransactionForm.qml
@@ -1,0 +1,174 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import "txformat.js" as TxFormat
+
+// Self-contained transaction-recording form. Like CreateAccountForm it depends only on an
+// injected `client` (the production FinchClient, a mock in tests) and an injected `accountId`
+// — the target account is fed from the Transactions screen's existing selector, so the form
+// carries no second account picker. Deliberately importing no Finch C++ type keeps it
+// instantiable by the Qt Quick Test harness with a mock client and no daemon.
+Item {
+    id: form
+
+    // Injected by the host: Main.qml/TransactionsPanel passes finchClient; tests pass a mock.
+    required property var client
+
+    // Injected target account. Empty string means no account selected — the form stays
+    // invalid, since a transaction must record against an account.
+    property string accountId: ""
+
+    // Public, test-facing surface — specs drive the form through these rather than reaching
+    // into private control ids.
+    property alias nameText: nameField.text
+    property alias amountText: amountField.text
+    property alias dateText: dateField.text
+    property alias descriptionText: descriptionField.text
+    property alias errorText: errorLabel.text
+    // Expense (true, default) vs Income. The single sign source: the magnitude field cannot
+    // express a sign, so this toggle alone decides whether cents are negative or positive.
+    property bool expense: true
+
+    // Derived state — one set of predicates shared by canSubmit, the preview, and the button,
+    // so they can never disagree at a boundary.
+    // parseFloat is NaN when the field is blank or non-numeric; the regex validator already
+    // forbids a sign or a comma decimal, so parseFloat reads the magnitude locale-cleanly.
+    readonly property real magnitude: parseFloat(amountField.text)
+    // Reject 0 and NaN: a $0 manual transaction is meaningless, and the daemon does not
+    // validate amount at all, so this form is the sole gate on amount quality.
+    readonly property bool amountValid: !isNaN(magnitude) && magnitude > 0
+    // Math.round avoids float drift (12.34 * 100 -> 1233.9999...); the toggle applies the sign.
+    readonly property int signedCents: amountValid ? Math.round(magnitude * 100) * (expense ? -1 : 1) : 0
+    readonly property string previewText: amountValid ? TxFormat.formatAmount(signedCents) : ""
+
+    // canSubmit is the single validation predicate the button and the specs share.
+    readonly property bool canSubmit:
+        accountId !== ""
+        && nameField.text.trim().length > 0
+        && amountValid
+        && !(client && client.recordTransactionInProgress)
+
+    // Emitted once the daemon confirms the record; the host re-fetches the account on it.
+    signal recorded(string id)
+
+    implicitWidth: 360
+    implicitHeight: layout.implicitHeight
+
+    function submit() {
+        if (!canSubmit)
+            return
+        errorLabel.text = ""
+        // status 3 == TRANSACTION_STATUS_RECONCILED. #38 records actual events; the
+        // Projected/Scheduled statuses belong to the recurring/projection world.
+        client.recordTransaction(accountId, dateField.text, signedCents,
+                                 nameField.text.trim(), descriptionField.text, 3)
+    }
+
+    Connections {
+        target: form.client
+        function onTransactionRecorded(id) {
+            nameField.text = ""
+            amountField.text = ""
+            descriptionField.text = ""
+            errorLabel.text = ""
+            form.recorded(id)
+        }
+        function onTransactionRecordFailed(message) {
+            errorLabel.text = message
+        }
+    }
+
+    ColumnLayout {
+        id: layout
+        anchors.fill: parent
+        spacing: 12
+
+        Label { text: "Name" }
+        TextField {
+            id: nameField
+            Layout.fillWidth: true
+            placeholderText: "e.g. Groceries"
+            onTextChanged: errorLabel.text = ""
+        }
+
+        Label { text: "Amount" }
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 12
+
+            TextField {
+                id: amountField
+                Layout.fillWidth: true
+                placeholderText: "0.00"
+                inputMethodHints: Qt.ImhFormattedNumbersOnly
+                // Locale-independent: always "." (matching parseFloat), forbids a leading "-"
+                // so the Expense/Income toggle is the sole sign source, caps at 2 decimals.
+                // A default-locale DoubleValidator would accept "19,99", which parseFloat
+                // truncates to 19 — the regex avoids that mismatch.
+                validator: RegularExpressionValidator { regularExpression: /^\d+(\.\d{0,2})?$/ }
+                onTextChanged: errorLabel.text = ""
+            }
+
+            // Live signed-amount preview: the sign is visible before submit, so the user sees
+            // an Expense will subtract before committing it.
+            Label {
+                text: form.previewText
+                color: form.expense ? "#c0392b" : "#27ae60"
+                visible: form.previewText.length > 0
+            }
+        }
+
+        // Expense/Income toggle. The magnitude field cannot carry a sign, so this is the only
+        // way the user expresses direction — a control that can't express the wrong value.
+        RowLayout {
+            spacing: 12
+            ButtonGroup { id: signGroup }
+            RadioButton {
+                id: expenseRadio
+                text: "Expense"
+                ButtonGroup.group: signGroup
+                checked: form.expense
+                onClicked: form.expense = true
+            }
+            RadioButton {
+                id: incomeRadio
+                text: "Income"
+                ButtonGroup.group: signGroup
+                onClicked: form.expense = false
+            }
+        }
+
+        Label { text: "Date" }
+        TextField {
+            id: dateField
+            Layout.fillWidth: true
+            // Local-calendar "today" by design: the field is user-editable and the daemon
+            // takes the date string at face value (no zone conversion), so a local default
+            // matches the user's intent.
+            text: Qt.formatDate(new Date(), "yyyy-MM-dd")
+        }
+
+        Label { text: "Description" }
+        TextField {
+            id: descriptionField
+            Layout.fillWidth: true
+            placeholderText: "Optional"
+        }
+
+        Label {
+            id: errorLabel
+            Layout.fillWidth: true
+            color: "#c0392b"
+            wrapMode: Text.WordWrap
+            visible: text.length > 0
+        }
+
+        Button {
+            id: submitButton
+            text: (form.client && form.client.recordTransactionInProgress)
+                  ? "Recording…" : "Record transaction"
+            enabled: form.canSubmit
+            onClicked: form.submit()
+        }
+    }
+}

--- a/app/qml/RecordTransactionForm.qml
+++ b/app/qml/RecordTransactionForm.qml
@@ -128,13 +128,13 @@ Item {
                 text: "Expense"
                 ButtonGroup.group: signGroup
                 checked: form.expense
-                onClicked: form.expense = true
+                onClicked: { form.expense = true; errorLabel.text = "" }
             }
             RadioButton {
                 id: incomeRadio
                 text: "Income"
                 ButtonGroup.group: signGroup
-                onClicked: form.expense = false
+                onClicked: { form.expense = false; errorLabel.text = "" }
             }
         }
 
@@ -146,6 +146,9 @@ Item {
             // takes the date string at face value (no zone conversion), so a local default
             // matches the user's intent.
             text: Qt.formatDate(new Date(), "yyyy-MM-dd")
+            // Drop a stale daemon error the moment the user edits any input — consistent with
+            // the name/amount fields, so fixing the rejected field clears its message.
+            onTextChanged: errorLabel.text = ""
         }
 
         Label { text: "Description" }
@@ -153,6 +156,7 @@ Item {
             id: descriptionField
             Layout.fillWidth: true
             placeholderText: "Optional"
+            onTextChanged: errorLabel.text = ""
         }
 
         Label {

--- a/app/qml/RecordTransactionForm.qml
+++ b/app/qml/RecordTransactionForm.qml
@@ -38,7 +38,10 @@ Item {
     // validate amount at all, so this form is the sole gate on amount quality.
     readonly property bool amountValid: !isNaN(magnitude) && magnitude > 0
     // Math.round avoids float drift (12.34 * 100 -> 1233.9999...); the toggle applies the sign.
-    readonly property int signedCents: amountValid ? Math.round(magnitude * 100) * (expense ? -1 : 1) : 0
+    // Typed var, not int: the client's amount is a 64-bit qlonglong, and a QML int is 32-bit —
+    // an int here would overflow above ~$21.5M and record a truncated amount. A JS number
+    // marshals cleanly to qlonglong (exact integers up to 2^53).
+    readonly property var signedCents: amountValid ? Math.round(magnitude * 100) * (expense ? -1 : 1) : 0
     readonly property string previewText: amountValid ? TxFormat.formatAmount(signedCents) : ""
 
     // canSubmit is the single validation predicate the button and the specs share.

--- a/app/qml/TransactionsPanel.qml
+++ b/app/qml/TransactionsPanel.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import "txformat.js" as TxFormat
 
 // Transactions destination: a per-account master-detail view. An account selector drives a
 // per-account fetch; the master list shows one row per transaction; selecting a row fills
@@ -24,6 +25,14 @@ Item {
     // The account list backing the selector; the transaction list backing the master view.
     readonly property var accounts: client ? client.accounts : []
     readonly property var transactions: client ? client.transactions : []
+
+    // The id of the currently selected account, or "" when none is chosen. Single source for
+    // both the record form's injected accountId and the post-record re-fetch, so the two can
+    // never diverge; onAccountSelected reads it too rather than re-deriving the index->id.
+    readonly property string currentAccountId:
+        (client && accountCombo.currentIndex >= 0 && accounts[accountCombo.currentIndex])
+            ? accounts[accountCombo.currentIndex].id
+            : ""
 
     // The currently selected transaction, or null when nothing valid is selected. Null-guards
     // the detail pane against transactions[-1] / an index past the end of a shorter new list.
@@ -49,28 +58,15 @@ Item {
     property alias detailStatusText: detailStatus.text
     property alias detailDescriptionText: detailDescription.text
     property alias detailRecurringRuleText: detailRecurringRule.text
-
-    // TransactionStatus enum (proto int 0-3) -> human label. No app-wide status map exists
-    // yet; defined inline here, mirroring how CreateAccountForm hardcodes its AccountType map.
-    function statusLabel(status) {
-        switch (status) {
-        case 1: return "Projected"
-        case 2: return "Scheduled"
-        case 3: return "Reconciled"
-        default: return "Unspecified"
-        }
-    }
-
-    // Signed int64 cents -> sign-correct currency. Math.abs keeps the "-" ahead of the "$"
-    // ("-$12.34", not "$-12.34").
-    // TODO: lift this (and statusLabel) into a shared helper once #38's record form needs it.
-    function formatAmount(cents) {
-        return (cents < 0 ? "-$" : "$") + Math.abs(cents / 100).toFixed(2)
-    }
+    // Test surface: the panel spec reaches the embedded record form through this.
+    property alias recordForm: recordTxForm
 
     function onAccountSelected() {
         // Drop any prior detail selection: the incoming list is a different account's.
         list.currentIndex = -1
+        // Read the freshly-changed index directly rather than the derived currentAccountId:
+        // inside this change handler that binding can still hold its pre-change value (the
+        // dependent binding is not guaranteed re-evaluated before this explicit handler runs).
         if (accountCombo.currentIndex >= 0 && client) {
             var account = accounts[accountCombo.currentIndex]
             if (account)
@@ -108,6 +104,23 @@ Item {
             currentIndex: -1
             displayText: currentIndex < 0 ? "Select an account…" : currentText
             onCurrentIndexChanged: panel.onAccountSelected()
+        }
+
+        // Record-transaction form, seated above the master-detail content and fed by the
+        // selector above it (no second account picker). Disabled until the daemon is connected
+        // and an account is chosen — there is nothing to record against otherwise.
+        RecordTransactionForm {
+            id: recordTxForm
+            Layout.fillWidth: true
+            client: panel.client
+            accountId: panel.currentAccountId
+            enabled: panel.connected && panel.currentAccountId !== ""
+            // The daemon persists before transactionRecorded fires, so re-fetching the account
+            // here brings the new row in; the onTransactionsChanged Connection clears selection.
+            onRecorded: {
+                if (panel.currentAccountId !== "")
+                    panel.client.listTransactions(panel.currentAccountId)
+            }
         }
 
         RowLayout {
@@ -152,8 +165,8 @@ Item {
                             elide: Text.ElideRight
                             text: row.modelData.name
                         }
-                        Label { text: panel.statusLabel(row.modelData.status) }
-                        Label { text: panel.formatAmount(row.modelData.amount) }
+                        Label { text: TxFormat.statusLabel(row.modelData.status) }
+                        Label { text: TxFormat.formatAmount(row.modelData.amount) }
                     }
                 }
             }
@@ -186,13 +199,13 @@ Item {
                     Label { text: "Amount"; font.bold: true }
                     Label {
                         id: detailAmount
-                        text: panel.selectedTransaction ? panel.formatAmount(panel.selectedTransaction.amount) : ""
+                        text: panel.selectedTransaction ? TxFormat.formatAmount(panel.selectedTransaction.amount) : ""
                     }
 
                     Label { text: "Status"; font.bold: true }
                     Label {
                         id: detailStatus
-                        text: panel.selectedTransaction ? panel.statusLabel(panel.selectedTransaction.status) : ""
+                        text: panel.selectedTransaction ? TxFormat.statusLabel(panel.selectedTransaction.status) : ""
                     }
 
                     Label { text: "Description"; font.bold: true }

--- a/app/qml/txformat.js
+++ b/app/qml/txformat.js
@@ -1,0 +1,21 @@
+// Shared transaction-formatting helpers, lifted verbatim from TransactionsPanel so the
+// record form's live amount preview and the panel's master/detail both read from one source.
+// Stateless pure functions, so .pragma library (one shared instance, no per-import context).
+.pragma library
+
+// TransactionStatus enum (proto int 0-3) -> human label. No app-wide status map exists yet;
+// the proto enum values are mirrored here (Projected=1, Scheduled=2, Reconciled=3).
+function statusLabel(status) {
+    switch (status) {
+    case 1: return "Projected"
+    case 2: return "Scheduled"
+    case 3: return "Reconciled"
+    default: return "Unspecified"
+    }
+}
+
+// Signed int64 cents -> sign-correct currency. Math.abs keeps the "-" ahead of the "$"
+// ("-$12.34", not "$-12.34").
+function formatAmount(cents) {
+    return (cents < 0 ? "-$" : "$") + Math.abs(cents / 100).toFixed(2)
+}

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -29,6 +29,8 @@ FinchClient::FinchClient(const QString& socketPath, QObject* parent)
             this, &FinchClient::onCreateAccountFinished);
     connect(&m_transactionsWatcher, &QFutureWatcher<ListTransactionsResult>::finished,
             this, &FinchClient::onListTransactionsFinished);
+    connect(&m_recordTransactionWatcher, &QFutureWatcher<RecordTransactionResult>::finished,
+            this, &FinchClient::onRecordTransactionFinished);
     connect(&m_timeSeriesWatcher, &QFutureWatcher<TimeSeriesResult>::finished,
             this, &FinchClient::onTimeSeriesFinished);
 }
@@ -39,6 +41,7 @@ FinchClient::~FinchClient()
     m_accountsWatcher.waitForFinished();
     m_createAccountWatcher.waitForFinished();
     m_transactionsWatcher.waitForFinished();
+    m_recordTransactionWatcher.waitForFinished();
     m_timeSeriesWatcher.waitForFinished();
 }
 
@@ -218,6 +221,71 @@ void FinchClient::startTransactionsFetch()
     });
 
     m_transactionsWatcher.setFuture(future);
+}
+
+void FinchClient::recordTransaction(const QString& accountId, const QString& date,
+                                    qlonglong amount, const QString& name,
+                                    const QString& description, int status)
+{
+    // Authoritative re-entrancy guard, mirroring createAccount: the QML submit-disable is
+    // cosmetic, so without this a rapid double-submit could fire two RecordTransaction RPCs
+    // (the daemon does not dedupe) and record two transactions.
+    if (m_recordTransactionInProgress)
+        return;
+
+    m_recordTransactionInProgress = true;
+    emit recordTransactionInProgressChanged();
+
+    auto stub = m_stub.get();
+    std::string accountIdStr = accountId.toStdString();
+    std::string dateStr = date.toStdString();
+    std::string nameStr = name.toStdString();
+    std::string descriptionStr = description.toStdString();
+    auto future = QtConcurrent::run([stub, accountIdStr, dateStr, amount, nameStr,
+                                     descriptionStr, status]() -> RecordTransactionResult {
+        grpc::ClientContext context;
+        context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(5));
+
+        finch::v1::RecordTransactionRequest request;
+        request.set_account_id(accountIdStr);
+        request.set_date(dateStr);
+        request.set_amount(amount);
+        request.set_name(nameStr);
+        request.set_description(descriptionStr);
+        request.set_status(static_cast<finch::v1::TransactionStatus>(status));
+
+        finch::v1::RecordTransactionResponse response;
+        grpc::Status grpcStatus = stub->RecordTransaction(&context, request, &response);
+
+        RecordTransactionResult result;
+        if (grpcStatus.ok()) {
+            result.ok = true;
+            result.id = QString::fromStdString(response.transaction().id());
+            return result;
+        }
+
+        // Surface the daemon's validation message verbatim (it is user-facing and specific);
+        // everything else gets a generic message rather than a raw low-level gRPC string.
+        // status only lives on this worker thread, so the message is copied into the result
+        // and emitted from the GUI-thread slot.
+        switch (grpcStatus.error_code()) {
+        case grpc::StatusCode::INVALID_ARGUMENT:
+            result.errorMessage = QString::fromStdString(grpcStatus.error_message());
+            break;
+        case grpc::StatusCode::UNAVAILABLE:
+            result.errorMessage = QStringLiteral("Could not reach the daemon.");
+            break;
+        case grpc::StatusCode::DEADLINE_EXCEEDED:
+            result.errorMessage = QStringLiteral("The request timed out. Please try again.");
+            break;
+        default:
+            result.errorMessage = QStringLiteral("Could not record the transaction. Please try again.");
+            break;
+        }
+        return result;
+    });
+
+    m_recordTransactionWatcher.setFuture(future);
 }
 
 void FinchClient::fetchTimeSeries(const QString& fromDate, const QString& toDate,
@@ -436,6 +504,21 @@ void FinchClient::onListTransactionsFinished()
         m_transactions.clear();
     }
     emit transactionsChanged();
+}
+
+void FinchClient::onRecordTransactionFinished()
+{
+    auto result = m_recordTransactionWatcher.result();
+
+    m_recordTransactionInProgress = false;
+    emit recordTransactionInProgressChanged();
+
+    if (!result.ok) {
+        emit transactionRecordFailed(result.errorMessage);
+        return;
+    }
+
+    emit transactionRecorded(result.id);
 }
 
 void FinchClient::onPingFinished()

--- a/app/src/finchclient.h
+++ b/app/src/finchclient.h
@@ -36,6 +36,12 @@ struct ListTransactionsResult {
     QVariantList transactions;
 };
 
+struct RecordTransactionResult {
+    bool ok = false;
+    QString id;
+    QString errorMessage;
+};
+
 struct TimeSeriesPoint {
     qint64 msecsSinceEpoch;
     double balance;
@@ -56,6 +62,7 @@ class FinchClient : public QObject {
     Q_PROPERTY(bool createAccountInProgress READ createAccountInProgress NOTIFY createAccountInProgressChanged)
     Q_PROPERTY(QVariantList transactions READ transactions NOTIFY transactionsChanged)
     Q_PROPERTY(bool transactionsLoading READ transactionsLoading NOTIFY transactionsLoadingChanged)
+    Q_PROPERTY(bool recordTransactionInProgress READ recordTransactionInProgress NOTIFY recordTransactionInProgressChanged)
     Q_PROPERTY(bool timeSeriesLoading READ timeSeriesLoading NOTIFY timeSeriesLoadingChanged)
     Q_PROPERTY(bool timeSeriesEmpty READ timeSeriesEmpty NOTIFY timeSeriesDataChanged)
     Q_PROPERTY(QStringList timeSeriesAccountIds READ timeSeriesAccountIds NOTIFY timeSeriesDataChanged)
@@ -79,6 +86,7 @@ public:
     bool createAccountInProgress() const { return m_createAccountInProgress; }
     QVariantList transactions() const { return m_transactions; }
     bool transactionsLoading() const { return m_transactionsLoading; }
+    bool recordTransactionInProgress() const { return m_recordTransactionInProgress; }
     bool timeSeriesLoading() const { return m_timeSeriesLoading; }
     bool timeSeriesEmpty() const;
     QStringList timeSeriesAccountIds() const;
@@ -91,6 +99,9 @@ public:
     Q_INVOKABLE void listAccounts();
     Q_INVOKABLE void createAccount(const QString& name, int accountType);
     Q_INVOKABLE void listTransactions(const QString& accountId);
+    Q_INVOKABLE void recordTransaction(const QString& accountId, const QString& date,
+                                       qlonglong amount, const QString& name,
+                                       const QString& description, int status);
     Q_INVOKABLE void fetchTimeSeries(const QString& fromDate, const QString& toDate,
                                      int interval, const QStringList& accountIds);
     Q_INVOKABLE void populateSeries(QObject* series, const QString& accountId);
@@ -106,6 +117,9 @@ signals:
     void accountCreateFailed(QString message);
     void transactionsChanged();
     void transactionsLoadingChanged();
+    void recordTransactionInProgressChanged();
+    void transactionRecorded(QString id);
+    void transactionRecordFailed(QString message);
     void timeSeriesLoadingChanged();
     void timeSeriesDataChanged();
 
@@ -115,6 +129,7 @@ private slots:
     void onListAccountsFinished();
     void onCreateAccountFinished();
     void onListTransactionsFinished();
+    void onRecordTransactionFinished();
     void onTimeSeriesFinished();
 
 private:
@@ -147,6 +162,8 @@ private:
     QString m_requestedTransactionsAccountId;
     QString m_inFlightTransactionsAccountId;
     QFutureWatcher<ListTransactionsResult> m_transactionsWatcher;
+    bool m_recordTransactionInProgress = false;
+    QFutureWatcher<RecordTransactionResult> m_recordTransactionWatcher;
     bool m_timeSeriesLoading = false;
     QFutureWatcher<TimeSeriesResult> m_timeSeriesWatcher;
     TimeSeriesResult m_timeSeriesData;

--- a/app/tests/MockFinchClient.qml
+++ b/app/tests/MockFinchClient.qml
@@ -24,8 +24,22 @@ QtObject {
     // account switch rather than an unrealistic two-concurrent-fetch model.
     property string inFlightAccountId: ""
 
+    // RecordTransactionForm (embedded in TransactionsPanel) drives these; default in-progress
+    // false so the embedded form starts enabled. Each field is captured separately so a spec
+    // can catch a name<->description transpose in the 6-arg positional call.
+    property bool recordTransactionInProgress: false
+    property string lastRecordAccountId: ""
+    property string lastRecordDate: ""
+    property var lastRecordAmount: 0
+    property string lastRecordName: ""
+    property string lastRecordDescription: ""
+    property int lastRecordStatus: -1
+    property int recordCallCount: 0
+
     signal accountCreated(string id)
     signal accountCreateFailed(string message)
+    signal transactionRecorded(string id)
+    signal transactionRecordFailed(string message)
 
     // Mirror the real client's observable lifecycle: in-progress latches true on the
     // call and clears when the test drives a terminal outcome via succeed()/fail().
@@ -44,6 +58,30 @@ QtObject {
     function fail(message) {
         createAccountInProgress = false
         accountCreateFailed(message)
+    }
+
+    // Mirror the real client: in-progress latches true synchronously on the call and clears
+    // when the test drives a terminal outcome via succeedRecord()/failRecord().
+    function recordTransaction(accountId, date, amount, name, description, status) {
+        lastRecordAccountId = accountId
+        lastRecordDate = date
+        lastRecordAmount = amount
+        lastRecordName = name
+        lastRecordDescription = description
+        lastRecordStatus = status
+        recordCallCount += 1
+        recordTransactionInProgress = true
+    }
+
+    // Clear in-progress BEFORE emitting so the after-success specs see an enabled form again.
+    function succeedRecord(id) {
+        recordTransactionInProgress = false
+        transactionRecorded(id)
+    }
+
+    function failRecord(message) {
+        recordTransactionInProgress = false
+        transactionRecordFailed(message)
     }
 
     // callCount counts invocations (every call). The re-entrancy guard mirrors the real

--- a/app/tests/recordtransactionform/tst_RecordTransactionForm.qml
+++ b/app/tests/recordtransactionform/tst_RecordTransactionForm.qml
@@ -148,6 +148,19 @@ TestCase {
         verify(ctx.form.signedCents > 0)
     }
 
+    // A large amount (above the 32-bit int ceiling) records exactly: signedCents is a JS
+    // number, not a 32-bit QML int, so ~$30M does not overflow or truncate on the way to the
+    // client's 64-bit qlonglong amount.
+    function test_largeAmountDoesNotOverflow() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "House"
+        ctx.form.amountText = "30000000" // $30,000,000 -> 3,000,000,000 cents (> INT32_MAX)
+        ctx.form.expense = true
+        compare(ctx.form.signedCents, -3000000000)
+        ctx.form.submit()
+        compare(ctx.mock.lastRecordAmount, -3000000000)
+    }
+
     // Preview shows the signed amount and flips with the toggle; empty when magnitude invalid.
     function test_previewReflectsSignAndMagnitude() {
         var ctx = build({ accountId: "a1" })

--- a/app/tests/recordtransactionform/tst_RecordTransactionForm.qml
+++ b/app/tests/recordtransactionform/tst_RecordTransactionForm.qml
@@ -1,0 +1,222 @@
+import QtQuick
+import QtTest
+// FinchRecordTest is the test-only module (see app/CMakeLists.txt) holding the real shipping
+// RecordTransactionForm, the txformat.js helper it imports, and the shared MockFinchClient
+// double — scoped to just those files so the test doesn't pull in the rest of the app's QML.
+import FinchRecordTest
+
+TestCase {
+    id: testCase
+    name: "RecordTransactionForm"
+    when: windowShown
+
+    Component {
+        id: formFactory
+        RecordTransactionForm {}
+    }
+
+    Component {
+        id: mockFactory
+        MockFinchClient {}
+    }
+
+    SignalSpy {
+        id: recordedSpy
+        signalName: "recorded"
+    }
+
+    property var currentForm: null
+    property var currentMock: null
+
+    // Returns { form, mock }; cleanup() destroys them after each test — even on an assertion
+    // failure, which aborts the test function before any manual teardown runs. accountId is
+    // injected (the panel feeds it from the screen's selector) so build() takes it as an opt.
+    function build(opts) {
+        opts = opts || {}
+        currentMock = mockFactory.createObject(testCase)
+        var props = { client: currentMock }
+        if (opts.accountId !== undefined)
+            props.accountId = opts.accountId
+        currentForm = formFactory.createObject(testCase, props)
+        verify(currentForm !== null, "form instantiated")
+        return { form: currentForm, mock: currentMock }
+    }
+
+    function cleanup() {
+        recordedSpy.target = null
+        if (currentForm) { currentForm.destroy(); currentForm = null }
+        if (currentMock) { currentMock.destroy(); currentMock = null }
+    }
+
+    // Drives a valid Expense in one step: account injected, name + magnitude set.
+    function fillValidExpense(ctx) {
+        ctx.form.accountId = "a1"
+        ctx.form.nameText = "Coffee"
+        ctx.form.amountText = "12.34"
+    }
+
+    function test_loadsAndStartsInvalid() {
+        var ctx = build()
+        compare(ctx.form.canSubmit, false)
+    }
+
+    function test_enabledOnceAccountNameAmountPresent() {
+        var ctx = build()
+        fillValidExpense(ctx)
+        compare(ctx.form.canSubmit, true)
+    }
+
+    // No account selected (injected accountId empty) blocks submit even with name + amount.
+    function test_disabledWhenNoAccount() {
+        var ctx = build()
+        ctx.form.nameText = "Coffee"
+        ctx.form.amountText = "12.34"
+        compare(ctx.form.accountId, "")
+        compare(ctx.form.canSubmit, false)
+    }
+
+    function test_disabledWhenNameBlank() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.amountText = "12.34"
+        ctx.form.nameText = "   " // whitespace only
+        compare(ctx.form.canSubmit, false)
+    }
+
+    // The form is the SOLE amount gate — the daemon does not validate amount at all — so a
+    // zero, blank, or non-numeric magnitude must keep submit disabled.
+    function test_disabledWhenAmountZero() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Coffee"
+        ctx.form.amountText = "0"
+        compare(ctx.form.canSubmit, false)
+    }
+
+    function test_disabledWhenAmountBlank() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Coffee"
+        ctx.form.amountText = ""
+        compare(ctx.form.canSubmit, false)
+    }
+
+    function test_disabledWhenAmountNonNumeric() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Coffee"
+        ctx.form.amountText = "abc"
+        compare(ctx.form.canSubmit, false)
+    }
+
+    // submit() sends signed cents, trimmed name, the date, description, status Reconciled (3),
+    // and the injected accountId. lastRecordName and lastRecordDescription are asserted
+    // INDEPENDENTLY — a 6-arg positional Q_INVOKABLE with two adjacent strings is a transpose
+    // waiting to happen, and only separate assertions catch a name<->description swap.
+    function test_submitSendsExpenseAsNegativeCents() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "  Coffee  "
+        ctx.form.amountText = "12.34"
+        ctx.form.expense = true
+        ctx.form.dateText = "2026-06-22"
+        ctx.form.descriptionText = "morning latte"
+        ctx.form.submit()
+        compare(ctx.mock.recordCallCount, 1)
+        compare(ctx.mock.lastRecordAccountId, "a1")
+        compare(ctx.mock.lastRecordDate, "2026-06-22")
+        compare(ctx.mock.lastRecordAmount, -1234)
+        compare(ctx.mock.lastRecordName, "Coffee")
+        compare(ctx.mock.lastRecordDescription, "morning latte")
+        compare(ctx.mock.lastRecordStatus, 3)
+    }
+
+    function test_submitSendsIncomeAsPositiveCents() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Paycheck"
+        ctx.form.amountText = "50"
+        ctx.form.expense = false // Income
+        ctx.form.submit()
+        compare(ctx.mock.recordCallCount, 1)
+        compare(ctx.mock.lastRecordAmount, 5000)
+    }
+
+    // Sign integrity: the toggle is the sole sign source. The validator forbids a leading "-",
+    // so whatever the user types, an Expense is never positive and an Income never negative.
+    function test_signIntegrity() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Thing"
+        ctx.form.amountText = "9.99"
+        ctx.form.expense = true
+        verify(ctx.form.signedCents < 0)
+        ctx.form.expense = false
+        verify(ctx.form.signedCents > 0)
+    }
+
+    // Preview shows the signed amount and flips with the toggle; empty when magnitude invalid.
+    function test_previewReflectsSignAndMagnitude() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.amountText = "12.34"
+        ctx.form.expense = true
+        compare(ctx.form.previewText, "-$12.34")
+        ctx.form.expense = false
+        compare(ctx.form.previewText, "$12.34")
+    }
+
+    function test_previewEmptyWhenAmountInvalid() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.amountText = ""
+        compare(ctx.form.previewText, "")
+        ctx.form.amountText = "abc"
+        compare(ctx.form.previewText, "")
+        ctx.form.amountText = "0"
+        compare(ctx.form.previewText, "")
+    }
+
+    function test_submitIgnoredWhenInvalid() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "   "
+        ctx.form.amountText = "12.34"
+        ctx.form.submit()
+        compare(ctx.mock.recordCallCount, 0)
+    }
+
+    function test_successClearsFieldsAndSignalsRecorded() {
+        var ctx = build({ accountId: "a1" })
+        recordedSpy.target = ctx.form
+        recordedSpy.clear()
+        ctx.form.nameText = "Coffee"
+        ctx.form.amountText = "12.34"
+        ctx.form.descriptionText = "latte"
+        ctx.form.submit()
+        ctx.mock.succeedRecord("txn-1")
+        compare(recordedSpy.count, 1)
+        compare(ctx.form.nameText, "")
+        compare(ctx.form.amountText, "")
+        compare(ctx.form.descriptionText, "")
+        recordedSpy.target = null
+    }
+
+    function test_failureShowsErrorMessage() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Coffee"
+        ctx.form.amountText = "12.34"
+        ctx.form.submit()
+        ctx.mock.failRecord("name must not be empty")
+        compare(ctx.form.errorText, "name must not be empty")
+    }
+
+    function test_disabledWhileRecordInProgress() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Coffee"
+        ctx.form.amountText = "12.34"
+        verify(ctx.form.canSubmit) // enabled before submit
+        ctx.form.submit() // mock latches recordTransactionInProgress synchronously
+        compare(ctx.mock.recordTransactionInProgress, true)
+        compare(ctx.form.canSubmit, false)
+    }
+
+    function test_doubleSubmitSendsOnlyOne() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Coffee"
+        ctx.form.amountText = "12.34"
+        ctx.form.submit()
+        ctx.form.submit() // second gated by canSubmit (in-progress)
+        compare(ctx.mock.recordCallCount, 1)
+    }
+}

--- a/app/tests/transactionspanel/tst_TransactionsPanel.qml
+++ b/app/tests/transactionspanel/tst_TransactionsPanel.qml
@@ -215,4 +215,35 @@ TestCase {
         compare(ctx.panel.transactionList.currentIndex, -1)
         verify(ctx.panel.selectedTransaction === null)
     }
+
+    // The embedded record form is fed by the panel's selector — no account chosen means the
+    // form has no target, so its logical canSubmit is false. (Assert the logical predicate,
+    // never the visual `enabled`, which is unreliable under the offscreen harness.)
+    function test_recordFormDisabledBeforeAccountSelected() {
+        var ctx = build()
+        compare(ctx.panel.recordForm.canSubmit, false)
+    }
+
+    // Once an account is selected (injecting its id into the form) plus a name and a valid
+    // amount, the embedded form becomes submittable — the injection wiring is live.
+    function test_recordFormEnabledAfterAccountAndFields() {
+        var ctx = build()
+        ctx.panel.selectedAccountIndex = 0
+        ctx.panel.recordForm.nameText = "Coffee"
+        ctx.panel.recordForm.amountText = "12.34"
+        compare(ctx.panel.recordForm.canSubmit, true)
+    }
+
+    // Driving the form's success path re-fetches the selected account, so the new row appears.
+    function test_recordingRefetchesSelectedAccount() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleTransactions)
+        var before = ctx.mock.transactionsCallCount
+        ctx.panel.recordForm.nameText = "Coffee"
+        ctx.panel.recordForm.amountText = "12.34"
+        ctx.panel.recordForm.submit()
+        ctx.mock.succeedRecord("txn-99")
+        compare(ctx.mock.transactionsCallCount, before + 1)
+        compare(ctx.mock.lastAccountId, "a1")
+    }
 }

--- a/app/tests/tst_recordtransactionform.cpp
+++ b/app/tests/tst_recordtransactionform.cpp
@@ -1,0 +1,6 @@
+// Qt Quick Test entry point. QUICK_TEST_MAIN scans QUICK_TEST_SOURCE_DIR (set in
+// CMake) for tst_*.qml at runtime; the specs load the form via a directory import,
+// so no C++ type registration is needed here.
+#include <QtQuickTest/quicktest.h>
+
+QUICK_TEST_MAIN(recordtransactionform)


### PR DESCRIPTION
## Overview

Manual transactions could previously only be entered through the MCP tools, so every ad-hoc financial event meant opening Claude instead of the app. This adds an in-app form on the Transactions screen to record a manual transaction against an account — enter a name, amount, and Expense/Income, with the date defaulting to today and a live signed-amount preview showing the effect before submit.

The form is seated above the master-detail content and fed by the screen's existing account selector, so there is no second account picker — the selected account is injected into a standalone, independently-testable component. Status is always Reconciled; recurring and projected entries belong to the recurring/projection work.

## How it works

The Expense/Income toggle is the sole source of the amount's sign: the magnitude field's validator forbids a typed sign, so a user can't enter a value that fights the toggle. The daemon does not validate the amount at all, so the form's `canSubmit` is the sole gate on amount quality — it rejects zero, blank, and non-numeric magnitudes, with the preview, the predicate, and the submit button all reading one shared derived-state chain so they can't disagree at a boundary.

`formatAmount`/`statusLabel` move into a shared `qml/txformat.js` so the new preview and the existing transactions panel read one source. `FinchClient` gains a `recordTransaction` path mirroring the existing `createAccount` path (re-entrancy guard, off-thread call, verbatim daemon validation message). The form, the client path, and the panel embedding are each covered by Qt Quick Test specs driving the real components against a mock client.

Closes #38
