### PR TITLE
feat(app): view and create recurring rules in the Qt app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Qt app: create accounts through a UI form (previously only via MCP tools).
 - Qt app: view an account's individual transactions on the Transactions screen — pick an account, browse its transactions in a list, and select one to see its full details (previously only the aggregated balance chart was visible).
 - Qt app: record a manual transaction against an account from the Transactions screen — enter a name, amount, and Expense/Income, with a live signed-amount preview and the date defaulting to today (previously only via MCP tools).
+- Qt app: view and create an account's recurring rules on the Recurring Rules screen — pick an account, browse its rules, and add a new rule at any frequency (weekly, biweekly, semi-monthly, monthly, or yearly) with an Expense/Income amount and an optional end date (previously only via MCP tools).
 
 ### Changed
 
@@ -19,3 +20,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Qt app now restores window size and position across restarts.
+- Daemon returns `InvalidArgument` (not `Internal`) when a recurring-rule create has an out-of-range day-of-month or malformed semi-monthly days, and `NotFound` (not `Internal`) when updating the amount of a rule that does not exist — so callers can tell a bad request from a daemon failure.

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -81,6 +81,7 @@ qt_add_qml_module(finch-app
         qml/AccountsPanel.qml
         qml/TransactionsPanel.qml
         qml/RecordTransactionForm.qml
+        qml/SignedAmountField.qml
         qml/RecurringRulesPanel.qml
         qml/CreateRecurringRuleForm.qml
         qml/txformat.js
@@ -173,6 +174,7 @@ qt_add_qml_module(tst_transactionspanel
     QML_FILES
         qml/TransactionsPanel.qml
         qml/RecordTransactionForm.qml
+        qml/SignedAmountField.qml
         qml/txformat.js
         tests/MockFinchClient.qml
 )
@@ -204,6 +206,7 @@ qt_add_qml_module(tst_recordtransactionform
     VERSION 1.0
     QML_FILES
         qml/RecordTransactionForm.qml
+        qml/SignedAmountField.qml
         qml/txformat.js
         tests/MockFinchClient.qml
 )
@@ -234,6 +237,7 @@ qt_add_qml_module(tst_recurringruleform
     VERSION 1.0
     QML_FILES
         qml/CreateRecurringRuleForm.qml
+        qml/SignedAmountField.qml
         qml/txformat.js
         tests/MockFinchClient.qml
 )
@@ -264,6 +268,7 @@ qt_add_qml_module(tst_recurringrulespanel
     QML_FILES
         qml/RecurringRulesPanel.qml
         qml/CreateRecurringRuleForm.qml
+        qml/SignedAmountField.qml
         qml/txformat.js
         tests/MockFinchClient.qml
 )

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -81,6 +81,7 @@ qt_add_qml_module(finch-app
         qml/AccountsPanel.qml
         qml/TransactionsPanel.qml
         qml/RecordTransactionForm.qml
+        qml/CreateRecurringRuleForm.qml
         qml/txformat.js
         qml/PlaceholderScreen.qml
 )
@@ -219,4 +220,34 @@ target_link_libraries(tst_recordtransactionform PRIVATE
 add_test(NAME tst_recordtransactionform COMMAND tst_recordtransactionform)
 
 set_tests_properties(tst_recordtransactionform PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_CONTROLS_STYLE=Basic")
+
+# --- CreateRecurringRuleForm test ---
+add_executable(tst_recurringruleform tests/tst_recurringruleform.cpp)
+
+# A test-only module scoped to the real recurring-rule create form, the txformat.js helper it
+# imports, and the shared mock client. txformat.js must be a member of this SAME module for the
+# form's relative `import "txformat.js"` to resolve (the module-membership invariant).
+qt_add_qml_module(tst_recurringruleform
+    URI FinchRecurringFormTest
+    VERSION 1.0
+    QML_FILES
+        qml/CreateRecurringRuleForm.qml
+        qml/txformat.js
+        tests/MockFinchClient.qml
+)
+
+target_compile_definitions(tst_recurringruleform PRIVATE
+    QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/recurringruleform")
+
+target_link_libraries(tst_recurringruleform PRIVATE
+    Qt6::Quick
+    Qt6::QuickControls2
+    Qt6::QuickTest
+    Qt6::Qml
+)
+
+add_test(NAME tst_recurringruleform COMMAND tst_recurringruleform)
+
+set_tests_properties(tst_recurringruleform PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_CONTROLS_STYLE=Basic")

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -81,6 +81,7 @@ qt_add_qml_module(finch-app
         qml/AccountsPanel.qml
         qml/TransactionsPanel.qml
         qml/RecordTransactionForm.qml
+        qml/RecurringRulesPanel.qml
         qml/CreateRecurringRuleForm.qml
         qml/txformat.js
         qml/PlaceholderScreen.qml
@@ -250,4 +251,34 @@ target_link_libraries(tst_recurringruleform PRIVATE
 add_test(NAME tst_recurringruleform COMMAND tst_recurringruleform)
 
 set_tests_properties(tst_recurringruleform PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_CONTROLS_STYLE=Basic")
+
+# --- RecurringRulesPanel test ---
+add_executable(tst_recurringrulespanel tests/tst_recurringrulespanel.cpp)
+
+# A test-only module scoped to the real master-detail panel, the create form it embeds, the
+# txformat.js helper both import, and the shared mock client.
+qt_add_qml_module(tst_recurringrulespanel
+    URI FinchRecurringPanelTest
+    VERSION 1.0
+    QML_FILES
+        qml/RecurringRulesPanel.qml
+        qml/CreateRecurringRuleForm.qml
+        qml/txformat.js
+        tests/MockFinchClient.qml
+)
+
+target_compile_definitions(tst_recurringrulespanel PRIVATE
+    QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/recurringrulespanel")
+
+target_link_libraries(tst_recurringrulespanel PRIVATE
+    Qt6::Quick
+    Qt6::QuickControls2
+    Qt6::QuickTest
+    Qt6::Qml
+)
+
+add_test(NAME tst_recurringrulespanel COMMAND tst_recurringrulespanel)
+
+set_tests_properties(tst_recurringrulespanel PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_CONTROLS_STYLE=Basic")

--- a/app/qml/CreateRecurringRuleForm.qml
+++ b/app/qml/CreateRecurringRuleForm.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import "txformat.js" as TxFormat
 
 // Self-contained recurring-rule create form. Like RecordTransactionForm it depends only on an
 // injected `client` (the production FinchClient, a mock in tests) and an injected `accountId`
@@ -18,7 +17,7 @@ Item {
 
     // Public, test-facing surface — specs drive the form through these.
     property alias nameText: nameField.text
-    property alias amountText: amountField.text
+    property alias amountText: amountInput.amountText
     property alias startDateText: startDateField.text
     property alias endDateText: endDateField.text
     property alias dayOfMonthText: dayOfMonthField.text
@@ -26,9 +25,9 @@ Item {
     property alias semiDay2Text: semiDay2Field.text
     property alias frequencyIndex: freqCombo.currentIndex
     property alias errorText: errorLabel.text
-    // Expense (true, default) vs Income. The magnitude field cannot carry a sign, so this
-    // toggle alone decides whether cents are negative or positive.
-    property bool expense: true
+    // Amount, its sign, and the signed-cents derivation live in the shared SignedAmountField.
+    property alias expense: amountInput.expense
+    readonly property var signedCents: amountInput.signedCents
 
     // Frequency enum values (proto Frequency): Weekly=1 … Yearly=5. The ComboBox has no
     // sentinel row (currentIndex starts -1 with a placeholder), so a row's index is one less
@@ -36,15 +35,6 @@ Item {
     readonly property bool frequencyChosen: freqCombo.currentIndex >= 0
     readonly property bool isMonthly: frequencyChosen && freqCombo.currentValue === 4
     readonly property bool isSemiMonthly: frequencyChosen && freqCombo.currentValue === 3
-
-    // Amount: same treatment as RecordTransactionForm. The regex validator forbids a sign, so
-    // the Expense/Income toggle is the sole sign source; parseFloat reads the magnitude cleanly.
-    readonly property real magnitude: parseFloat(amountField.text)
-    readonly property bool amountValid: !isNaN(magnitude) && magnitude > 0
-    // Typed var, not int: the client's amount is a 64-bit qlonglong and a QML int is 32-bit —
-    // an int would overflow above ~$21.5M. A JS number marshals to qlonglong exactly (< 2^53).
-    readonly property var signedCents: amountValid ? Math.round(magnitude * 100) * (expense ? -1 : 1) : 0
-    readonly property string previewText: amountValid ? TxFormat.formatAmount(signedCents) : ""
 
     // Day-of-month (Monthly) and the two semi-monthly days must each be 1-31 — mirroring core's
     // validation so a request the daemon would reject never leaves the form.
@@ -68,7 +58,7 @@ Item {
     readonly property bool canSubmit:
         accountId !== ""
         && nameField.text.trim().length > 0
-        && amountValid
+        && amountInput.amountValid
         && frequencyChosen
         && startDateValid
         && endDateOrderValid
@@ -98,7 +88,7 @@ Item {
         target: form.client
         function onRecurringRuleCreated(id) {
             nameField.text = ""
-            amountField.text = ""
+            amountInput.amountText = ""
             dayOfMonthField.text = ""
             semiDay1Field.text = ""
             semiDay2Field.text = ""
@@ -124,42 +114,10 @@ Item {
         }
 
         Label { text: "Amount" }
-        RowLayout {
+        SignedAmountField {
+            id: amountInput
             Layout.fillWidth: true
-            spacing: 12
-
-            TextField {
-                id: amountField
-                Layout.fillWidth: true
-                placeholderText: "0.00"
-                inputMethodHints: Qt.ImhFormattedNumbersOnly
-                // Locale-independent, forbids a leading "-" so the toggle is the sole sign
-                // source, caps at 2 decimals — same validator as the transaction form.
-                validator: RegularExpressionValidator { regularExpression: /^\d+(\.\d{0,2})?$/ }
-                onTextChanged: errorLabel.text = ""
-            }
-
-            Label {
-                text: form.previewText
-                color: form.expense ? "#c0392b" : "#27ae60"
-                visible: form.previewText.length > 0
-            }
-        }
-
-        RowLayout {
-            spacing: 12
-            ButtonGroup { id: signGroup }
-            RadioButton {
-                text: "Expense"
-                ButtonGroup.group: signGroup
-                checked: form.expense
-                onClicked: { form.expense = true; errorLabel.text = "" }
-            }
-            RadioButton {
-                text: "Income"
-                ButtonGroup.group: signGroup
-                onClicked: { form.expense = false; errorLabel.text = "" }
-            }
+            onEdited: errorLabel.text = ""
         }
 
         Label { text: "Frequency" }

--- a/app/qml/CreateRecurringRuleForm.qml
+++ b/app/qml/CreateRecurringRuleForm.qml
@@ -1,0 +1,258 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import "txformat.js" as TxFormat
+
+// Self-contained recurring-rule create form. Like RecordTransactionForm it depends only on an
+// injected `client` (the production FinchClient, a mock in tests) and an injected `accountId`
+// fed from the Recurring Rules screen's selector, so it carries no second account picker.
+// Deliberately importing no Finch C++ type keeps it instantiable by the Qt Quick Test harness.
+Item {
+    id: form
+
+    // Injected by the host: RecurringRulesPanel passes finchClient; tests pass a mock.
+    required property var client
+
+    // Injected target account. Empty string means no account selected — the form stays invalid.
+    property string accountId: ""
+
+    // Public, test-facing surface — specs drive the form through these.
+    property alias nameText: nameField.text
+    property alias amountText: amountField.text
+    property alias startDateText: startDateField.text
+    property alias endDateText: endDateField.text
+    property alias dayOfMonthText: dayOfMonthField.text
+    property alias semiDay1Text: semiDay1Field.text
+    property alias semiDay2Text: semiDay2Field.text
+    property alias frequencyIndex: freqCombo.currentIndex
+    property alias errorText: errorLabel.text
+    // Expense (true, default) vs Income. The magnitude field cannot carry a sign, so this
+    // toggle alone decides whether cents are negative or positive.
+    property bool expense: true
+
+    // Frequency enum values (proto Frequency): Weekly=1 … Yearly=5. The ComboBox has no
+    // sentinel row (currentIndex starts -1 with a placeholder), so a row's index is one less
+    // than its value — submit() sends currentValue, never currentIndex.
+    readonly property bool frequencyChosen: freqCombo.currentIndex >= 0
+    readonly property bool isMonthly: frequencyChosen && freqCombo.currentValue === 4
+    readonly property bool isSemiMonthly: frequencyChosen && freqCombo.currentValue === 3
+
+    // Amount: same treatment as RecordTransactionForm. The regex validator forbids a sign, so
+    // the Expense/Income toggle is the sole sign source; parseFloat reads the magnitude cleanly.
+    readonly property real magnitude: parseFloat(amountField.text)
+    readonly property bool amountValid: !isNaN(magnitude) && magnitude > 0
+    // Typed var, not int: the client's amount is a 64-bit qlonglong and a QML int is 32-bit —
+    // an int would overflow above ~$21.5M. A JS number marshals to qlonglong exactly (< 2^53).
+    readonly property var signedCents: amountValid ? Math.round(magnitude * 100) * (expense ? -1 : 1) : 0
+    readonly property string previewText: amountValid ? TxFormat.formatAmount(signedCents) : ""
+
+    // Day-of-month (Monthly) and the two semi-monthly days must each be 1-31 — mirroring core's
+    // validation so a request the daemon would reject never leaves the form.
+    readonly property int dayOfMonthValue: parseInt(dayOfMonthField.text)
+    readonly property bool dayOfMonthValid: dayOfMonthValue >= 1 && dayOfMonthValue <= 31
+    readonly property int semiDay1Value: parseInt(semiDay1Field.text)
+    readonly property int semiDay2Value: parseInt(semiDay2Field.text)
+    readonly property bool semiDaysValid:
+        semiDay1Value >= 1 && semiDay1Value <= 31 && semiDay2Value >= 1 && semiDay2Value <= 31
+    readonly property bool frequencyDetailsValid:
+        isMonthly ? dayOfMonthValid : (isSemiMonthly ? semiDaysValid : true)
+
+    // Dates are ISO "yyyy-MM-dd", so a lexical compare equals a chronological one. An end date
+    // before the start date creates a rule that projects nothing (neither daemon nor core
+    // validates ordering), so block it. Empty end date = open-ended.
+    readonly property bool startDateValid: startDateField.text.trim().length > 0
+    readonly property bool endDateOrderValid:
+        endDateField.text.length === 0 || endDateField.text >= startDateField.text
+
+    // canSubmit is the single validation predicate the button and the specs share.
+    readonly property bool canSubmit:
+        accountId !== ""
+        && nameField.text.trim().length > 0
+        && amountValid
+        && frequencyChosen
+        && startDateValid
+        && endDateOrderValid
+        && frequencyDetailsValid
+        && !(client && client.createRecurringRuleInProgress)
+
+    // Emitted once the daemon confirms creation; the host re-fetches the account's rules on it.
+    signal created(string id)
+
+    implicitWidth: 360
+    implicitHeight: layout.implicitHeight
+
+    function submit() {
+        if (!canSubmit)
+            return
+        errorLabel.text = ""
+        // Send day fields only for the frequency that uses them, so a stale value left from a
+        // frequency switch is never persisted.
+        var dom = isMonthly ? dayOfMonthValue : 0
+        var semis = isSemiMonthly ? [semiDay1Value, semiDay2Value] : []
+        client.createRecurringRule(accountId, nameField.text.trim(), signedCents,
+                                   freqCombo.currentValue, startDateField.text,
+                                   endDateField.text, dom, semis)
+    }
+
+    Connections {
+        target: form.client
+        function onRecurringRuleCreated(id) {
+            nameField.text = ""
+            amountField.text = ""
+            dayOfMonthField.text = ""
+            semiDay1Field.text = ""
+            semiDay2Field.text = ""
+            errorLabel.text = ""
+            form.created(id)
+        }
+        function onRecurringRuleCreateFailed(message) {
+            errorLabel.text = message
+        }
+    }
+
+    ColumnLayout {
+        id: layout
+        anchors.fill: parent
+        spacing: 12
+
+        Label { text: "Name" }
+        TextField {
+            id: nameField
+            Layout.fillWidth: true
+            placeholderText: "e.g. Rent"
+            onTextChanged: errorLabel.text = ""
+        }
+
+        Label { text: "Amount" }
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 12
+
+            TextField {
+                id: amountField
+                Layout.fillWidth: true
+                placeholderText: "0.00"
+                inputMethodHints: Qt.ImhFormattedNumbersOnly
+                // Locale-independent, forbids a leading "-" so the toggle is the sole sign
+                // source, caps at 2 decimals — same validator as the transaction form.
+                validator: RegularExpressionValidator { regularExpression: /^\d+(\.\d{0,2})?$/ }
+                onTextChanged: errorLabel.text = ""
+            }
+
+            Label {
+                text: form.previewText
+                color: form.expense ? "#c0392b" : "#27ae60"
+                visible: form.previewText.length > 0
+            }
+        }
+
+        RowLayout {
+            spacing: 12
+            ButtonGroup { id: signGroup }
+            RadioButton {
+                text: "Expense"
+                ButtonGroup.group: signGroup
+                checked: form.expense
+                onClicked: { form.expense = true; errorLabel.text = "" }
+            }
+            RadioButton {
+                text: "Income"
+                ButtonGroup.group: signGroup
+                onClicked: { form.expense = false; errorLabel.text = "" }
+            }
+        }
+
+        Label { text: "Frequency" }
+        ComboBox {
+            id: freqCombo
+            Layout.fillWidth: true
+            // No sentinel row: start unselected with a placeholder, so index != enum value.
+            currentIndex: -1
+            displayText: currentIndex < 0 ? "Select frequency…" : currentText
+            textRole: "label"
+            valueRole: "value"
+            model: [
+                { label: "Weekly",       value: 1 },
+                { label: "Biweekly",     value: 2 },
+                { label: "Semi-monthly", value: 3 },
+                { label: "Monthly",      value: 4 },
+                { label: "Yearly",       value: 5 }
+            ]
+            onCurrentIndexChanged: errorLabel.text = ""
+        }
+
+        // Monthly needs a day-of-month; only shown (and required) for Monthly.
+        Label {
+            text: "Day of month"
+            visible: form.isMonthly
+        }
+        TextField {
+            id: dayOfMonthField
+            Layout.fillWidth: true
+            visible: form.isMonthly
+            placeholderText: "1–31"
+            inputMethodHints: Qt.ImhDigitsOnly
+            validator: IntValidator { bottom: 1; top: 31 }
+            onTextChanged: errorLabel.text = ""
+        }
+
+        // Semi-monthly needs two days; only shown (and required) for Semi-monthly.
+        Label {
+            text: "Days of month (two)"
+            visible: form.isSemiMonthly
+        }
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 12
+            visible: form.isSemiMonthly
+            TextField {
+                id: semiDay1Field
+                Layout.fillWidth: true
+                placeholderText: "1–31"
+                inputMethodHints: Qt.ImhDigitsOnly
+                validator: IntValidator { bottom: 1; top: 31 }
+                onTextChanged: errorLabel.text = ""
+            }
+            TextField {
+                id: semiDay2Field
+                Layout.fillWidth: true
+                placeholderText: "1–31"
+                inputMethodHints: Qt.ImhDigitsOnly
+                validator: IntValidator { bottom: 1; top: 31 }
+                onTextChanged: errorLabel.text = ""
+            }
+        }
+
+        Label { text: "Start date" }
+        TextField {
+            id: startDateField
+            Layout.fillWidth: true
+            text: Qt.formatDate(new Date(), "yyyy-MM-dd")
+            onTextChanged: errorLabel.text = ""
+        }
+
+        Label { text: "End date (optional)" }
+        TextField {
+            id: endDateField
+            Layout.fillWidth: true
+            placeholderText: "yyyy-MM-dd — leave blank for no end"
+            onTextChanged: errorLabel.text = ""
+        }
+
+        Label {
+            id: errorLabel
+            Layout.fillWidth: true
+            color: "#c0392b"
+            wrapMode: Text.WordWrap
+            visible: text.length > 0
+        }
+
+        Button {
+            id: submitButton
+            text: (form.client && form.client.createRecurringRuleInProgress)
+                  ? "Creating…" : "Create rule"
+            enabled: form.canSubmit
+            onClicked: form.submit()
+        }
+    }
+}

--- a/app/qml/Main.qml
+++ b/app/qml/Main.qml
@@ -100,10 +100,11 @@ ApplicationWindow {
                 connected: finchClient.connectionState === FinchClient.Connected
             },
 
-            PlaceholderScreen {
+            RecurringRulesPanel {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-                headline: "Recurring Rules"
+                client: finchClient
+                connected: finchClient.connectionState === FinchClient.Connected
             }
         ]
     }

--- a/app/qml/RecordTransactionForm.qml
+++ b/app/qml/RecordTransactionForm.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import "txformat.js" as TxFormat
 
 // Self-contained transaction-recording form. Like CreateAccountForm it depends only on an
 // injected `client` (the production FinchClient, a mock in tests) and an injected `accountId`
@@ -19,36 +18,22 @@ Item {
     property string accountId: ""
 
     // Public, test-facing surface — specs drive the form through these rather than reaching
-    // into private control ids.
+    // into private control ids. The amount, its sign, and the signed-cents/preview derivation
+    // live in the shared SignedAmountField (amountInput); the form forwards its surface.
     property alias nameText: nameField.text
-    property alias amountText: amountField.text
+    property alias amountText: amountInput.amountText
     property alias dateText: dateField.text
     property alias descriptionText: descriptionField.text
     property alias errorText: errorLabel.text
-    // Expense (true, default) vs Income. The single sign source: the magnitude field cannot
-    // express a sign, so this toggle alone decides whether cents are negative or positive.
-    property bool expense: true
-
-    // Derived state — one set of predicates shared by canSubmit, the preview, and the button,
-    // so they can never disagree at a boundary.
-    // parseFloat is NaN when the field is blank or non-numeric; the regex validator already
-    // forbids a sign or a comma decimal, so parseFloat reads the magnitude locale-cleanly.
-    readonly property real magnitude: parseFloat(amountField.text)
-    // Reject 0 and NaN: a $0 manual transaction is meaningless, and the daemon does not
-    // validate amount at all, so this form is the sole gate on amount quality.
-    readonly property bool amountValid: !isNaN(magnitude) && magnitude > 0
-    // Math.round avoids float drift (12.34 * 100 -> 1233.9999...); the toggle applies the sign.
-    // Typed var, not int: the client's amount is a 64-bit qlonglong, and a QML int is 32-bit —
-    // an int here would overflow above ~$21.5M and record a truncated amount. A JS number
-    // marshals cleanly to qlonglong (exact integers up to 2^53).
-    readonly property var signedCents: amountValid ? Math.round(magnitude * 100) * (expense ? -1 : 1) : 0
-    readonly property string previewText: amountValid ? TxFormat.formatAmount(signedCents) : ""
+    property alias expense: amountInput.expense
+    readonly property var signedCents: amountInput.signedCents
+    readonly property string previewText: amountInput.previewText
 
     // canSubmit is the single validation predicate the button and the specs share.
     readonly property bool canSubmit:
         accountId !== ""
         && nameField.text.trim().length > 0
-        && amountValid
+        && amountInput.amountValid
         && !(client && client.recordTransactionInProgress)
 
     // Emitted once the daemon confirms the record; the host re-fetches the account on it.
@@ -71,7 +56,7 @@ Item {
         target: form.client
         function onTransactionRecorded(id) {
             nameField.text = ""
-            amountField.text = ""
+            amountInput.amountText = ""
             descriptionField.text = ""
             errorLabel.text = ""
             form.recorded(id)
@@ -95,50 +80,10 @@ Item {
         }
 
         Label { text: "Amount" }
-        RowLayout {
+        SignedAmountField {
+            id: amountInput
             Layout.fillWidth: true
-            spacing: 12
-
-            TextField {
-                id: amountField
-                Layout.fillWidth: true
-                placeholderText: "0.00"
-                inputMethodHints: Qt.ImhFormattedNumbersOnly
-                // Locale-independent: always "." (matching parseFloat), forbids a leading "-"
-                // so the Expense/Income toggle is the sole sign source, caps at 2 decimals.
-                // A default-locale DoubleValidator would accept "19,99", which parseFloat
-                // truncates to 19 — the regex avoids that mismatch.
-                validator: RegularExpressionValidator { regularExpression: /^\d+(\.\d{0,2})?$/ }
-                onTextChanged: errorLabel.text = ""
-            }
-
-            // Live signed-amount preview: the sign is visible before submit, so the user sees
-            // an Expense will subtract before committing it.
-            Label {
-                text: form.previewText
-                color: form.expense ? "#c0392b" : "#27ae60"
-                visible: form.previewText.length > 0
-            }
-        }
-
-        // Expense/Income toggle. The magnitude field cannot carry a sign, so this is the only
-        // way the user expresses direction — a control that can't express the wrong value.
-        RowLayout {
-            spacing: 12
-            ButtonGroup { id: signGroup }
-            RadioButton {
-                id: expenseRadio
-                text: "Expense"
-                ButtonGroup.group: signGroup
-                checked: form.expense
-                onClicked: { form.expense = true; errorLabel.text = "" }
-            }
-            RadioButton {
-                id: incomeRadio
-                text: "Income"
-                ButtonGroup.group: signGroup
-                onClicked: { form.expense = false; errorLabel.text = "" }
-            }
+            onEdited: errorLabel.text = ""
         }
 
         Label { text: "Date" }

--- a/app/qml/RecurringRulesPanel.qml
+++ b/app/qml/RecurringRulesPanel.qml
@@ -1,0 +1,236 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import "txformat.js" as TxFormat
+
+// Recurring Rules destination: a per-account master-detail view, mirroring TransactionsPanel.
+// An account selector drives a per-account fetch; an inline create form sits above the list;
+// the master list shows one row per rule; selecting a row fills the detail pane. Imports no
+// Finch C++ type — the host injects the client and the connection gate — so it stays
+// instantiable without a daemon. Selection is binding-driven (a currentIndex write), so the
+// offscreen test harness can drive it.
+Item {
+    id: panel
+
+    // Injected by the host: Main.qml passes finchClient.
+    required property var client
+
+    // Whether the daemon is connected (host-gated). When false the account list is empty and
+    // the selector is disabled; the state message shows a connect hint.
+    property bool connected: true
+
+    readonly property var accounts: client ? client.accounts : []
+    readonly property var rules: client ? client.recurringRules : []
+
+    // The id of the currently selected account, or "" when none is chosen. Single source for
+    // both the create form's injected accountId and the post-create re-fetch.
+    readonly property string currentAccountId:
+        (client && accountCombo.currentIndex >= 0 && accounts[accountCombo.currentIndex])
+            ? accounts[accountCombo.currentIndex].id
+            : ""
+
+    // The currently selected rule, or null. Null-guards the detail pane against rules[-1] or an
+    // index past the end of a shorter new list.
+    readonly property var selectedRule:
+        (list.currentIndex >= 0 && list.currentIndex < rules.length)
+            ? rules[list.currentIndex]
+            : null
+
+    // Whether the contextual state message is showing (no rows, not mid-fetch). A logical
+    // property, not an alias to the Label's visible (which is unreliable offscreen).
+    readonly property bool stateMessageVisible:
+        list.count === 0 && !(client && client.recurringRulesLoading)
+
+    // Test/host surface.
+    property alias selectedAccountIndex: accountCombo.currentIndex
+    property alias ruleList: list
+    property alias stateMessageText: stateLabel.text
+    property alias detailNameText: detailName.text
+    property alias detailAmountText: detailAmount.text
+    property alias detailFrequencyText: detailFrequency.text
+    property alias detailStartDateText: detailStartDate.text
+    property alias detailEndDateText: detailEndDate.text
+    property alias detailScheduleText: detailSchedule.text
+    property alias detailStatusText: detailStatus.text
+    property alias createForm: createRuleForm
+
+    // Human-readable schedule for a rule's frequency-conditional day fields.
+    function scheduleText(rule) {
+        if (!rule)
+            return ""
+        if (rule.frequency === 4)
+            return "Day " + rule.dayOfMonth
+        if (rule.frequency === 3 && rule.semiMonthlyDays && rule.semiMonthlyDays.length === 2)
+            return "Days " + rule.semiMonthlyDays[0] + " & " + rule.semiMonthlyDays[1]
+        return "—"
+    }
+
+    function onAccountSelected() {
+        // Drop any prior detail selection: the incoming list is a different account's.
+        list.currentIndex = -1
+        // Read the freshly-changed index directly rather than the derived currentAccountId:
+        // inside this handler that binding can still hold its pre-change value.
+        if (accountCombo.currentIndex >= 0 && client) {
+            var account = accounts[accountCombo.currentIndex]
+            if (account)
+                client.listRecurringRules(account.id)
+        }
+    }
+
+    // New data (even for the same account) invalidates the prior row index. Clear it so the
+    // detail pane null-guards cleanly.
+    Connections {
+        target: panel.client
+        function onRecurringRulesChanged() { list.currentIndex = -1 }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 16
+        spacing: 16
+
+        ComboBox {
+            id: accountCombo
+            Layout.fillWidth: true
+            enabled: panel.connected
+            model: panel.accounts
+            textRole: "name"
+            // Start unselected: index 0 is a real account, so a placeholder displayText is the
+            // only way to offer "no account chosen" and avoid an auto-fetch on load.
+            currentIndex: -1
+            displayText: currentIndex < 0 ? "Select an account…" : currentText
+            onCurrentIndexChanged: panel.onAccountSelected()
+        }
+
+        // Create-rule form, seated above the master-detail content and fed by the selector above
+        // it (no second account picker). Disabled until connected and an account is chosen.
+        CreateRecurringRuleForm {
+            id: createRuleForm
+            Layout.fillWidth: true
+            client: panel.client
+            accountId: panel.currentAccountId
+            enabled: panel.connected && panel.currentAccountId !== ""
+            // The daemon persists before recurringRuleCreated fires, so re-fetching the account
+            // here brings the new row in; the onRecurringRulesChanged Connection clears selection.
+            onCreated: {
+                if (panel.currentAccountId !== "")
+                    panel.client.listRecurringRules(panel.currentAccountId)
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: 16
+
+            // Master: one row per rule.
+            ListView {
+                id: list
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                clip: true
+                currentIndex: -1
+                model: panel.rules
+                delegate: ItemDelegate {
+                    id: row
+                    required property int index
+                    required property var modelData
+                    width: ListView.view.width
+                    implicitHeight: rowContent.implicitHeight + 12
+                    highlighted: ListView.isCurrentItem
+                    onClicked: list.currentIndex = row.index
+                    RowLayout {
+                        id: rowContent
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.leftMargin: 8
+                        anchors.rightMargin: 8
+                        spacing: 12
+                        Label {
+                            Layout.fillWidth: true
+                            elide: Text.ElideRight
+                            text: row.modelData.paused
+                                  ? row.modelData.name + " (paused)"
+                                  : row.modelData.name
+                        }
+                        Label { text: TxFormat.frequencyLabel(row.modelData.frequency) }
+                        Label { text: TxFormat.formatAmount(row.modelData.amount) }
+                    }
+                }
+            }
+
+            // Detail: the selected rule's full record, or a placeholder.
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.alignment: Qt.AlignTop
+                spacing: 8
+
+                Label {
+                    visible: panel.selectedRule === null
+                    text: "Select a rule to see its details."
+                    color: "gray"
+                }
+
+                GridLayout {
+                    visible: panel.selectedRule !== null
+                    columns: 2
+                    columnSpacing: 12
+                    rowSpacing: 4
+
+                    Label { text: "Name"; font.bold: true }
+                    Label { id: detailName; text: panel.selectedRule ? panel.selectedRule.name : "" }
+
+                    Label { text: "Amount"; font.bold: true }
+                    Label {
+                        id: detailAmount
+                        text: panel.selectedRule ? TxFormat.formatAmount(panel.selectedRule.amount) : ""
+                    }
+
+                    Label { text: "Frequency"; font.bold: true }
+                    Label {
+                        id: detailFrequency
+                        text: panel.selectedRule ? TxFormat.frequencyLabel(panel.selectedRule.frequency) : ""
+                    }
+
+                    Label { text: "Schedule"; font.bold: true }
+                    Label { id: detailSchedule; text: panel.scheduleText(panel.selectedRule) }
+
+                    Label { text: "Start date"; font.bold: true }
+                    Label { id: detailStartDate; text: panel.selectedRule ? panel.selectedRule.startDate : "" }
+
+                    Label { text: "End date"; font.bold: true }
+                    Label {
+                        id: detailEndDate
+                        text: (panel.selectedRule && panel.selectedRule.endDate)
+                              ? panel.selectedRule.endDate
+                              : "—"
+                    }
+
+                    Label { text: "Status"; font.bold: true }
+                    Label {
+                        id: detailStatus
+                        text: !panel.selectedRule ? ""
+                              : (panel.selectedRule.paused ? "Paused" : "Active")
+                    }
+                }
+            }
+        }
+
+        // Single contextual message explaining an empty master view.
+        Label {
+            id: stateLabel
+            Layout.fillWidth: true
+            color: "gray"
+            visible: panel.stateMessageVisible
+            text: {
+                if (!panel.connected)
+                    return "Connect to the daemon to view recurring rules."
+                if (accountCombo.currentIndex < 0)
+                    return "Select an account to view its recurring rules."
+                return "No recurring rules for this account."
+            }
+        }
+    }
+}

--- a/app/qml/SignedAmountField.qml
+++ b/app/qml/SignedAmountField.qml
@@ -1,0 +1,83 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import "txformat.js" as TxFormat
+
+// Shared signed-amount input: a magnitude field whose validator forbids a sign, an
+// Expense/Income toggle as the sole sign source, and a live signed-amount preview. Extracted
+// from the transaction and recurring-rule forms so the 64-bit-overflow-safe cents handling
+// lives in one place. The host reads `signedCents`/`amountValid` and reacts to `edited()`.
+Item {
+    id: control
+
+    // Public, test-facing surface — hosts and specs drive the control through these.
+    property alias amountText: amountField.text
+    // Expense (true, default) vs Income. The magnitude field cannot carry a sign, so this
+    // toggle alone decides whether cents are negative or positive.
+    property bool expense: true
+
+    // parseFloat is NaN when blank or non-numeric; the regex validator already forbids a sign
+    // or a comma decimal, so parseFloat reads the magnitude locale-cleanly.
+    readonly property real magnitude: parseFloat(amountField.text)
+    // Reject 0 and NaN: a $0 entry is meaningless, and the daemon does not validate amount.
+    readonly property bool amountValid: !isNaN(magnitude) && magnitude > 0
+    // Math.round avoids float drift (12.34 * 100 -> 1233.9999…); the toggle applies the sign.
+    // Typed var, not int: cents cross into a 64-bit qlonglong and a QML int is 32-bit — an int
+    // would overflow above ~$21.5M. A JS number marshals to qlonglong exactly (< 2^53).
+    readonly property var signedCents: amountValid ? Math.round(magnitude * 100) * (expense ? -1 : 1) : 0
+    readonly property string previewText: amountValid ? TxFormat.formatAmount(signedCents) : ""
+
+    // Emitted on any edit (magnitude or sign) so the host can clear a stale error message.
+    signal edited()
+
+    implicitWidth: layout.implicitWidth
+    implicitHeight: layout.implicitHeight
+
+    ColumnLayout {
+        id: layout
+        anchors.fill: parent
+        spacing: 12
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 12
+
+            TextField {
+                id: amountField
+                Layout.fillWidth: true
+                placeholderText: "0.00"
+                inputMethodHints: Qt.ImhFormattedNumbersOnly
+                // Locale-independent: always ".", forbids a leading "-" so the Expense/Income
+                // toggle is the sole sign source, caps at 2 decimals. A default-locale
+                // DoubleValidator would accept "19,99", which parseFloat truncates to 19.
+                validator: RegularExpressionValidator { regularExpression: /^\d+(\.\d{0,2})?$/ }
+                onTextChanged: control.edited()
+            }
+
+            // Live signed-amount preview: the sign is visible before submit.
+            Label {
+                text: control.previewText
+                color: control.expense ? "#c0392b" : "#27ae60"
+                visible: control.previewText.length > 0
+            }
+        }
+
+        // The magnitude field cannot carry a sign, so this toggle is the only way the user
+        // expresses direction — a control that can't express the wrong value.
+        RowLayout {
+            spacing: 12
+            ButtonGroup { id: signGroup }
+            RadioButton {
+                text: "Expense"
+                ButtonGroup.group: signGroup
+                checked: control.expense
+                onClicked: { control.expense = true; control.edited() }
+            }
+            RadioButton {
+                text: "Income"
+                ButtonGroup.group: signGroup
+                onClicked: { control.expense = false; control.edited() }
+            }
+        }
+    }
+}

--- a/app/qml/txformat.js
+++ b/app/qml/txformat.js
@@ -19,3 +19,16 @@ function statusLabel(status) {
 function formatAmount(cents) {
     return (cents < 0 ? "-$" : "$") + Math.abs(cents / 100).toFixed(2)
 }
+
+// Frequency enum (proto int 1-5) -> human label. Mirrors the proto values (Weekly=1 …
+// Yearly=5); 0 is the unspecified sentinel, which a stored rule never carries.
+function frequencyLabel(frequency) {
+    switch (frequency) {
+    case 1: return "Weekly"
+    case 2: return "Biweekly"
+    case 3: return "Semi-monthly"
+    case 4: return "Monthly"
+    case 5: return "Yearly"
+    default: return "Unspecified"
+    }
+}

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -31,6 +31,8 @@ FinchClient::FinchClient(const QString& socketPath, QObject* parent)
             this, &FinchClient::onListTransactionsFinished);
     connect(&m_recordTransactionWatcher, &QFutureWatcher<RecordTransactionResult>::finished,
             this, &FinchClient::onRecordTransactionFinished);
+    connect(&m_createRecurringRuleWatcher, &QFutureWatcher<CreateRecurringRuleResult>::finished,
+            this, &FinchClient::onCreateRecurringRuleFinished);
     connect(&m_timeSeriesWatcher, &QFutureWatcher<TimeSeriesResult>::finished,
             this, &FinchClient::onTimeSeriesFinished);
 }
@@ -42,6 +44,7 @@ FinchClient::~FinchClient()
     m_createAccountWatcher.waitForFinished();
     m_transactionsWatcher.waitForFinished();
     m_recordTransactionWatcher.waitForFinished();
+    m_createRecurringRuleWatcher.waitForFinished();
     m_timeSeriesWatcher.waitForFinished();
 }
 
@@ -288,6 +291,79 @@ void FinchClient::recordTransaction(const QString& accountId, const QString& dat
     m_recordTransactionWatcher.setFuture(future);
 }
 
+void FinchClient::createRecurringRule(const QString& accountId, const QString& name,
+                                      qlonglong amount, int frequency,
+                                      const QString& startDate, const QString& endDate,
+                                      int dayOfMonth, const QVariantList& semiMonthlyDays)
+{
+    // Authoritative re-entrancy guard, mirroring createAccount/recordTransaction: the QML
+    // submit-disable is cosmetic, so without this a rapid double-submit could create two rules.
+    if (m_createRecurringRuleInProgress)
+        return;
+
+    m_createRecurringRuleInProgress = true;
+    emit createRecurringRuleInProgressChanged();
+
+    auto stub = m_stub.get();
+    std::string accountIdStr = accountId.toStdString();
+    std::string nameStr = name.toStdString();
+    std::string startDateStr = startDate.toStdString();
+    std::string endDateStr = endDate.toStdString();
+    QList<int> semiDays;
+    for (const auto& d : semiMonthlyDays)
+        semiDays.append(d.toInt());
+    auto future = QtConcurrent::run([stub, accountIdStr, nameStr, amount, frequency,
+                                     startDateStr, endDateStr, dayOfMonth,
+                                     semiDays]() -> CreateRecurringRuleResult {
+        grpc::ClientContext context;
+        context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(5));
+
+        finch::v1::CreateRecurringRuleRequest request;
+        request.set_account_id(accountIdStr);
+        request.set_name(nameStr);
+        request.set_amount(amount);
+        request.set_frequency(static_cast<finch::v1::Frequency>(frequency));
+        request.set_start_date(startDateStr);
+        request.set_end_date(endDateStr);
+        request.set_day_of_month(dayOfMonth);
+        for (int d : semiDays)
+            request.add_semi_monthly_days(d);
+        // Transfers are a distinct create mode not yet exposed in the UI.
+        request.set_is_transfer(false);
+
+        finch::v1::CreateRecurringRuleResponse response;
+        grpc::Status grpcStatus = stub->CreateRecurringRule(&context, request, &response);
+
+        CreateRecurringRuleResult result;
+        if (grpcStatus.ok()) {
+            result.ok = true;
+            result.id = QString::fromStdString(response.rule().id());
+            return result;
+        }
+
+        // Surface the daemon's validation message verbatim (user-facing and specific — the
+        // daemon now returns InvalidArgument for out-of-range day fields); everything else gets
+        // a generic message. status lives only on this worker thread, so copy it into result.
+        switch (grpcStatus.error_code()) {
+        case grpc::StatusCode::INVALID_ARGUMENT:
+            result.errorMessage = QString::fromStdString(grpcStatus.error_message());
+            break;
+        case grpc::StatusCode::UNAVAILABLE:
+            result.errorMessage = QStringLiteral("Could not reach the daemon.");
+            break;
+        case grpc::StatusCode::DEADLINE_EXCEEDED:
+            result.errorMessage = QStringLiteral("The request timed out. Please try again.");
+            break;
+        default:
+            result.errorMessage = QStringLiteral("Could not create the rule. Please try again.");
+            break;
+        }
+        return result;
+    });
+
+    m_createRecurringRuleWatcher.setFuture(future);
+}
+
 void FinchClient::fetchTimeSeries(const QString& fromDate, const QString& toDate,
                                   int interval, const QStringList& accountIds)
 {
@@ -519,6 +595,24 @@ void FinchClient::onRecordTransactionFinished()
     }
 
     emit transactionRecorded(result.id);
+}
+
+void FinchClient::onCreateRecurringRuleFinished()
+{
+    auto result = m_createRecurringRuleWatcher.result();
+
+    m_createRecurringRuleInProgress = false;
+    emit createRecurringRuleInProgressChanged();
+
+    if (!result.ok) {
+        emit recurringRuleCreateFailed(result.errorMessage);
+        return;
+    }
+
+    // Emit only — the panel re-fetches the account's rules on this signal (mirroring the
+    // transaction write path). Do not append to a local model like createAccount does: an
+    // append would be clobbered by the re-fetch's list-clear.
+    emit recurringRuleCreated(result.id);
 }
 
 void FinchClient::onPingFinished()

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -33,6 +33,8 @@ FinchClient::FinchClient(const QString& socketPath, QObject* parent)
             this, &FinchClient::onRecordTransactionFinished);
     connect(&m_createRecurringRuleWatcher, &QFutureWatcher<CreateRecurringRuleResult>::finished,
             this, &FinchClient::onCreateRecurringRuleFinished);
+    connect(&m_recurringRulesWatcher, &QFutureWatcher<ListRecurringRulesResult>::finished,
+            this, &FinchClient::onListRecurringRulesFinished);
     connect(&m_timeSeriesWatcher, &QFutureWatcher<TimeSeriesResult>::finished,
             this, &FinchClient::onTimeSeriesFinished);
 }
@@ -45,6 +47,7 @@ FinchClient::~FinchClient()
     m_transactionsWatcher.waitForFinished();
     m_recordTransactionWatcher.waitForFinished();
     m_createRecurringRuleWatcher.waitForFinished();
+    m_recurringRulesWatcher.waitForFinished();
     m_timeSeriesWatcher.waitForFinished();
 }
 
@@ -364,6 +367,71 @@ void FinchClient::createRecurringRule(const QString& accountId, const QString& n
     m_createRecurringRuleWatcher.setFuture(future);
 }
 
+void FinchClient::listRecurringRules(const QString& accountId)
+{
+    m_requestedRecurringRulesAccountId = accountId;
+    // A fetch is already in flight; do not start a concurrent one (a second QtConcurrent task
+    // would no longer be waited on by the destructor). onListRecurringRulesFinished reconciles
+    // to the requested account once it lands.
+    if (m_recurringRulesLoading)
+        return;
+
+    startRecurringRulesFetch();
+}
+
+void FinchClient::startRecurringRulesFetch()
+{
+    m_recurringRulesLoading = true;
+    m_inFlightRecurringRulesAccountId = m_requestedRecurringRulesAccountId;
+    emit recurringRulesLoadingChanged();
+
+    // Clear immediately so the in-flight window never shows the previously loaded account's
+    // rules under the newly selected account (the panel binds its list to this).
+    m_recurringRules.clear();
+    emit recurringRulesChanged();
+
+    auto stub = m_stub.get();
+    std::string id = m_inFlightRecurringRulesAccountId.toStdString();
+    auto future = QtConcurrent::run([stub, id]() -> ListRecurringRulesResult {
+        grpc::ClientContext context;
+        context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(5));
+
+        finch::v1::ListRecurringRulesRequest request;
+        request.set_account_id(id);
+        finch::v1::ListRecurringRulesResponse response;
+
+        grpc::Status status = stub->ListRecurringRules(&context, request, &response);
+        if (!status.ok())
+            return {false, {}};
+
+        QVariantList rules;
+        for (const auto& rule : response.rules()) {
+            QVariantMap entry;
+            entry["id"] = QString::fromStdString(rule.id());
+            entry["accountId"] = QString::fromStdString(rule.account_id());
+            entry["name"] = QString::fromStdString(rule.name());
+            // Signed cents; the panel formats and applies the sign.
+            entry["amount"] = static_cast<qlonglong>(rule.amount());
+            // Raw Frequency int; the panel maps it to a human label.
+            entry["frequency"] = static_cast<int>(rule.frequency());
+            entry["startDate"] = QString::fromStdString(rule.start_date());
+            entry["endDate"] = QString::fromStdString(rule.end_date());
+            entry["dayOfMonth"] = static_cast<int>(rule.day_of_month());
+            QVariantList semiDays;
+            for (int d : rule.semi_monthly_days())
+                semiDays.append(d);
+            entry["semiMonthlyDays"] = semiDays;
+            entry["isTransfer"] = rule.is_transfer();
+            entry["transferTargetAccountId"] = QString::fromStdString(rule.transfer_target_account_id());
+            entry["paused"] = rule.paused();
+            rules.append(entry);
+        }
+        return {true, rules};
+    });
+
+    m_recurringRulesWatcher.setFuture(future);
+}
+
 void FinchClient::fetchTimeSeries(const QString& fromDate, const QString& toDate,
                                   int interval, const QStringList& accountIds)
 {
@@ -613,6 +681,28 @@ void FinchClient::onCreateRecurringRuleFinished()
     // transaction write path). Do not append to a local model like createAccount does: an
     // append would be clobbered by the re-fetch's list-clear.
     emit recurringRuleCreated(result.id);
+}
+
+void FinchClient::onListRecurringRulesFinished()
+{
+    auto result = m_recurringRulesWatcher.result();
+
+    m_recurringRulesLoading = false;
+    emit recurringRulesLoadingChanged();
+
+    // A newer account was selected while this fetch was in flight (a rapid account switch); its
+    // result is for the wrong account. Discard it and fetch the account now selected.
+    if (m_inFlightRecurringRulesAccountId != m_requestedRecurringRulesAccountId) {
+        startRecurringRulesFetch();
+        return;
+    }
+
+    if (result.ok) {
+        m_recurringRules = result.rules;
+    } else {
+        m_recurringRules.clear();
+    }
+    emit recurringRulesChanged();
 }
 
 void FinchClient::onPingFinished()

--- a/app/src/finchclient.h
+++ b/app/src/finchclient.h
@@ -42,6 +42,12 @@ struct RecordTransactionResult {
     QString errorMessage;
 };
 
+struct CreateRecurringRuleResult {
+    bool ok = false;
+    QString id;
+    QString errorMessage;
+};
+
 struct TimeSeriesPoint {
     qint64 msecsSinceEpoch;
     double balance;
@@ -63,6 +69,7 @@ class FinchClient : public QObject {
     Q_PROPERTY(QVariantList transactions READ transactions NOTIFY transactionsChanged)
     Q_PROPERTY(bool transactionsLoading READ transactionsLoading NOTIFY transactionsLoadingChanged)
     Q_PROPERTY(bool recordTransactionInProgress READ recordTransactionInProgress NOTIFY recordTransactionInProgressChanged)
+    Q_PROPERTY(bool createRecurringRuleInProgress READ createRecurringRuleInProgress NOTIFY createRecurringRuleInProgressChanged)
     Q_PROPERTY(bool timeSeriesLoading READ timeSeriesLoading NOTIFY timeSeriesLoadingChanged)
     Q_PROPERTY(bool timeSeriesEmpty READ timeSeriesEmpty NOTIFY timeSeriesDataChanged)
     Q_PROPERTY(QStringList timeSeriesAccountIds READ timeSeriesAccountIds NOTIFY timeSeriesDataChanged)
@@ -87,6 +94,7 @@ public:
     QVariantList transactions() const { return m_transactions; }
     bool transactionsLoading() const { return m_transactionsLoading; }
     bool recordTransactionInProgress() const { return m_recordTransactionInProgress; }
+    bool createRecurringRuleInProgress() const { return m_createRecurringRuleInProgress; }
     bool timeSeriesLoading() const { return m_timeSeriesLoading; }
     bool timeSeriesEmpty() const;
     QStringList timeSeriesAccountIds() const;
@@ -102,6 +110,10 @@ public:
     Q_INVOKABLE void recordTransaction(const QString& accountId, const QString& date,
                                        qlonglong amount, const QString& name,
                                        const QString& description, int status);
+    Q_INVOKABLE void createRecurringRule(const QString& accountId, const QString& name,
+                                         qlonglong amount, int frequency,
+                                         const QString& startDate, const QString& endDate,
+                                         int dayOfMonth, const QVariantList& semiMonthlyDays);
     Q_INVOKABLE void fetchTimeSeries(const QString& fromDate, const QString& toDate,
                                      int interval, const QStringList& accountIds);
     Q_INVOKABLE void populateSeries(QObject* series, const QString& accountId);
@@ -120,6 +132,9 @@ signals:
     void recordTransactionInProgressChanged();
     void transactionRecorded(QString id);
     void transactionRecordFailed(QString message);
+    void createRecurringRuleInProgressChanged();
+    void recurringRuleCreated(QString id);
+    void recurringRuleCreateFailed(QString message);
     void timeSeriesLoadingChanged();
     void timeSeriesDataChanged();
 
@@ -130,6 +145,7 @@ private slots:
     void onCreateAccountFinished();
     void onListTransactionsFinished();
     void onRecordTransactionFinished();
+    void onCreateRecurringRuleFinished();
     void onTimeSeriesFinished();
 
 private:
@@ -164,6 +180,8 @@ private:
     QFutureWatcher<ListTransactionsResult> m_transactionsWatcher;
     bool m_recordTransactionInProgress = false;
     QFutureWatcher<RecordTransactionResult> m_recordTransactionWatcher;
+    bool m_createRecurringRuleInProgress = false;
+    QFutureWatcher<CreateRecurringRuleResult> m_createRecurringRuleWatcher;
     bool m_timeSeriesLoading = false;
     QFutureWatcher<TimeSeriesResult> m_timeSeriesWatcher;
     TimeSeriesResult m_timeSeriesData;

--- a/app/src/finchclient.h
+++ b/app/src/finchclient.h
@@ -48,6 +48,11 @@ struct CreateRecurringRuleResult {
     QString errorMessage;
 };
 
+struct ListRecurringRulesResult {
+    bool ok = false;
+    QVariantList rules;
+};
+
 struct TimeSeriesPoint {
     qint64 msecsSinceEpoch;
     double balance;
@@ -70,6 +75,8 @@ class FinchClient : public QObject {
     Q_PROPERTY(bool transactionsLoading READ transactionsLoading NOTIFY transactionsLoadingChanged)
     Q_PROPERTY(bool recordTransactionInProgress READ recordTransactionInProgress NOTIFY recordTransactionInProgressChanged)
     Q_PROPERTY(bool createRecurringRuleInProgress READ createRecurringRuleInProgress NOTIFY createRecurringRuleInProgressChanged)
+    Q_PROPERTY(QVariantList recurringRules READ recurringRules NOTIFY recurringRulesChanged)
+    Q_PROPERTY(bool recurringRulesLoading READ recurringRulesLoading NOTIFY recurringRulesLoadingChanged)
     Q_PROPERTY(bool timeSeriesLoading READ timeSeriesLoading NOTIFY timeSeriesLoadingChanged)
     Q_PROPERTY(bool timeSeriesEmpty READ timeSeriesEmpty NOTIFY timeSeriesDataChanged)
     Q_PROPERTY(QStringList timeSeriesAccountIds READ timeSeriesAccountIds NOTIFY timeSeriesDataChanged)
@@ -95,6 +102,8 @@ public:
     bool transactionsLoading() const { return m_transactionsLoading; }
     bool recordTransactionInProgress() const { return m_recordTransactionInProgress; }
     bool createRecurringRuleInProgress() const { return m_createRecurringRuleInProgress; }
+    QVariantList recurringRules() const { return m_recurringRules; }
+    bool recurringRulesLoading() const { return m_recurringRulesLoading; }
     bool timeSeriesLoading() const { return m_timeSeriesLoading; }
     bool timeSeriesEmpty() const;
     QStringList timeSeriesAccountIds() const;
@@ -114,6 +123,7 @@ public:
                                          qlonglong amount, int frequency,
                                          const QString& startDate, const QString& endDate,
                                          int dayOfMonth, const QVariantList& semiMonthlyDays);
+    Q_INVOKABLE void listRecurringRules(const QString& accountId);
     Q_INVOKABLE void fetchTimeSeries(const QString& fromDate, const QString& toDate,
                                      int interval, const QStringList& accountIds);
     Q_INVOKABLE void populateSeries(QObject* series, const QString& accountId);
@@ -135,6 +145,8 @@ signals:
     void createRecurringRuleInProgressChanged();
     void recurringRuleCreated(QString id);
     void recurringRuleCreateFailed(QString message);
+    void recurringRulesChanged();
+    void recurringRulesLoadingChanged();
     void timeSeriesLoadingChanged();
     void timeSeriesDataChanged();
 
@@ -146,6 +158,7 @@ private slots:
     void onListTransactionsFinished();
     void onRecordTransactionFinished();
     void onCreateRecurringRuleFinished();
+    void onListRecurringRulesFinished();
     void onTimeSeriesFinished();
 
 private:
@@ -153,6 +166,10 @@ private:
     // in-flight account). The re-entrancy guard in listTransactions and the reconciliation in
     // onListTransactionsFinished both funnel through here.
     void startTransactionsFetch();
+    // Starts a recurring-rules fetch for m_requestedRecurringRulesAccountId. The re-entrancy
+    // guard in listRecurringRules and the reconciliation in onListRecurringRulesFinished funnel
+    // through here — the account-id-keyed twin of startTransactionsFetch.
+    void startRecurringRulesFetch();
 
     std::shared_ptr<grpc::Channel> m_channel;
     std::unique_ptr<finch::v1::FinchService::Stub> m_stub;
@@ -182,6 +199,13 @@ private:
     QFutureWatcher<RecordTransactionResult> m_recordTransactionWatcher;
     bool m_createRecurringRuleInProgress = false;
     QFutureWatcher<CreateRecurringRuleResult> m_createRecurringRuleWatcher;
+    QVariantList m_recurringRules;
+    bool m_recurringRulesLoading = false;
+    // Account-id-keyed single-in-flight reconciliation, like the transactions path: the account
+    // the running fetch is for vs. the account most recently requested.
+    QString m_requestedRecurringRulesAccountId;
+    QString m_inFlightRecurringRulesAccountId;
+    QFutureWatcher<ListRecurringRulesResult> m_recurringRulesWatcher;
     bool m_timeSeriesLoading = false;
     QFutureWatcher<TimeSeriesResult> m_timeSeriesWatcher;
     TimeSeriesResult m_timeSeriesData;

--- a/app/tests/MockFinchClient.qml
+++ b/app/tests/MockFinchClient.qml
@@ -24,6 +24,18 @@ QtObject {
     // account switch rather than an unrealistic two-concurrent-fetch model.
     property string inFlightAccountId: ""
 
+    // RecurringRulesPanel binds its ListView model to this; default empty so the binding is
+    // clean. succeedRecurringRules() ASSIGNS it (not just emits) so the bound list refreshes.
+    property var recurringRules: []
+    property string lastRulesAccountId: ""
+    property int recurringRulesCallCount: 0
+    property bool recurringRulesLoading: false
+    // Account-id-keyed single-in-flight reconciliation, faithful to the real client's
+    // listRecurringRules (mirrors the listTransactions pattern): the account the running fetch
+    // is for vs. the account most recently requested. When they diverge, the stale completion
+    // is discarded and the requested account re-fetched.
+    property string inFlightRulesAccountId: ""
+
     // RecordTransactionForm (embedded in TransactionsPanel) drives these; default in-progress
     // false so the embedded form starts enabled. Each field is captured separately so a spec
     // can catch a name<->description transpose in the 6-arg positional call.
@@ -123,6 +135,33 @@ QtObject {
     function failCreateRecurringRule(message) {
         createRecurringRuleInProgress = false
         recurringRuleCreateFailed(message)
+    }
+
+    // Mirrors the real client's account-id-keyed single-in-flight reconciliation, exactly like
+    // listTransactions/succeedTransactions above: a second request while a fetch is in flight
+    // is recorded as the new requested account but does NOT start a concurrent fetch.
+    function listRecurringRules(accountId) {
+        lastRulesAccountId = accountId
+        recurringRulesCallCount += 1
+        if (recurringRulesLoading)
+            return
+        inFlightRulesAccountId = accountId
+        recurringRulesLoading = true
+        recurringRules = []
+    }
+
+    // Completes the in-flight fetch; assigning `recurringRules` is the notification the panel's
+    // model binding reacts to. If a newer account was requested meanwhile, discard `list` and
+    // re-enter the in-flight state for the requested account.
+    function succeedRecurringRules(list) {
+        recurringRulesLoading = false
+        if (inFlightRulesAccountId !== lastRulesAccountId) {
+            inFlightRulesAccountId = lastRulesAccountId
+            recurringRulesLoading = true
+            recurringRules = []
+            return
+        }
+        recurringRules = list
     }
 
     // callCount counts invocations (every call). The re-entrancy guard mirrors the real

--- a/app/tests/MockFinchClient.qml
+++ b/app/tests/MockFinchClient.qml
@@ -36,10 +36,26 @@ QtObject {
     property int lastRecordStatus: -1
     property int recordCallCount: 0
 
+    // CreateRecurringRuleForm drives these; default in-progress false so the form starts
+    // enabled. Each arg is captured separately so a spec can catch a transpose in the 8-arg
+    // positional call.
+    property bool createRecurringRuleInProgress: false
+    property string lastCreateAccountId: ""
+    property string lastCreateName: ""
+    property var lastCreateAmount: 0
+    property int lastCreateFrequency: -1
+    property string lastCreateStartDate: ""
+    property string lastCreateEndDate: ""
+    property int lastCreateDayOfMonth: -1
+    property var lastCreateSemiMonthlyDays: []
+    property int createRecurringRuleCallCount: 0
+
     signal accountCreated(string id)
     signal accountCreateFailed(string message)
     signal transactionRecorded(string id)
     signal transactionRecordFailed(string message)
+    signal recurringRuleCreated(string id)
+    signal recurringRuleCreateFailed(string message)
 
     // Mirror the real client's observable lifecycle: in-progress latches true on the
     // call and clears when the test drives a terminal outcome via succeed()/fail().
@@ -82,6 +98,31 @@ QtObject {
     function failRecord(message) {
         recordTransactionInProgress = false
         transactionRecordFailed(message)
+    }
+
+    // Mirror the real client: in-progress latches true synchronously on the call and clears
+    // when the test drives a terminal outcome via succeed/failCreateRecurringRule().
+    function createRecurringRule(accountId, name, amount, frequency, startDate, endDate, dayOfMonth, semiMonthlyDays) {
+        lastCreateAccountId = accountId
+        lastCreateName = name
+        lastCreateAmount = amount
+        lastCreateFrequency = frequency
+        lastCreateStartDate = startDate
+        lastCreateEndDate = endDate
+        lastCreateDayOfMonth = dayOfMonth
+        lastCreateSemiMonthlyDays = semiMonthlyDays
+        createRecurringRuleCallCount += 1
+        createRecurringRuleInProgress = true
+    }
+
+    function succeedCreateRecurringRule(id) {
+        createRecurringRuleInProgress = false
+        recurringRuleCreated(id)
+    }
+
+    function failCreateRecurringRule(message) {
+        createRecurringRuleInProgress = false
+        recurringRuleCreateFailed(message)
     }
 
     // callCount counts invocations (every call). The re-entrancy guard mirrors the real

--- a/app/tests/recurringruleform/tst_CreateRecurringRuleForm.qml
+++ b/app/tests/recurringruleform/tst_CreateRecurringRuleForm.qml
@@ -1,0 +1,271 @@
+import QtQuick
+import QtTest
+// FinchRecurringFormTest is the test-only module (see app/CMakeLists.txt) holding the real
+// shipping CreateRecurringRuleForm, the txformat.js helper it imports, and the shared
+// MockFinchClient double — scoped to just those files.
+import FinchRecurringFormTest
+
+TestCase {
+    id: testCase
+    name: "CreateRecurringRuleForm"
+    when: windowShown
+
+    // Frequency enum values (proto Frequency): Weekly=1 … Yearly=5. The ComboBox has no
+    // sentinel row, so a row's index is one less than its value — picking index 3 (Monthly)
+    // must submit value 4, which is what catches an index-vs-value bug.
+    readonly property int idxWeekly: 0
+    readonly property int idxSemiMonthly: 2
+    readonly property int idxMonthly: 3
+
+    Component { id: formFactory; CreateRecurringRuleForm {} }
+    Component { id: mockFactory; MockFinchClient {} }
+
+    SignalSpy { id: createdSpy; signalName: "created" }
+
+    property var currentForm: null
+    property var currentMock: null
+
+    function build(opts) {
+        opts = opts || {}
+        currentMock = mockFactory.createObject(testCase)
+        var props = { client: currentMock }
+        if (opts.accountId !== undefined)
+            props.accountId = opts.accountId
+        currentForm = formFactory.createObject(testCase, props)
+        verify(currentForm !== null, "form instantiated")
+        return { form: currentForm, mock: currentMock }
+    }
+
+    function cleanup() {
+        createdSpy.target = null
+        if (currentForm) { currentForm.destroy(); currentForm = null }
+        if (currentMock) { currentMock.destroy(); currentMock = null }
+    }
+
+    // Fills a valid Weekly expense: account injected, name + magnitude + a frequency set. The
+    // start date defaults to today, so a minimal weekly rule needs no date input.
+    function fillValidWeekly(ctx) {
+        ctx.form.accountId = "a1"
+        ctx.form.nameText = "Gym"
+        ctx.form.amountText = "40"
+        ctx.form.frequencyIndex = idxWeekly
+    }
+
+    function test_loadsAndStartsInvalid() {
+        var ctx = build()
+        compare(ctx.form.canSubmit, false)
+    }
+
+    function test_disabledWithoutFrequency() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Gym"
+        ctx.form.amountText = "40"
+        // No frequency chosen yet.
+        compare(ctx.form.canSubmit, false)
+    }
+
+    function test_enabledWeeklyMinimal() {
+        var ctx = build()
+        fillValidWeekly(ctx)
+        compare(ctx.form.canSubmit, true)
+    }
+
+    function test_disabledWhenNoAccount() {
+        var ctx = build()
+        ctx.form.nameText = "Gym"
+        ctx.form.amountText = "40"
+        ctx.form.frequencyIndex = idxWeekly
+        compare(ctx.form.accountId, "")
+        compare(ctx.form.canSubmit, false)
+    }
+
+    function test_disabledWhenNameBlank() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.amountText = "40"
+        ctx.form.frequencyIndex = idxWeekly
+        ctx.form.nameText = "   "
+        compare(ctx.form.canSubmit, false)
+    }
+
+    function test_disabledWhenAmountZero() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Gym"
+        ctx.form.frequencyIndex = idxWeekly
+        ctx.form.amountText = "0"
+        compare(ctx.form.canSubmit, false)
+    }
+
+    // A weekly rule sends signed cents, the trimmed name, the account, frequency value 1, the
+    // start date, an empty end date, day-of-month 0 and no semi-monthly days. Each arg is
+    // asserted independently — an 8-arg positional call is a transpose waiting to happen.
+    function test_submitSendsWeeklyArgs() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "  Gym  "
+        ctx.form.amountText = "40"
+        ctx.form.expense = true
+        ctx.form.frequencyIndex = idxWeekly
+        ctx.form.startDateText = "2025-06-01"
+        ctx.form.submit()
+        compare(ctx.mock.createRecurringRuleCallCount, 1)
+        compare(ctx.mock.lastCreateAccountId, "a1")
+        compare(ctx.mock.lastCreateName, "Gym")
+        compare(ctx.mock.lastCreateAmount, -4000)
+        compare(ctx.mock.lastCreateFrequency, 1)
+        compare(ctx.mock.lastCreateStartDate, "2025-06-01")
+        compare(ctx.mock.lastCreateEndDate, "")
+        compare(ctx.mock.lastCreateDayOfMonth, 0)
+        compare(ctx.mock.lastCreateSemiMonthlyDays.length, 0)
+    }
+
+    function test_incomeIsPositive() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Paycheck"
+        ctx.form.amountText = "2000"
+        ctx.form.expense = false
+        ctx.form.frequencyIndex = idxWeekly
+        ctx.form.submit()
+        compare(ctx.mock.lastCreateAmount, 200000)
+    }
+
+    function test_signIntegrity() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.amountText = "9.99"
+        ctx.form.expense = true
+        verify(ctx.form.signedCents < 0)
+        ctx.form.expense = false
+        verify(ctx.form.signedCents > 0)
+    }
+
+    // Above the 32-bit int ceiling: signedCents is a JS number (not a QML int), so ~$30M does
+    // not overflow on the way to the client's 64-bit qlonglong amount.
+    function test_largeAmountDoesNotOverflow() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Mortgage payoff"
+        ctx.form.amountText = "30000000"
+        ctx.form.expense = true
+        ctx.form.frequencyIndex = idxWeekly
+        compare(ctx.form.signedCents, -3000000000)
+        ctx.form.submit()
+        compare(ctx.mock.lastCreateAmount, -3000000000)
+    }
+
+    // Monthly is index 3 but enum value 4. Submitting the value (not the index) is what this
+    // asserts — with no sentinel row, index != value, so a currentIndex-instead-of-value bug
+    // would send 3 and fail here.
+    function test_monthlySubmitsFrequencyValueNotIndex() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Rent"
+        ctx.form.amountText = "1500"
+        ctx.form.frequencyIndex = idxMonthly
+        ctx.form.dayOfMonthText = "15"
+        ctx.form.submit()
+        compare(ctx.mock.lastCreateFrequency, 4)
+        compare(ctx.mock.lastCreateDayOfMonth, 15)
+        compare(ctx.mock.lastCreateSemiMonthlyDays.length, 0)
+    }
+
+    function test_monthlyRequiresDayInRange() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Rent"
+        ctx.form.amountText = "1500"
+        ctx.form.frequencyIndex = idxMonthly
+        ctx.form.dayOfMonthText = ""          // missing
+        compare(ctx.form.canSubmit, false)
+        ctx.form.dayOfMonthText = "40"        // out of range
+        compare(ctx.form.canSubmit, false)
+        ctx.form.dayOfMonthText = "15"        // valid
+        compare(ctx.form.canSubmit, true)
+    }
+
+    function test_semiMonthlyRequiresTwoDaysInRange() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Paycheck"
+        ctx.form.amountText = "2000"
+        ctx.form.frequencyIndex = idxSemiMonthly
+        ctx.form.semiDay1Text = "1"
+        ctx.form.semiDay2Text = ""            // second missing
+        compare(ctx.form.canSubmit, false)
+        ctx.form.semiDay2Text = "40"          // out of range
+        compare(ctx.form.canSubmit, false)
+        ctx.form.semiDay2Text = "15"          // both valid
+        compare(ctx.form.canSubmit, true)
+    }
+
+    function test_semiMonthlySubmitsBothDays() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Paycheck"
+        ctx.form.amountText = "2000"
+        ctx.form.frequencyIndex = idxSemiMonthly
+        ctx.form.semiDay1Text = "1"
+        ctx.form.semiDay2Text = "15"
+        ctx.form.submit()
+        compare(ctx.mock.lastCreateFrequency, 3)
+        compare(ctx.mock.lastCreateDayOfMonth, 0)
+        compare(ctx.mock.lastCreateSemiMonthlyDays.length, 2)
+        compare(ctx.mock.lastCreateSemiMonthlyDays[0], 1)
+        compare(ctx.mock.lastCreateSemiMonthlyDays[1], 15)
+    }
+
+    // An end date before the start date creates a rule that projects zero occurrences (the
+    // daemon and core do not validate ordering), so the form must block it.
+    function test_endDateBeforeStartDisables() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "Gym"
+        ctx.form.amountText = "40"
+        ctx.form.frequencyIndex = idxWeekly
+        ctx.form.startDateText = "2025-06-01"
+        ctx.form.endDateText = "2025-05-01"   // before start
+        compare(ctx.form.canSubmit, false)
+        ctx.form.endDateText = "2025-07-01"   // after start
+        compare(ctx.form.canSubmit, true)
+        ctx.form.endDateText = ""             // open-ended
+        compare(ctx.form.canSubmit, true)
+    }
+
+    function test_submitIgnoredWhenInvalid() {
+        var ctx = build({ accountId: "a1" })
+        ctx.form.nameText = "   "
+        ctx.form.amountText = "40"
+        ctx.form.frequencyIndex = idxWeekly
+        ctx.form.submit()
+        compare(ctx.mock.createRecurringRuleCallCount, 0)
+    }
+
+    function test_successClearsFieldsAndSignalsCreated() {
+        var ctx = build({ accountId: "a1" })
+        createdSpy.target = ctx.form
+        createdSpy.clear()
+        fillValidWeekly(ctx)
+        ctx.form.submit()
+        ctx.mock.succeedCreateRecurringRule("rule-1")
+        compare(createdSpy.count, 1)
+        compare(ctx.form.nameText, "")
+        compare(ctx.form.amountText, "")
+        createdSpy.target = null
+    }
+
+    function test_failureShowsErrorMessage() {
+        var ctx = build({ accountId: "a1" })
+        fillValidWeekly(ctx)
+        ctx.form.submit()
+        ctx.mock.failCreateRecurringRule("day_of_month must be 1-31")
+        compare(ctx.form.errorText, "day_of_month must be 1-31")
+    }
+
+    function test_disabledWhileCreateInProgress() {
+        var ctx = build({ accountId: "a1" })
+        fillValidWeekly(ctx)
+        verify(ctx.form.canSubmit)
+        ctx.form.submit()
+        compare(ctx.mock.createRecurringRuleInProgress, true)
+        compare(ctx.form.canSubmit, false)
+    }
+
+    function test_doubleSubmitSendsOnlyOne() {
+        var ctx = build({ accountId: "a1" })
+        fillValidWeekly(ctx)
+        ctx.form.submit()
+        ctx.form.submit()
+        compare(ctx.mock.createRecurringRuleCallCount, 1)
+    }
+}

--- a/app/tests/recurringrulespanel/tst_RecurringRulesPanel.qml
+++ b/app/tests/recurringrulespanel/tst_RecurringRulesPanel.qml
@@ -1,0 +1,242 @@
+import QtQuick
+import QtTest
+// FinchRecurringPanelTest is the test-only module (see app/CMakeLists.txt) holding the real
+// shipping RecurringRulesPanel, the CreateRecurringRuleForm it embeds, the txformat.js helper,
+// and the shared MockFinchClient double — scoped to just those files.
+import FinchRecurringPanelTest
+
+TestCase {
+    id: testCase
+    name: "RecurringRulesPanel"
+    when: windowShown
+    width: 640
+    height: 480
+
+    Component { id: panelFactory; RecurringRulesPanel {} }
+    Component { id: mockFactory; MockFinchClient {} }
+
+    property var currentPanel: null
+    property var currentMock: null
+
+    readonly property var sampleAccounts: [
+        { id: "a1", name: "Checking" },
+        { id: "a2", name: "Savings" }
+    ]
+
+    // A monthly expense and a semi-monthly paused credit, so one fixture pins the amount
+    // format, the frequency->label mapping, the schedule text, and the paused flag.
+    readonly property var sampleRules: [
+        { id: "r1", accountId: "a1", name: "Rent", amount: -150000, frequency: 4,
+          startDate: "2025-01-01", endDate: "", dayOfMonth: 1, semiMonthlyDays: [],
+          isTransfer: false, transferTargetAccountId: "", paused: false },
+        { id: "r2", accountId: "a1", name: "Paycheck", amount: 200000, frequency: 3,
+          startDate: "2025-01-01", endDate: "2025-12-31", dayOfMonth: 0, semiMonthlyDays: [1, 15],
+          isTransfer: false, transferTargetAccountId: "", paused: true }
+    ]
+
+    // Accounts are set on the mock BEFORE the panel is built, so the selector model is populated
+    // at completion — the only way to prove the panel does not auto-fetch on a non-empty list.
+    function build(opts) {
+        opts = opts || {}
+        currentMock = mockFactory.createObject(testCase)
+        currentMock.accounts = (opts.accounts !== undefined) ? opts.accounts : sampleAccounts
+        var props = { client: currentMock }
+        props.connected = (opts.connected !== undefined) ? opts.connected : true
+        currentPanel = panelFactory.createObject(testCase, props)
+        verify(currentPanel !== null, "panel instantiated")
+        return { panel: currentPanel, mock: currentMock }
+    }
+
+    function cleanup() {
+        if (currentPanel) { currentPanel.destroy(); currentPanel = null }
+        if (currentMock) { currentMock.destroy(); currentMock = null }
+    }
+
+    function selectAccountWith(ctx, index, rules) {
+        ctx.panel.selectedAccountIndex = index
+        ctx.mock.succeedRecurringRules(rules)
+    }
+
+    function test_loadsAndStartsUnselected() {
+        var ctx = build()
+        compare(ctx.panel.selectedAccountIndex, -1)
+        compare(ctx.mock.recurringRulesCallCount, 0)
+    }
+
+    function test_noFetchUntilAccountSelected() {
+        var ctx = build()
+        compare(ctx.mock.recurringRulesCallCount, 0)
+        ctx.panel.selectedAccountIndex = 0
+        compare(ctx.mock.recurringRulesCallCount, 1)
+        compare(ctx.mock.lastRulesAccountId, "a1")
+    }
+
+    function test_selectingAccountListsThatAccount() {
+        var ctx = build()
+        ctx.panel.selectedAccountIndex = 1
+        compare(ctx.mock.recurringRulesCallCount, 1)
+        compare(ctx.mock.lastRulesAccountId, "a2")
+    }
+
+    function test_changingAccountRefetches() {
+        var ctx = build()
+        ctx.panel.selectedAccountIndex = 0
+        ctx.panel.selectedAccountIndex = 1
+        compare(ctx.mock.recurringRulesCallCount, 2)
+        compare(ctx.mock.lastRulesAccountId, "a2")
+    }
+
+    function test_rulesRenderAsRows() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleRules)
+        compare(ctx.panel.ruleList.count, 2)
+    }
+
+    function test_selectingRowFillsDetail() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleRules)
+        ctx.panel.ruleList.currentIndex = 0
+        verify(ctx.panel.selectedRule !== null)
+        compare(ctx.panel.detailNameText, "Rent")
+        compare(ctx.panel.detailStartDateText, "2025-01-01")
+    }
+
+    function test_amountFormattedWithSign() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleRules)
+        ctx.panel.ruleList.currentIndex = 0
+        compare(ctx.panel.detailAmountText, "-$1500.00")
+    }
+
+    function test_frequencyRenderedAsLabelNotInt() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleRules)
+        ctx.panel.ruleList.currentIndex = 0
+        compare(ctx.panel.detailFrequencyText, "Monthly")
+        ctx.panel.ruleList.currentIndex = 1
+        compare(ctx.panel.detailFrequencyText, "Semi-monthly")
+    }
+
+    // Schedule text reads the frequency-conditional day fields: a day-of-month for Monthly,
+    // the two days for Semi-monthly.
+    function test_scheduleTextReflectsFrequency() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleRules)
+        ctx.panel.ruleList.currentIndex = 0
+        compare(ctx.panel.detailScheduleText, "Day 1")
+        ctx.panel.ruleList.currentIndex = 1
+        compare(ctx.panel.detailScheduleText, "Days 1 & 15")
+    }
+
+    function test_pausedRuleShown() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleRules)
+        ctx.panel.ruleList.currentIndex = 0
+        compare(ctx.panel.detailStatusText, "Active")
+        ctx.panel.ruleList.currentIndex = 1
+        compare(ctx.panel.detailStatusText, "Paused")
+    }
+
+    function test_endDateShownOrDash() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleRules)
+        ctx.panel.ruleList.currentIndex = 0
+        compare(ctx.panel.detailEndDateText, "—")   // open-ended
+        ctx.panel.ruleList.currentIndex = 1
+        compare(ctx.panel.detailEndDateText, "2025-12-31")
+    }
+
+    function test_emptyResultShowsNoRules() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, [])
+        verify(ctx.panel.stateMessageVisible)
+        compare(ctx.panel.stateMessageText, "No recurring rules for this account.")
+    }
+
+    function test_noAccountSelectedShowsPrompt() {
+        var ctx = build()
+        verify(ctx.panel.stateMessageVisible)
+        compare(ctx.panel.stateMessageText, "Select an account to view its recurring rules.")
+    }
+
+    function test_disconnectedShowsConnectHint() {
+        var ctx = build({ connected: false, accounts: [] })
+        verify(ctx.panel.stateMessageVisible)
+        compare(ctx.panel.stateMessageText, "Connect to the daemon to view recurring rules.")
+    }
+
+    function test_changingAccountResetsSelection() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleRules)
+        ctx.panel.ruleList.currentIndex = 0
+        verify(ctx.panel.selectedRule !== null)
+        ctx.panel.selectedAccountIndex = 1
+        compare(ctx.panel.ruleList.currentIndex, -1)
+        verify(ctx.panel.selectedRule === null)
+        ctx.mock.succeedRecurringRules([sampleRules[1]])
+        compare(ctx.panel.ruleList.count, 1)
+        compare(ctx.panel.ruleList.currentIndex, -1)
+        verify(ctx.panel.selectedRule === null)
+    }
+
+    function test_switchingAccountClearsPriorRowsWhileLoading() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleRules)
+        compare(ctx.panel.ruleList.count, 2)
+        ctx.panel.selectedAccountIndex = 1
+        verify(ctx.mock.recurringRulesLoading)
+        compare(ctx.panel.ruleList.count, 0)
+    }
+
+    // Rapid account switch: selecting B while A's fetch is in flight must end showing B's rules.
+    function test_midFetchSwitchReconcilesToRequestedAccount() {
+        var ctx = build()
+        ctx.panel.selectedAccountIndex = 0
+        verify(ctx.mock.recurringRulesLoading)
+        ctx.panel.selectedAccountIndex = 1
+        compare(ctx.mock.lastRulesAccountId, "a2")
+        ctx.mock.succeedRecurringRules(sampleRules)     // A completes; must be discarded
+        verify(ctx.mock.recurringRulesLoading)          // B re-fetch in flight
+        compare(ctx.panel.ruleList.count, 0)
+        ctx.mock.succeedRecurringRules([sampleRules[1]]) // B completes
+        verify(!ctx.mock.recurringRulesLoading)
+        compare(ctx.panel.ruleList.count, 1)
+    }
+
+    function test_newDataResetsSelection() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleRules)
+        ctx.panel.ruleList.currentIndex = 1
+        ctx.mock.succeedRecurringRules([])
+        compare(ctx.panel.ruleList.currentIndex, -1)
+        verify(ctx.panel.selectedRule === null)
+    }
+
+    function test_createFormDisabledBeforeAccountSelected() {
+        var ctx = build()
+        compare(ctx.panel.createForm.canSubmit, false)
+    }
+
+    function test_createFormEnabledAfterAccountAndFields() {
+        var ctx = build()
+        ctx.panel.selectedAccountIndex = 0
+        ctx.panel.createForm.nameText = "Gym"
+        ctx.panel.createForm.amountText = "40"
+        ctx.panel.createForm.frequencyIndex = 0   // Weekly
+        compare(ctx.panel.createForm.canSubmit, true)
+    }
+
+    // Driving the embedded form's success path re-fetches the selected account's rules.
+    function test_creatingRefetchesSelectedAccount() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleRules)
+        var before = ctx.mock.recurringRulesCallCount
+        ctx.panel.createForm.nameText = "Gym"
+        ctx.panel.createForm.amountText = "40"
+        ctx.panel.createForm.frequencyIndex = 0
+        ctx.panel.createForm.submit()
+        ctx.mock.succeedCreateRecurringRule("rule-99")
+        compare(ctx.mock.recurringRulesCallCount, before + 1)
+        compare(ctx.mock.lastRulesAccountId, "a1")
+    }
+}

