### PR TITLE
docs(mcp): document how to connect the MCP server to an assistant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Four components communicating via gRPC over Unix socket:
 - **Separate Go modules:** `core/`, `daemon/`, and `mcp/` each have their own `go.mod`.
 - **Pure Go SQLite:** Uses `modernc.org/sqlite` (no cgo required for Go builds).
 - **Buf for protobuf:** `buf.yaml` + `buf.gen.yaml` at repo root. Never use raw `protoc`.
-- **Socket path:** `$XDG_RUNTIME_DIR/finch/finch.sock` (Linux), `/tmp/finch-$UID/finch.sock` (fallback).
+- **Socket path:** `$XDG_RUNTIME_DIR/finch/finch.sock` (Linux), `/tmp/finch-$UID/finch.sock` (macOS). Any other platform is a hard error — there is no fallback.
 - **DB path:** `~/.local/share/finch/finch.db` (Linux), `~/Library/Application Support/finch/finch.db` (macOS). Override with `FINCH_DB_PATH`.
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Finch projects your personal finances forward — model accounts, recurring rule
 You interact with it two ways, both backed by a single daemon that owns your data:
 
 - a **desktop GUI** (the Qt app), and
-- **any AI assistant** that speaks the [Model Context Protocol](https://modelcontextprotocol.io) (Claude Desktop and others) — the MCP server is what makes your finances reachable from an assistant, not just a terminal.
+- **any AI assistant** that speaks the [Model Context Protocol](https://modelcontextprotocol.io) (Claude Code and others) — the MCP server is what makes your finances reachable from an assistant, not just a terminal.
 
 ## Architecture
 
@@ -20,11 +20,13 @@ Four components communicating via gRPC over a Unix socket:
 
 ### Go toolchain and dev tools
 
-Finch uses [mise](https://mise.jdx.dev/) to manage tool versions. See `mise.toml` for pinned versions of Go, buf, protoc plugins, and golangci-lint.
+Finch uses [mise](https://mise.jdx.dev/) to manage tool versions. See `mise.toml` for pinned versions of Go, just, buf, protoc plugins, and golangci-lint.
 
 ```bash
 mise install
 ```
+
+This installs every tool the build needs, including the `just` command runner the targets below are written for. mise has to be [activated in your shell](https://mise.jdx.dev/getting-started.html) for those tools to land on your `PATH` — without it, prefix commands with `mise exec --`.
 
 ### System packages (Qt app only)
 
@@ -87,12 +89,11 @@ This builds the MCP binary and copies it to `~/.local/bin/`. That installs the b
 
 Finch's MCP server is a stdio server: your assistant spawns it as a child process and talks to it over stdin and stdout. You never launch it yourself.
 
-Finch is build-from-source today — there are no prebuilt binaries — so start by completing [Getting Started](#getting-started), then install the daemon and the MCP server:
+Finch is build-from-source today — there are no prebuilt binaries — so start from [Prerequisites](#prerequisites), then install the daemon and the MCP server. You don't need the Qt system packages for this; the MCP server and daemon are Go-only.
 
 ```bash
 mise install
 just proto            # daemon/gen/ is generated and not committed; the MCP build needs it
-just all
 just install-service  # the MCP server exits at startup if it can't reach the daemon
 just install-mcp
 ```
@@ -105,7 +106,7 @@ Running the daemon means Linux with systemd user services. The daemon and MCP se
 claude mcp add --scope user finch ~/.local/bin/finch-mcp
 ```
 
-`--scope user` makes Finch available in every project. Without it you get `local` scope — private to you, and only in the directory you ran the command from.
+`--scope user` makes Finch available in every project. Without it you get `local` scope — private to you, and only in the directory you ran the command from — which is what you want if Finch should appear only while you're working in one checkout. Your shell expands the `~` before `claude` records it, so the stored command is an absolute path.
 
 **Any other MCP client:** add an entry to the client's MCP configuration file, consulting its documentation for where that file lives:
 
@@ -125,30 +126,36 @@ Verify by asking your assistant to run Finch's `ping` tool. It reports the daemo
 
 #### When the server doesn't start
 
-The MCP server writes errors to stderr, which your client captures in its MCP server log rather than showing you. Read that log first and match the message:
+The MCP server writes errors to stderr, which most clients capture in an MCP server log rather than showing you. Read that log first and match the message:
 
 | Message | Cause | Fix |
 |---|---|---|
-| `daemon socket not found at ...` | The daemon isn't running. | `systemctl --user status finch.service` |
-| `XDG_RUNTIME_DIR not set` | The client spawned the server without that variable, which is how the server locates the daemon's socket. A GUI-launched or sandboxed client may not pass it through. | Set it explicitly on the server entry, below. |
+| `daemon socket not found at ...` | The daemon isn't running — or it is, and the server is looking in the wrong runtime directory. Compare the path in the message against `echo "$XDG_RUNTIME_DIR"/finch/finch.sock`. | `systemctl --user status finch.service`, and `just install-service` if the unit isn't installed. |
+| `XDG_RUNTIME_DIR not set` | The client spawned the server without that variable, which is how the server locates the daemon's socket. A desktop-launched client may not pass it through. | Set it explicitly on the server entry, below. |
 | `ping daemon: ...` | A socket file exists but nothing answers — a crashed daemon that left the socket behind (refused immediately), or a hung one (after a five-second timeout). | `systemctl --user restart finch.service` |
 
-Don't diagnose the second case by checking `$XDG_RUNTIME_DIR/finch/finch.sock` from your shell: your shell has the variable set, so the check passes while the server keeps failing. Pass it through explicitly instead:
+Don't diagnose the second case by checking whether `$XDG_RUNTIME_DIR/finch/finch.sock` exists from your shell: your shell has the variable set, so the check passes while the server keeps failing. Reading the variable is fine — it's how you get the value for the fix. Run `echo "$XDG_RUNTIME_DIR"` in a normal terminal and paste the result:
 
 ```json
 {
   "mcpServers": {
     "finch": {
       "command": "/absolute/path/to/finch-mcp",
-      "env": { "XDG_RUNTIME_DIR": "/run/user/YOUR_UID" }
+      "env": { "XDG_RUNTIME_DIR": "/run/user/1234" }
     }
   }
 }
 ```
 
+A wrong value here doesn't produce the same message twice — the server finds the variable set, builds a socket path under it, and reports `daemon socket not found` instead. If that message names a directory you don't recognize, this is why. With Claude Code the equivalent is `claude mcp add -e XDG_RUNTIME_DIR=/run/user/1234 ...`, though a terminal-launched client inherits the variable already and won't hit this.
+
+Finch can't be reached from a sandboxed client (Flatpak, Snap) today. The sandbox gives the spawned server its own filesystem namespace, so neither the installed binary nor the daemon's socket is visible inside it, and pinning `XDG_RUNTIME_DIR` doesn't help — the sandbox rewrites it by design. Use a client running unsandboxed on the same machine as the daemon.
+
 #### Working on Finch itself
 
-Your client spawns the MCP server once, at client startup — there is no live reload. After changing anything under `mcp/`, `proto/`, `core/`, or `daemon/`, reinstall and restart your assistant session. The repo's `mcp-reload` skill (`.claude/skills/mcp-reload/`) walks that loop.
+Most clients spawn the MCP server once, at client startup, with no live reload. After changing anything under `mcp/`, `proto/`, `core/`, or `daemon/`, reinstall and restart your assistant session. The repo's `mcp-reload` skill (`.claude/skills/mcp-reload/`) walks that loop.
+
+You register the same installed binary a user does — the path doesn't change while you work on Finch, only the scope you registered it at.
 
 ### Install the desktop app
 
@@ -163,10 +170,11 @@ This builds the Qt app, copies the `finch-app` binary to `~/.local/bin/`, instal
 Run the daemon without systemd — an alternative to the service, not a supplement:
 
 ```bash
+systemctl --user stop finch.service   # if the service is installed and running
 daemon/finch-daemon
 ```
 
-Don't run both. The daemon removes and recreates the socket at startup, so a hand-started daemon silently takes it over from the service and you end up with two processes on the same database.
+Stop the service first. The daemon removes and recreates the socket at startup, so a hand-started daemon silently takes it over from a running service and you end up with two processes on the same database. `systemctl --user start finch.service` puts things back.
 
 There is no manual step for the MCP server: your assistant spawns `finch-mcp` itself (see [Connect it to an assistant](#connect-it-to-an-assistant)). Running the binary from a shell only checks that it can reach the daemon — with no client on the other end it just blocks.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ just install-service  # the MCP server exits at startup if it can't reach the da
 just install-mcp
 ```
 
-Running the daemon means Linux with systemd user services. The daemon and MCP server both carry macOS socket paths, but there is no supported way to start the daemon there yet.
+Running the daemon *as a service* means Linux with systemd. The daemon and MCP server also carry macOS paths — the socket lives at `/tmp/finch-$UID/finch.sock` there — so the [manual path](#manual) can start the daemon on macOS, though it isn't tested and the troubleshooting below assumes systemd.
 
 **Claude Code:**
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,74 @@ This builds the daemon, copies it to `~/.local/bin/`, installs the systemd unit,
 just install-mcp
 ```
 
-This builds the MCP binary and copies it to `~/.local/bin/`.
+This builds the MCP binary and copies it to `~/.local/bin/`. That installs the binary and nothing more — an MCP client still has to be told to spawn it, which is the next section. (`just install` does this and the daemon service together.)
+
+### Connect it to an assistant
+
+Finch's MCP server is a stdio server: your assistant spawns it as a child process and talks to it over stdin and stdout. You never launch it yourself.
+
+Finch is build-from-source today — there are no prebuilt binaries — so start by completing [Getting Started](#getting-started), then install the daemon and the MCP server:
+
+```bash
+mise install
+just proto            # daemon/gen/ is generated and not committed; the MCP build needs it
+just all
+just install-service  # the MCP server exits at startup if it can't reach the daemon
+just install-mcp
+```
+
+Running the daemon means Linux with systemd user services. The daemon and MCP server both carry macOS socket paths, but there is no supported way to start the daemon there yet.
+
+**Claude Code:**
+
+```bash
+claude mcp add --scope user finch ~/.local/bin/finch-mcp
+```
+
+`--scope user` makes Finch available in every project. Without it you get `local` scope — private to you, and only in the directory you ran the command from.
+
+**Any other MCP client:** add an entry to the client's MCP configuration file, consulting its documentation for where that file lives:
+
+```json
+{
+  "mcpServers": {
+    "finch": {
+      "command": "/absolute/path/to/finch-mcp"
+    }
+  }
+}
+```
+
+Use an absolute path — many clients don't expand `~`.
+
+Verify by asking your assistant to run Finch's `ping` tool. It reports the daemon version.
+
+#### When the server doesn't start
+
+The MCP server writes errors to stderr, which your client captures in its MCP server log rather than showing you. Read that log first and match the message:
+
+| Message | Cause | Fix |
+|---|---|---|
+| `daemon socket not found at ...` | The daemon isn't running. | `systemctl --user status finch.service` |
+| `XDG_RUNTIME_DIR not set` | The client spawned the server without that variable, which is how the server locates the daemon's socket. A GUI-launched or sandboxed client may not pass it through. | Set it explicitly on the server entry, below. |
+| `ping daemon: ...` | A socket file exists but nothing answers — a crashed daemon that left the socket behind (refused immediately), or a hung one (after a five-second timeout). | `systemctl --user restart finch.service` |
+
+Don't diagnose the second case by checking `$XDG_RUNTIME_DIR/finch/finch.sock` from your shell: your shell has the variable set, so the check passes while the server keeps failing. Pass it through explicitly instead:
+
+```json
+{
+  "mcpServers": {
+    "finch": {
+      "command": "/absolute/path/to/finch-mcp",
+      "env": { "XDG_RUNTIME_DIR": "/run/user/YOUR_UID" }
+    }
+  }
+}
+```
+
+#### Working on Finch itself
+
+Your client spawns the MCP server once, at client startup — there is no live reload. After changing anything under `mcp/`, `proto/`, `core/`, or `daemon/`, reinstall and restart your assistant session. The repo's `mcp-reload` skill (`.claude/skills/mcp-reload/`) walks that loop.
 
 ### Install the desktop app
 
@@ -93,10 +160,15 @@ This builds the Qt app, copies the `finch-app` binary to `~/.local/bin/`, instal
 
 ### Manual
 
+Run the daemon without systemd — an alternative to the service, not a supplement:
+
 ```bash
-daemon/finch-daemon &   # Start the gRPC server
-mcp/finch-mcp           # Start the MCP server (connects to daemon)
+daemon/finch-daemon
 ```
+
+Don't run both. The daemon removes and recreates the socket at startup, so a hand-started daemon silently takes it over from the service and you end up with two processes on the same database.
+
+There is no manual step for the MCP server: your assistant spawns `finch-mcp` itself (see [Connect it to an assistant](#connect-it-to-an-assistant)). Running the binary from a shell only checks that it can reach the daemon — with no client on the other end it just blocks.
 
 ## Project Layout
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 go = "1.25"
+just = "1.57.0"
 buf = "1.66.1"
 "go:google.golang.org/protobuf/cmd/protoc-gen-go" = "1.36.11"
 "go:google.golang.org/grpc/cmd/protoc-gen-go-grpc" = "1.6.1"


### PR DESCRIPTION
## Overview

Finch's README opens by saying your finances are reachable from any assistant that speaks MCP, then stops at `just install-mcp` — a target that copies a binary onto your PATH and nothing more. Nothing said how to tell a client to spawn it, so the promise had no path behind it. Installing the binary and registering it with a client are two separate acts, and the docs treated them as one.

This adds the missing half and settles the stance behind it: whether you use Finch or work on it, you register the same installed binary, differing only in the scope you register it at. It also states what the project is today rather than implying an on-ramp that doesn't exist — build-from-source with no prebuilt binaries, and a service install bound to Linux and systemd even though the manual daemon path runs elsewhere.

## How it works

The startup failures are documented by the message text a reader will actually see in their client's log, since that string is all they have to match against. Two of the three are easy to misread: a wrong `XDG_RUNTIME_DIR` produces the same `socket not found` message as a stopped daemon, so a healthy `systemctl status` looks like it contradicts the diagnosis. A sandboxed client is a separate case that no configuration fixes — the spawned server gets its own filesystem namespace, so neither the binary nor the socket is visible to it, and pinning the runtime directory can't reach across that boundary.

`just` is pinned in `mise.toml` because it wasn't. The README presents `mise install` as the step that gets you the toolchain, but `just` resolved from whatever the developer had globally, leaving a new reader with no way to run a single build target.

The two constraints this documents rather than removes are tracked separately — related to #98, related to #99.
