### PR TITLE
docs(rules): QML int-width, binding-freshness, boundary-value gotchas

### DIFF
--- a/.claude/rules/qt-app.md
+++ b/.claude/rules/qt-app.md
@@ -18,11 +18,19 @@ Before using a Qt API, check its "since" version annotation against the **pinned
 
 Qt Quick Controls types mark many properties as FINAL. NEVER declare custom properties that shadow built-in names (e.g., `currentValue` on `ComboBox`). The QML engine will error with "Cannot override FINAL property" at runtime.
 
+## QML Numeric Property Width
+
+A QML `int` is 32-bit. A value in cents — which the daemon and proto carry as 64-bit `int64` — overflows a QML `int` above ~21.5 million cents (~$214,748.36) and silently records a truncated amount. Type any property holding cents, or any value that crosses into a C++ `qlonglong` / proto `int64` sink, as `var` (a JS number marshals to `qlonglong` exactly for integers up to 2^53), never `int`. The narrowing is silent — no compile error, no runtime warning — so the thing that catches it is a boundary test with an amount past `INT32_MAX`, not code reading.
+
 ## Qt Quick Layouts
 
 A `Layout` nested directly inside another `Layout` (e.g. a `ColumnLayout` rail inside a `RowLayout`) defaults `Layout.fillWidth`/`Layout.fillHeight` to **true** — unlike plain Items and controls, which default false. A fixed-size child therefore expands and starves its siblings. To pin a sidebar/rail at a fixed width, set `Layout.fillWidth: false` explicitly plus `Layout.preferredWidth`/`minimumWidth`/`maximumWidth`. Headless tests that assert child existence rather than geometry will not catch this.
 
 NEVER bind a child's `Layout.preferredWidth`/`preferredHeight` to its parent layout's own size (e.g. `Layout.preferredWidth: parent.width * 0.55` inside the `RowLayout` being sized). The parent sizes from the child, so the binding feeds back and Qt aborts the pass with "Detected recursive rearrange. Aborting after two iterations" — a runtime warning headless tests spam but still pass through, so only a runtime log surfaces it. Split the space with `Layout.fillWidth` on the children instead. Same feedback for a `ListView` delegate: give the `ItemDelegate` a fixed `width` (`ListView.view.width`) and size its height from content, rather than nesting a `fillWidth` layout as the delegate's `contentItem`.
+
+## Binding Freshness in Change Handlers
+
+Inside an `onXChanged` handler, a *derived* property that depends on `x` may still hold its pre-change value — the engine does not guarantee the dependent binding is re-evaluated before the explicit handler runs. Read the source property that changed (`x`) directly in the handler; reserve the derived property for ordinary bindings and other handlers, which run after re-evaluation. Seen as: a `ComboBox.onCurrentIndexChanged` handler read a `currentAccountId` derived from `currentIndex`, got the *previous* account, and the first selection out of an unselected state silently did nothing.
 
 ## Qt Charts Gotchas
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -18,6 +18,10 @@ Shared helpers (`openTestDB`, `createTestAccount`, `date()`) live in `*_test.go`
 
 Test domain invariants, validation boundaries, error conditions, and event production. Do NOT test framework plumbing, generated code, or trivial getters/setters. A test earns its keep by catching regressions in behavior that matters.
 
+## Boundary Values
+
+A value that crosses a type or representation boundary — narrowed to a smaller integer width, marshaled across a language seam (QML ↔ C++ ↔ proto), or carrying money as integer cents — earns explicit boundary tests, not just representative ones. Example-based tests cover only the magnitudes the author imagined; a 32-bit overflow or an edge sign error hides between $12.34 and $50. Probe the edges: zero, a value past the narrower type's max, a large amount, a negative. The generated extreme catches the defect no reviewer suspected.
+
 ## Qt App
 
 The Qt app has a Qt Quick Test suite, run via `just test-app` (which builds the app, then runs the specs). A spec drives the real shipping component with an injected mock client and asserts on the calls that component makes — so behavior is verified, not just compilation. Build verification alone is no longer the ceiling; a form or view with input validation or data mutation earns a spec. See `qt-app.md` for the harness mechanics (test-only QML module, mock injection, headless/style settings).


### PR DESCRIPTION
## Overview

The transaction-recording-form work surfaced three durable lessons worth encoding in the repo's own rule set so the next agent doesn't re-discover them rather than relying on one session's memory:

- A QML `int` is 32-bit, so a cents value — carried as `int64` end to end through the daemon and proto — silently truncates above ~$214k. `qt-app.md` now documents typing any cents-bearing or `int64`-crossing property as `var`, not `int`.
- A derived property read inside the `onXChanged` handler of the property it depends on can return a stale, pre-change value. `qt-app.md` now records reading the changed source property directly in the handler.
- The overflow slipped every reading pass because example-based specs only probe representative magnitudes. `testing.md` gains a boundary-value convention — the orthogonal modality that catches that class — framed around type/representation/seam crossings so it complements the existing input-validation guidance rather than duplicating it.

The two `qt-app.md` sections are path-conditioned to `app/**`, so they cost nothing off-app; the `testing.md` section is cross-cutting (core/daemon/app seams) and always-loaded.

## Issue references

Related to #38.