--- a/app/tests/tst_recurringruleform.cpp
+++ b/app/tests/tst_recurringruleform.cpp
@@ -1,0 +1,2 @@
+#include <QtQuickTest/quicktest.h>
+QUICK_TEST_MAIN(recurringruleform)

--- a/app/tests/tst_recurringrulespanel.cpp
+++ b/app/tests/tst_recurringrulespanel.cpp
@@ -1,0 +1,2 @@
+#include <QtQuickTest/quicktest.h>
+QUICK_TEST_MAIN(recurringrulespanel)

--- a/daemon/finchd/server.go
+++ b/daemon/finchd/server.go
@@ -114,6 +114,26 @@ func (s *Server) CreateRecurringRule(ctx context.Context, req *finchv1.CreateRec
 		return nil, status.Error(codes.InvalidArgument, "frequency must be specified")
 	}
 
+	// Validate the frequency-conditional day fields at the boundary so a bad request
+	// surfaces as InvalidArgument. Core re-validates these (defense in depth), but core
+	// returns untyped errors, so without this check they would reach the caller as
+	// Internal. The exactly-two check also guards the [2]int mapping below.
+	switch req.Frequency {
+	case finchv1.Frequency_FREQUENCY_MONTHLY:
+		if req.DayOfMonth < 1 || req.DayOfMonth > 31 {
+			return nil, status.Errorf(codes.InvalidArgument, "day_of_month must be 1-31 for monthly frequency, got %d", req.DayOfMonth)
+		}
+	case finchv1.Frequency_FREQUENCY_SEMI_MONTHLY:
+		if len(req.SemiMonthlyDays) != 2 {
+			return nil, status.Errorf(codes.InvalidArgument, "semi_monthly frequency requires exactly two semi_monthly_days, got %d", len(req.SemiMonthlyDays))
+		}
+		for _, d := range req.SemiMonthlyDays {
+			if d < 1 || d > 31 {
+				return nil, status.Errorf(codes.InvalidArgument, "semi_monthly_days must each be 1-31, got %d", d)
+			}
+		}
+	}
+
 	startDate, err := time.Parse(time.DateOnly, req.StartDate)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid start_date: %v", err)
@@ -173,7 +193,7 @@ func (s *Server) UpdateRecurringRuleAmount(ctx context.Context, req *finchv1.Upd
 		return nil, status.Errorf(codes.InvalidArgument, "invalid effective_date: %v", err)
 	}
 	if err := s.db.UpdateRecurringRuleAmount(ctx, req.RuleId, req.NewAmount, effectiveDate, req.Reason); err != nil {
-		return nil, status.Errorf(codes.Internal, "update recurring rule amount: %v", err)
+		return nil, ruleError("update recurring rule amount", err)
 	}
 	return &finchv1.UpdateRecurringRuleAmountResponse{}, nil
 }

--- a/daemon/finchd/server.go
+++ b/daemon/finchd/server.go
@@ -107,11 +107,14 @@ func (s *Server) CreateRecurringRule(ctx context.Context, req *finchv1.CreateRec
 	if strings.TrimSpace(req.Name) == "" {
 		return nil, status.Error(codes.InvalidArgument, "name must not be empty")
 	}
-	if req.AccountId == "" {
+	if strings.TrimSpace(req.AccountId) == "" {
 		return nil, status.Error(codes.InvalidArgument, "account_id must not be empty")
 	}
 	if req.Frequency == finchv1.Frequency_FREQUENCY_UNSPECIFIED {
 		return nil, status.Error(codes.InvalidArgument, "frequency must be specified")
+	}
+	if req.Frequency < finchv1.Frequency_FREQUENCY_WEEKLY || req.Frequency > finchv1.Frequency_FREQUENCY_YEARLY {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid frequency: %d", req.Frequency)
 	}
 
 	// Validate the frequency-conditional day fields at the boundary so a bad request

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -291,6 +291,21 @@ func TestCreateRecurringRuleValidationReturnsInvalidArgument(t *testing.T) {
 				SemiMonthlyDays: []int32{15},
 			},
 		},
+		{
+			name: "whitespace account_id",
+			req: &finchv1.CreateRecurringRuleRequest{
+				AccountId: "   ", Name: "Rent", Amount: -150000,
+				Frequency: finchv1.Frequency_FREQUENCY_MONTHLY, StartDate: "2025-01-01",
+				DayOfMonth: 1,
+			},
+		},
+		{
+			name: "out-of-range frequency value",
+			req: &finchv1.CreateRecurringRuleRequest{
+				AccountId: accountID, Name: "Rent", Amount: -150000,
+				Frequency: finchv1.Frequency(99), StartDate: "2025-01-01",
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/jakewan/finch/daemon/finchd"
 	finchv1 "github.com/jakewan/finch/daemon/gen/finch/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -237,6 +239,102 @@ func TestProjectBalancesViaGRPC(t *testing.T) {
 	}
 	if len(projResp.Balances) == 0 {
 		t.Fatal("expected non-empty balances")
+	}
+}
+
+// createRulesAccount is a small helper for the recurring-rule error tests below.
+func createRulesAccount(t *testing.T, client finchv1.FinchServiceClient, ctx context.Context) string {
+	t.Helper()
+	acct, err := client.CreateAccount(ctx, &finchv1.CreateAccountRequest{
+		Name: "Rules Acct",
+		Type: finchv1.AccountType_ACCOUNT_TYPE_CHECKING,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	return acct.Account.Id
+}
+
+// A malformed recurring-rule create is the caller's fault, so it must surface as
+// InvalidArgument (not Internal) — callers depend on the code to tell a bad request
+// from a daemon failure (see .claude/rules/api-design.md).
+func TestCreateRecurringRuleValidationReturnsInvalidArgument(t *testing.T) {
+	client := startTestServer(t)
+	ctx := context.Background()
+	accountID := createRulesAccount(t, client, ctx)
+
+	cases := []struct {
+		name string
+		req  *finchv1.CreateRecurringRuleRequest
+	}{
+		{
+			name: "monthly day_of_month out of range",
+			req: &finchv1.CreateRecurringRuleRequest{
+				AccountId: accountID, Name: "Rent", Amount: -150000,
+				Frequency: finchv1.Frequency_FREQUENCY_MONTHLY, StartDate: "2025-01-01",
+				DayOfMonth: 40,
+			},
+		},
+		{
+			name: "semi-monthly day out of range",
+			req: &finchv1.CreateRecurringRuleRequest{
+				AccountId: accountID, Name: "Paycheck", Amount: 200000,
+				Frequency: finchv1.Frequency_FREQUENCY_SEMI_MONTHLY, StartDate: "2025-01-01",
+				SemiMonthlyDays: []int32{15, 40},
+			},
+		},
+		{
+			name: "semi-monthly wrong day count",
+			req: &finchv1.CreateRecurringRuleRequest{
+				AccountId: accountID, Name: "Paycheck", Amount: 200000,
+				Frequency: finchv1.Frequency_FREQUENCY_SEMI_MONTHLY, StartDate: "2025-01-01",
+				SemiMonthlyDays: []int32{15},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := client.CreateRecurringRule(ctx, tc.req)
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("expected InvalidArgument, got %v (err: %v)", status.Code(err), err)
+			}
+		})
+	}
+}
+
+// A valid semi-monthly rule must still be accepted — guards against over-gating
+// the count/range validation added above.
+func TestCreateRecurringRuleSemiMonthlyValid(t *testing.T) {
+	client := startTestServer(t)
+	ctx := context.Background()
+	accountID := createRulesAccount(t, client, ctx)
+
+	resp, err := client.CreateRecurringRule(ctx, &finchv1.CreateRecurringRuleRequest{
+		AccountId: accountID, Name: "Paycheck", Amount: 200000,
+		Frequency: finchv1.Frequency_FREQUENCY_SEMI_MONTHLY, StartDate: "2025-01-01",
+		SemiMonthlyDays: []int32{1, 15},
+	})
+	if err != nil {
+		t.Fatalf("CreateRecurringRule: %v", err)
+	}
+	if resp.Rule.Id == "" {
+		t.Fatal("expected non-empty rule ID")
+	}
+}
+
+// Updating a rule that does not exist is a NotFound, not an Internal error — the
+// other rule mutations (pause/resume/end) already map this correctly.
+func TestUpdateRecurringRuleAmountNotFound(t *testing.T) {
+	client := startTestServer(t)
+	ctx := context.Background()
+
+	_, err := client.UpdateRecurringRuleAmount(ctx, &finchv1.UpdateRecurringRuleAmountRequest{
+		RuleId:        "does-not-exist",
+		NewAmount:     -1000,
+		EffectiveDate: "2025-02-01",
+	})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("expected NotFound for missing rule, got %v (err: %v)", status.Code(err), err)
 	}
 }
 


### PR DESCRIPTION
## Overview

The Qt app now has a Recurring Rules screen, so you can see an account's recurring rules and create new ones directly in the app instead of only through the MCP tools. Pick an account, browse its rules in a master-detail list, and add a rule at any frequency (weekly, biweekly, semi-monthly, monthly, or yearly) with an Expense/Income amount and an optional end date. This is the view-and-create slice of the app's recurring-rule support; managing existing rules (pause/resume, end, change amount), transfer rules, and editing a rule's other fields are deferred and tracked under #37 as sub-issues #89–#93.

## How it works

The screen mirrors the existing Transactions screen: a per-account master-detail view with the same account-id-keyed fetch reconciliation, so a rapid account switch always ends showing the selected account's rules. The create form's frequency selector uses a placeholder with no sentinel row, so a row's index differs from its enum value and the submitted value can't be confused with the index; the form validates the frequency-conditional day fields (day-of-month for monthly, two days for semi-monthly) and blocks an end-date-before-start-date rule, which would otherwise project no occurrences.

The change also corrects the daemon's error categorization for recurring rules, which the app relies on to surface specific messages: `CreateRecurringRule` now returns `InvalidArgument` (not `Internal`) for invalid create input — an out-of-range day-of-month or semi-monthly day, a whitespace-only account_id, or an out-of-range frequency — via boundary validation, and `UpdateRecurringRuleAmount` returns `NotFound` for a missing rule. The amount-update path reuses the existing `ruleError` helper, which matches on the "not found" substring — the same approach pause/resume/end already use — pending typed core errors that would let the daemon distinguish error kinds without string matching.

Finally, the shared signed-amount input (magnitude field, Expense/Income toggle, overflow-safe cents) is extracted from the transaction and recurring-rule forms into one `SignedAmountField` component.

## Issue references

Related to #37 — delivers its view-and-create slice; the remaining management, transfer, and field-edit gaps are tracked as sub-issues #89–#93 under it. Related to #47 (the typed-core-errors work that would replace the string match in the amount-update path).
