### PR TITLE
feat(app): create recurring transfer rules in the Qt app

### DIFF
--- a/.claude/rules/qt-app.md
+++ b/.claude/rules/qt-app.md
@@ -75,3 +75,18 @@ Automated tests: `just test-app` configures, builds, and runs the Qt Quick Test 
 - **Offscreen assertions.** A control's `visible`/`enabled` getter returns *effective* state — false when an ancestor is hidden/disabled or the item is not on a shown window — so under `offscreen` it reads false even when the local binding is true. NEVER assert on a component's `visible`/`enabled` (directly or via a property alias to one); the assertion is unreliable in the harness. Instead expose the underlying condition as a logical `readonly property bool` and assert that, binding the visual `visible`/`enabled` to the same property (e.g. `TransactionsPanel`'s `stateMessageVisible`).
 
 Manual testing requires a running daemon with seed data. The daemon must be built and started separately (`just build-daemon && daemon/finch-daemon`).
+
+**Check which daemon build you are actually talking to before trusting a manual result.** The app and the daemon are separate binaries with separate release paths, so a freshly built app routinely talks to a much older daemon — most easily when the daemon runs as the installed systemd user service rather than from the build directory. Any app behavior that depends on a daemon-side or core-side change then fails for a reason that has nothing to do with the app change under test, and it fails looking exactly like an app bug.
+
+Two things make this quieter than it sounds:
+
+- `just install-service` ends in `systemctl --user enable --now`, which starts an inactive service but does **not** restart an active one. Combined with the recipe's deliberate cp+mv (which lets the install succeed while the old binary runs, since the running process keeps its file descriptor to the replaced inode), a service that was already up keeps serving the **previous** build after a successful-looking install. Restart it explicitly:
+
+    ```bash
+    just install-service
+    systemctl --user restart finch.service
+    ```
+
+- The unit is named `finch.service`, not `finch-daemon` — so a status check on the latter reports "inactive" for a daemon that is running fine.
+
+Compare the installed binary's timestamp against the commits the behavior under test depends on (`stat -c %y ~/.local/bin/finch-daemon`), and reinstall before concluding anything about the app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Qt app: create accounts through a UI form (previously only via MCP tools).
 - Qt app: view an account's individual transactions on the Transactions screen — pick an account, browse its transactions in a list, and select one to see its full details (previously only the aggregated balance chart was visible).
 - Qt app: record a manual transaction against an account from the Transactions screen — enter a name, amount, and Expense/Income, with a live signed-amount preview and the date defaulting to today (previously only via MCP tools).
-- Qt app: view and create an account's recurring rules on the Recurring Rules screen — pick an account, browse its rules, and add a new rule at any frequency (weekly, biweekly, semi-monthly, monthly, or yearly) with an Expense/Income amount and an optional end date (previously only via MCP tools).
+- Qt app: view and create an account's recurring rules on the Recurring Rules screen — pick an account, browse its rules, and add a new rule at any frequency (weekly, biweekly, semi-monthly, monthly, or yearly) with an optional end date (previously only via MCP tools). A rule is either an Expense/Income amount on the selected account, or a recurring transfer to another account chosen from a "Transfer to" list. A transfer has no Expense/Income choice, because its direction is set by the pair of accounts it moves money between. Transfer rules show as a debit on the account they leave, naming the destination.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Monthly cash flow no longer counts a transfer as both income and an expense. Moving money between your own accounts is neither, so transfers are reported in a new `transfers` total instead of inflating income and expenses. Income plus expenses plus transfers equals the period's balance change, so a cash-flow report can still be reconciled against the balance chart — for a single-account view this means a transfer no longer changes that account's net cash flow, but the movement is still visible.
 - Projected transactions and recorded transactions now carry an `is_transfer` flag over gRPC and MCP, so a client can tell why a transfer appears in projected balances but not in cash-flow income.
 - Recurring transfer rules are validated on create and on amount changes: the destination must be an existing account other than the source, and the amount must be positive (direction comes from the source and destination pair). Invalid input returns `InvalidArgument` rather than `Internal`.
+- The Qt app now shows a recurring transfer rule as a debit on the account it leaves, naming the destination. Previously it displayed the rule's stored magnitude as a credit on the account being debited, with no indication of where the money went — affecting any transfer rule created through the MCP tools.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Qt app: create accounts through a UI form (previously only via MCP tools).
 - Qt app: view an account's individual transactions on the Transactions screen — pick an account, browse its transactions in a list, and select one to see its full details (previously only the aggregated balance chart was visible).
 - Qt app: record a manual transaction against an account from the Transactions screen — enter a name, amount, and Expense/Income, with a live signed-amount preview and the date defaulting to today (previously only via MCP tools).
-- Qt app: view and create an account's recurring rules on the Recurring Rules screen — pick an account, browse its rules, and add a new rule at any frequency (weekly, biweekly, semi-monthly, monthly, or yearly) with an optional end date (previously only via MCP tools). A rule is either an Expense/Income amount on the selected account, or a recurring transfer to another account chosen from a "Transfer to" list. A transfer has no Expense/Income choice, because its direction is set by the pair of accounts it moves money between. Transfer rules show as a debit on the account they leave, naming the destination.
+- Qt app: view and create an account's recurring rules on the Recurring Rules screen — pick an account, browse its rules, and add a new rule at any frequency (weekly, biweekly, semi-monthly, monthly, or yearly) with an optional end date (previously only via MCP tools). A rule is either an Expense/Income amount on the selected account or a recurring transfer to another account, picked from a "Transfer to" list. Transfer rules show as a debit on the account they leave, naming the destination.
 
 ### Changed
 

--- a/app/qml/CreateRecurringRuleForm.qml
+++ b/app/qml/CreateRecurringRuleForm.qml
@@ -31,7 +31,13 @@ Item {
     property alias previewText: amountInput.previewText
     readonly property var signedCents: amountInput.signedCents
     readonly property var unsignedCents: amountInput.unsignedCents
+    // A transfer's direction is implied by its source/target pair, so there is no author-chosen
+    // sign to offer. Single source for both the child control and the specs, which assert this
+    // rather than an effective `visible` read (unreliable offscreen).
     readonly property bool signSelectorVisible: !isTransfer
+    // Whether any other account exists to transfer to. A single-account database has none, and
+    // the control is pointless then.
+    readonly property bool transferAvailable: transferTargets.length > 1
 
     // The destination list: a real "Not a transfer" row at index 0, then every account except
     // the source. The sentinel is a selectable row rather than a placeholder so leaving
@@ -75,7 +81,6 @@ Item {
         } else {
             amountInput.expense = priorExpense
         }
-        errorLabel.text = ""
     }
 
     // A destination held against the previous source's list is meaningless. Index 0 is always
@@ -188,12 +193,12 @@ Item {
         // account list offers no candidate destination (a single-account database).
         Label {
             text: "Transfer to"
-            visible: form.transferTargets.length > 1
+            visible: form.transferAvailable
         }
         ComboBox {
             id: destCombo
             Layout.fillWidth: true
-            visible: form.transferTargets.length > 1
+            visible: form.transferAvailable
             model: form.transferTargets
             textRole: "name"
             // valueRole, so the form submits the row's account id. The model is filtered, so an
@@ -207,9 +212,7 @@ Item {
         SignedAmountField {
             id: amountInput
             Layout.fillWidth: true
-            // A transfer's direction is implied by its source/target pair, so there is no
-            // author-chosen sign to offer.
-            signSelectorVisible: !form.isTransfer
+            signSelectorVisible: form.signSelectorVisible
             onEdited: errorLabel.text = ""
         }
 

--- a/app/qml/CreateRecurringRuleForm.qml
+++ b/app/qml/CreateRecurringRuleForm.qml
@@ -79,9 +79,20 @@ Item {
         // frequency switch is never persisted.
         var dom = isMonthly ? dayOfMonthValue : 0
         var semis = isSemiMonthly ? [semiDay1Value, semiDay2Value] : []
-        client.createRecurringRule(accountId, nameField.text.trim(), signedCents,
-                                   freqCombo.currentValue, startDateField.text,
-                                   endDateField.text, dom, semis)
+        // A params object, not positional args: named fields make a transpose impossible, and
+        // the key names here are the contract the C++ side unpacks.
+        client.createRecurringRule({
+            accountId: accountId,
+            name: nameField.text.trim(),
+            amount: signedCents,
+            frequency: freqCombo.currentValue,
+            startDate: startDateField.text,
+            endDate: endDateField.text,
+            dayOfMonth: dom,
+            semiMonthlyDays: semis,
+            isTransfer: false,
+            transferTargetAccountId: ""
+        })
     }
 
     Connections {

--- a/app/qml/CreateRecurringRuleForm.qml
+++ b/app/qml/CreateRecurringRuleForm.qml
@@ -28,7 +28,7 @@ Item {
     property alias errorText: errorLabel.text
     // Amount, its sign, and the cents derivations live in the shared SignedAmountField.
     property alias expense: amountInput.expense
-    property alias previewText: amountInput.previewText
+    readonly property string previewText: amountInput.previewText
     readonly property var signedCents: amountInput.signedCents
     readonly property var unsignedCents: amountInput.unsignedCents
     // A transfer's direction is implied by its source/target pair, so there is no author-chosen

--- a/app/qml/CreateRecurringRuleForm.qml
+++ b/app/qml/CreateRecurringRuleForm.qml
@@ -24,10 +24,64 @@ Item {
     property alias semiDay1Text: semiDay1Field.text
     property alias semiDay2Text: semiDay2Field.text
     property alias frequencyIndex: freqCombo.currentIndex
+    property alias transferTargetIndex: destCombo.currentIndex
     property alias errorText: errorLabel.text
-    // Amount, its sign, and the signed-cents derivation live in the shared SignedAmountField.
+    // Amount, its sign, and the cents derivations live in the shared SignedAmountField.
     property alias expense: amountInput.expense
+    property alias previewText: amountInput.previewText
     readonly property var signedCents: amountInput.signedCents
+    readonly property var unsignedCents: amountInput.unsignedCents
+    readonly property bool signSelectorVisible: !isTransfer
+
+    // The destination list: a real "Not a transfer" row at index 0, then every account except
+    // the source. The sentinel is a selectable row rather than a placeholder so leaving
+    // transfer mode is possible — this form persists across navigation, so a placeholder-only
+    // control would make a mis-click unescapable without submitting or restarting the app.
+    //
+    // The source is absent from the list rather than validated against, so choosing an account
+    // as its own transfer target is unrepresentable. Empty while no source is chosen: the form
+    // is disabled then anyway, and offering a destination before a source has no meaning.
+    readonly property var transferTargets: {
+        var rows = [{ id: "", name: "Not a transfer" }]
+        if (accountId === "" || !client)
+            return rows
+        var all = client.accounts || []
+        for (var i = 0; i < all.length; i++) {
+            if (all[i].id !== accountId)
+                rows.push({ id: all[i].id, name: all[i].name })
+        }
+        return rows
+    }
+
+    // Transfer mode is derived from the selected row's *value*, never its index: the model is
+    // filtered, so an index into it does not index `client.accounts`. Reading currentValue also
+    // means a model swap cannot leave a stale id behind, so correctness here does not depend on
+    // a reset winning a race with the model's own re-evaluation.
+    readonly property string transferTargetId: destCombo.currentValue ? destCombo.currentValue : ""
+    readonly property bool isTransfer: transferTargetId !== ""
+
+    // Holds the author's Expense/Income choice while transfer mode overrides it, so leaving
+    // transfer mode restores it instead of silently discarding it.
+    property bool priorExpense: true
+
+    onIsTransferChanged: {
+        if (isTransfer) {
+            priorExpense = amountInput.expense
+            // A transfer debits its source, so the preview must read as a debit. Leaving
+            // `expense` untouched while hiding its control would show a green credit above a
+            // rule that takes money out — the wrong direction, stated at authoring time, with
+            // the explaining control removed.
+            amountInput.expense = true
+        } else {
+            amountInput.expense = priorExpense
+        }
+        errorLabel.text = ""
+    }
+
+    // A destination held against the previous source's list is meaningless. Index 0 is always
+    // the sentinel, so this lands on "not a transfer" whichever order it and the model
+    // re-evaluation run in.
+    onAccountIdChanged: destCombo.currentIndex = 0
 
     // Frequency enum values (proto Frequency): Weekly=1 … Yearly=5. The ComboBox has no
     // sentinel row (currentIndex starts -1 with a placeholder), so a row's index is one less
@@ -84,14 +138,16 @@ Item {
         client.createRecurringRule({
             accountId: accountId,
             name: nameField.text.trim(),
-            amount: signedCents,
+            // A transfer's amount is a positive magnitude — direction comes from the
+            // source/target pair, and the daemon rejects a non-positive one.
+            amount: isTransfer ? amountInput.unsignedCents : amountInput.signedCents,
             frequency: freqCombo.currentValue,
             startDate: startDateField.text,
             endDate: endDateField.text,
             dayOfMonth: dom,
             semiMonthlyDays: semis,
-            isTransfer: false,
-            transferTargetAccountId: ""
+            isTransfer: isTransfer,
+            transferTargetAccountId: transferTargetId
         })
     }
 
@@ -103,6 +159,8 @@ Item {
             dayOfMonthField.text = ""
             semiDay1Field.text = ""
             semiDay2Field.text = ""
+            // Back to "not a transfer", so a follow-up rule does not inherit transfer mode.
+            destCombo.currentIndex = 0
             errorLabel.text = ""
             form.created(id)
         }
@@ -124,10 +182,34 @@ Item {
             onTextChanged: errorLabel.text = ""
         }
 
+        // Seated above Amount because it decides what kind of rule this is, and that decision
+        // governs whether Amount carries an Expense/Income choice at all. Choosing the kind
+        // first keeps the sign toggle from vanishing under the author's cursor. Hidden when the
+        // account list offers no candidate destination (a single-account database).
+        Label {
+            text: "Transfer to"
+            visible: form.transferTargets.length > 1
+        }
+        ComboBox {
+            id: destCombo
+            Layout.fillWidth: true
+            visible: form.transferTargets.length > 1
+            model: form.transferTargets
+            textRole: "name"
+            // valueRole, so the form submits the row's account id. The model is filtered, so an
+            // index into it is not an index into client.accounts.
+            valueRole: "id"
+            currentIndex: 0
+            onCurrentIndexChanged: errorLabel.text = ""
+        }
+
         Label { text: "Amount" }
         SignedAmountField {
             id: amountInput
             Layout.fillWidth: true
+            // A transfer's direction is implied by its source/target pair, so there is no
+            // author-chosen sign to offer.
+            signSelectorVisible: !form.isTransfer
             onEdited: errorLabel.text = ""
         }
 

--- a/app/qml/RecurringRulesPanel.qml
+++ b/app/qml/RecurringRulesPanel.qml
@@ -57,9 +57,7 @@ Item {
 
     // Whether the selected rule moves money to another account, and so has a direction to
     // explain. A logical property, not an alias to a Label's visible (unreliable offscreen).
-    readonly property bool detailTransferVisible:
-        selectedRule !== null && selectedRule.isTransfer === true
-        && selectedRule.transferTargetAccountId !== ""
+    readonly property bool detailTransferVisible: TxFormat.isDirectedTransfer(selectedRule)
 
     // An account's display name, falling back to its raw id. Never returns undefined: a miss
     // would otherwise be concatenated into a row label sitting beside a money amount.
@@ -77,7 +75,7 @@ Item {
         if (!rule)
             return ""
         var label = rule.name
-        if (rule.isTransfer && rule.transferTargetAccountId)
+        if (TxFormat.isDirectedTransfer(rule))
             label += " → " + accountName(rule.transferTargetAccountId)
         if (rule.paused)
             label += " (paused)"

--- a/app/qml/RecurringRulesPanel.qml
+++ b/app/qml/RecurringRulesPanel.qml
@@ -52,7 +52,46 @@ Item {
     property alias detailEndDateText: detailEndDate.text
     property alias detailScheduleText: detailSchedule.text
     property alias detailStatusText: detailStatus.text
+    property alias detailTransferText: detailTransfer.text
     property alias createForm: createRuleForm
+
+    // Whether the selected rule moves money to another account, and so has a direction to
+    // explain. A logical property, not an alias to a Label's visible (unreliable offscreen).
+    readonly property bool detailTransferVisible:
+        selectedRule !== null && selectedRule.isTransfer === true
+        && selectedRule.transferTargetAccountId !== ""
+
+    // An account's display name, falling back to its raw id. Never returns undefined: a miss
+    // would otherwise be concatenated into a row label sitting beside a money amount.
+    function accountName(id) {
+        for (var i = 0; i < accounts.length; i++) {
+            if (accounts[i].id === id)
+                return accounts[i].name
+        }
+        return id
+    }
+
+    // The master row's name cell, annotated with a transfer's destination and a paused flag.
+    // Called by the delegate, so it is the shipping composition a spec can assert directly.
+    function rowLabel(rule) {
+        if (!rule)
+            return ""
+        var label = rule.name
+        if (rule.isTransfer && rule.transferTargetAccountId)
+            label += " → " + accountName(rule.transferTargetAccountId)
+        if (rule.paused)
+            label += " (paused)"
+        return label
+    }
+
+    // A rule's amount as it applies to the account being viewed — a transfer's stored magnitude
+    // is direction-less, so rendering it raw would show an outbound transfer as a credit on the
+    // account it debits. Shared by the master row and the detail pane.
+    function ruleAmountText(rule) {
+        if (!rule)
+            return ""
+        return TxFormat.formatAmount(TxFormat.ruleAmount(rule, currentAccountId))
+    }
 
     // Human-readable schedule for a rule's frequency-conditional day fields.
     function scheduleText(rule) {
@@ -150,12 +189,10 @@ Item {
                         Label {
                             Layout.fillWidth: true
                             elide: Text.ElideRight
-                            text: row.modelData.paused
-                                  ? row.modelData.name + " (paused)"
-                                  : row.modelData.name
+                            text: panel.rowLabel(row.modelData)
                         }
                         Label { text: TxFormat.frequencyLabel(row.modelData.frequency) }
-                        Label { text: TxFormat.formatAmount(row.modelData.amount) }
+                        Label { text: panel.ruleAmountText(row.modelData) }
                     }
                 }
             }
@@ -185,7 +222,23 @@ Item {
                     Label { text: "Amount"; font.bold: true }
                     Label {
                         id: detailAmount
-                        text: panel.selectedRule ? TxFormat.formatAmount(panel.selectedRule.amount) : ""
+                        text: panel.ruleAmountText(panel.selectedRule)
+                    }
+
+                    // Names the direction in words, not just by the amount's sign. Repricing a
+                    // rule from this pane works on the stored magnitude, so a bare "-$500.00"
+                    // would imply a negative stored value the backend rejects.
+                    Label {
+                        text: "Transfer"
+                        font.bold: true
+                        visible: panel.detailTransferVisible
+                    }
+                    Label {
+                        id: detailTransfer
+                        visible: panel.detailTransferVisible
+                        text: panel.detailTransferVisible
+                              ? "Out to " + panel.accountName(panel.selectedRule.transferTargetAccountId)
+                              : ""
                     }
 
                     Label { text: "Frequency"; font.bold: true }

--- a/app/qml/RecurringRulesPanel.qml
+++ b/app/qml/RecurringRulesPanel.qml
@@ -57,7 +57,10 @@ Item {
 
     // Whether the selected rule moves money to another account, and so has a direction to
     // explain. A logical property, not an alias to a Label's visible (unreliable offscreen).
-    readonly property bool detailTransferVisible: TxFormat.isDirectedTransfer(selectedRule)
+    // Keyed on the side test, not merely on being a transfer: a rule touching neither side would
+    // otherwise show the row with nothing in it.
+    readonly property bool detailTransferVisible:
+        TxFormat.transferDirection(selectedRule, currentAccountId) !== ""
 
     // An account's display name, falling back to its raw id. Never returns undefined: a miss
     // would otherwise be concatenated into a row label sitting beside a money amount.
@@ -75,8 +78,11 @@ Item {
         if (!rule)
             return ""
         var label = rule.name
-        if (TxFormat.isDirectedTransfer(rule))
+        var direction = TxFormat.transferDirection(rule, currentAccountId)
+        if (direction === "out")
             label += " → " + accountName(rule.transferTargetAccountId)
+        else if (direction === "in")
+            label += " ← " + accountName(rule.accountId)
         if (rule.paused)
             label += " (paused)"
         return label
@@ -234,9 +240,15 @@ Item {
                     Label {
                         id: detailTransfer
                         visible: panel.detailTransferVisible
-                        text: panel.detailTransferVisible
-                              ? "Out to " + panel.accountName(panel.selectedRule.transferTargetAccountId)
-                              : ""
+                        text: {
+                            var direction =
+                                TxFormat.transferDirection(panel.selectedRule, panel.currentAccountId)
+                            if (direction === "out")
+                                return "Out to " + panel.accountName(panel.selectedRule.transferTargetAccountId)
+                            if (direction === "in")
+                                return "In from " + panel.accountName(panel.selectedRule.accountId)
+                            return ""
+                        }
                     }
 
                     Label { text: "Frequency"; font.bold: true }

--- a/app/qml/SignedAmountField.qml
+++ b/app/qml/SignedAmountField.qml
@@ -15,16 +15,27 @@ Item {
     // Expense (true, default) vs Income. The magnitude field cannot carry a sign, so this
     // toggle alone decides whether cents are negative or positive.
     property bool expense: true
+    // Hosts whose value has no user-chosen direction hide the toggle — a recurring transfer's
+    // direction comes from its source/target pair, not from the author. Kept as a plain
+    // property (not an alias to the row's `visible`) because an effective-visibility read is
+    // unreliable offscreen, so this is what a spec asserts.
+    property bool signSelectorVisible: true
 
     // parseFloat is NaN when blank or non-numeric; the regex validator already forbids a sign
     // or a comma decimal, so parseFloat reads the magnitude locale-cleanly.
     readonly property real magnitude: parseFloat(amountField.text)
     // Reject 0 and NaN: a $0 entry is meaningless, and the daemon does not validate amount.
     readonly property bool amountValid: !isNaN(magnitude) && magnitude > 0
-    // Math.round avoids float drift (12.34 * 100 -> 1233.9999…); the toggle applies the sign.
+    // Math.round avoids float drift (12.34 * 100 -> 1233.9999…).
     // Typed var, not int: cents cross into a 64-bit qlonglong and a QML int is 32-bit — an int
     // would overflow above ~$21.5M. A JS number marshals to qlonglong exactly (< 2^53).
-    readonly property var signedCents: amountValid ? Math.round(magnitude * 100) * (expense ? -1 : 1) : 0
+    //
+    // The unsigned magnitude is its own property rather than something a host derives by
+    // negating signedCents: a host that needs a positive value (a transfer, whose amount is a
+    // magnitude the daemon rejects unless positive) would otherwise send a negative one
+    // whenever Income was the standing choice. Sign-free by construction.
+    readonly property var unsignedCents: amountValid ? Math.round(magnitude * 100) : 0
+    readonly property var signedCents: amountValid ? unsignedCents * (expense ? -1 : 1) : 0
     readonly property string previewText: amountValid ? TxFormat.formatAmount(signedCents) : ""
 
     // Emitted on any edit (magnitude or sign) so the host can clear a stale error message.
@@ -66,6 +77,7 @@ Item {
         // expresses direction — a control that can't express the wrong value.
         RowLayout {
             spacing: 12
+            visible: control.signSelectorVisible
             ButtonGroup { id: signGroup }
             RadioButton {
                 text: "Expense"

--- a/app/qml/txformat.js
+++ b/app/qml/txformat.js
@@ -42,13 +42,28 @@ function isDirectedTransfer(rule) {
 // Takes the viewing account rather than assuming the source, because rules are currently fetched
 // scoped to their owner and that will stop being true once inbound transfers are listable.
 function ruleAmount(rule, accountId) {
-    if (isDirectedTransfer(rule)) {
-        if (accountId === rule.accountId)
-            return -rule.amount
-        if (accountId === rule.transferTargetAccountId)
-            return rule.amount
-    }
+    var direction = transferDirection(rule, accountId)
+    if (direction === "out")
+        return -rule.amount
+    if (direction === "in")
+        return rule.amount
     return rule.amount
+}
+
+// Which side of a transfer the viewing account sits on: "out" when it is the source being
+// debited, "in" when it is the destination being credited, "" when the rule is not a directed
+// transfer or touches this account on neither side.
+//
+// The single side test, so a rule's amount and the labels beside it cannot disagree about
+// direction — a row reading "out to X" above a credited amount would contradict itself.
+function transferDirection(rule, accountId) {
+    if (!isDirectedTransfer(rule))
+        return ""
+    if (accountId === rule.accountId)
+        return "out"
+    if (accountId === rule.transferTargetAccountId)
+        return "in"
+    return ""
 }
 
 // Frequency enum (proto int 1-5) -> human label. Mirrors the proto values (Weekly=1 …

--- a/app/qml/txformat.js
+++ b/app/qml/txformat.js
@@ -20,6 +20,14 @@ function formatAmount(cents) {
     return (cents < 0 ? "-$" : "$") + Math.abs(cents / 100).toFixed(2)
 }
 
+// Whether a rule actually moves money between two accounts — flagged as a transfer AND carrying
+// a destination. Both halves are required, matching the condition core's effectOn applies before
+// deriving direction. Single definition because every consumer must agree: a renderer that
+// treated a target-less transfer as directed would announce a destination it cannot name.
+function isDirectedTransfer(rule) {
+    return !!(rule && rule.isTransfer && rule.transferTargetAccountId)
+}
+
 // A recurring rule's effect on one account, in signed cents. Mirrors core's effectOn in
 // core/projection.go, branch for branch, so the app and the projection engine cannot disagree
 // about which way a rule moves money.
@@ -34,7 +42,7 @@ function formatAmount(cents) {
 // Takes the viewing account rather than assuming the source, because rules are currently fetched
 // scoped to their owner and that will stop being true once inbound transfers are listable.
 function ruleAmount(rule, accountId) {
-    if (rule.isTransfer && rule.transferTargetAccountId) {
+    if (isDirectedTransfer(rule)) {
         if (accountId === rule.accountId)
             return -rule.amount
         if (accountId === rule.transferTargetAccountId)

--- a/app/qml/txformat.js
+++ b/app/qml/txformat.js
@@ -20,6 +20,29 @@ function formatAmount(cents) {
     return (cents < 0 ? "-$" : "$") + Math.abs(cents / 100).toFixed(2)
 }
 
+// A recurring rule's effect on one account, in signed cents. Mirrors core's effectOn in
+// core/projection.go, branch for branch, so the app and the projection engine cannot disagree
+// about which way a rule moves money.
+//
+// A transfer rule stores a POSITIVE magnitude and belongs to its source account; direction comes
+// from which side of the transfer the viewing account sits on. A non-transfer rule applies its
+// stored signed amount as-is — and so does a rule flagged as a transfer with no target, which is
+// the third branch. That state is not reachable through the API (the daemon and core both reject
+// it), but the branch is reproduced anyway: a partial copy of authority logic is the thing that
+// drifts from its original.
+//
+// Takes the viewing account rather than assuming the source, because rules are currently fetched
+// scoped to their owner and that will stop being true once inbound transfers are listable.
+function ruleAmount(rule, accountId) {
+    if (rule.isTransfer && rule.transferTargetAccountId) {
+        if (accountId === rule.accountId)
+            return -rule.amount
+        if (accountId === rule.transferTargetAccountId)
+            return rule.amount
+    }
+    return rule.amount
+}
+
 // Frequency enum (proto int 1-5) -> human label. Mirrors the proto values (Weekly=1 …
 // Yearly=5); 0 is the unspecified sentinel, which a stored rule never carries.
 function frequencyLabel(frequency) {

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -294,29 +294,58 @@ void FinchClient::recordTransaction(const QString& accountId, const QString& dat
     m_recordTransactionWatcher.setFuture(future);
 }
 
-void FinchClient::createRecurringRule(const QString& accountId, const QString& name,
-                                      qlonglong amount, int frequency,
-                                      const QString& startDate, const QString& endDate,
-                                      int dayOfMonth, const QVariantList& semiMonthlyDays)
+void FinchClient::createRecurringRule(const QVariantMap& params)
 {
     // Authoritative re-entrancy guard, mirroring createAccount/recordTransaction: the QML
     // submit-disable is cosmetic, so without this a rapid double-submit could create two rules.
     if (m_createRecurringRuleInProgress)
         return;
 
+    // A params object cannot transpose its arguments, but it trades that for a quieter hazard:
+    // a mistyped or omitted key is not an error — it reads back as an invalid QVariant and
+    // would reach the daemon as an empty field, surfacing as a confusing InvalidArgument about
+    // input the user did supply. Fail here instead, naming the key, so the defect is local.
+    static const QStringList requiredKeys = {
+        QStringLiteral("accountId"), QStringLiteral("name"),
+        QStringLiteral("amount"), QStringLiteral("frequency"),
+        QStringLiteral("startDate"), QStringLiteral("endDate"),
+        QStringLiteral("dayOfMonth"), QStringLiteral("semiMonthlyDays"),
+        QStringLiteral("isTransfer"), QStringLiteral("transferTargetAccountId")
+    };
+    QStringList missingKeys;
+    for (const QString& key : requiredKeys) {
+        if (!params.contains(key))
+            missingKeys.append(key);
+    }
+    if (!missingKeys.isEmpty()) {
+        emit recurringRuleCreateFailed(
+            QStringLiteral("Internal error: rule request missing %1.")
+                .arg(missingKeys.join(QStringLiteral(", "))));
+        return;
+    }
+
     m_createRecurringRuleInProgress = true;
     emit createRecurringRuleInProgressChanged();
 
     auto stub = m_stub.get();
-    std::string accountIdStr = accountId.toStdString();
-    std::string nameStr = name.toStdString();
-    std::string startDateStr = startDate.toStdString();
-    std::string endDateStr = endDate.toStdString();
+    std::string accountIdStr = params.value(QStringLiteral("accountId")).toString().toStdString();
+    std::string nameStr = params.value(QStringLiteral("name")).toString().toStdString();
+    // toLongLong, not toInt: cents are int64 on the wire and a large amount arrives from QML
+    // as a double, which toInt would truncate.
+    qlonglong amount = params.value(QStringLiteral("amount")).toLongLong();
+    int frequency = params.value(QStringLiteral("frequency")).toInt();
+    std::string startDateStr = params.value(QStringLiteral("startDate")).toString().toStdString();
+    std::string endDateStr = params.value(QStringLiteral("endDate")).toString().toStdString();
+    int dayOfMonth = params.value(QStringLiteral("dayOfMonth")).toInt();
+    bool isTransfer = params.value(QStringLiteral("isTransfer")).toBool();
+    std::string transferTargetStr =
+        params.value(QStringLiteral("transferTargetAccountId")).toString().toStdString();
     QList<int> semiDays;
-    for (const auto& d : semiMonthlyDays)
+    for (const auto& d : params.value(QStringLiteral("semiMonthlyDays")).toList())
         semiDays.append(d.toInt());
     auto future = QtConcurrent::run([stub, accountIdStr, nameStr, amount, frequency,
-                                     startDateStr, endDateStr, dayOfMonth,
+                                     startDateStr, endDateStr, dayOfMonth, isTransfer,
+                                     transferTargetStr,
                                      semiDays]() -> CreateRecurringRuleResult {
         grpc::ClientContext context;
         context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(5));
@@ -331,8 +360,12 @@ void FinchClient::createRecurringRule(const QString& accountId, const QString& n
         request.set_day_of_month(dayOfMonth);
         for (int d : semiDays)
             request.add_semi_monthly_days(d);
-        // Transfers are a distinct create mode not yet exposed in the UI.
-        request.set_is_transfer(false);
+        // A transfer's amount is a positive magnitude and its direction comes from the
+        // source/target pair, so the form sends the unsigned value and the daemon rejects a
+        // non-positive one. Both fields go together: the daemon requires a target whenever
+        // is_transfer is set.
+        request.set_is_transfer(isTransfer);
+        request.set_transfer_target_account_id(transferTargetStr);
 
         finch::v1::CreateRecurringRuleResponse response;
         grpc::Status grpcStatus = stub->CreateRecurringRule(&context, request, &response);

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -301,10 +301,13 @@ void FinchClient::createRecurringRule(const QVariantMap& params)
     if (m_createRecurringRuleInProgress)
         return;
 
-    // A params object cannot transpose its arguments, but it trades that for a quieter hazard:
-    // a mistyped or omitted key is not an error — it reads back as an invalid QVariant and
-    // would reach the daemon as an empty field, surfacing as a confusing InvalidArgument about
-    // input the user did supply. Fail here instead, naming the key, so the defect is local.
+    // A params object cannot transpose its arguments, but it trades that for a quieter hazard.
+    // Two distinct defects live here and only one is a missing key: a misspelled *key* is
+    // absent, while a typo in a key's *value* expression yields a present key holding an
+    // invalid QVariant. The second is the dangerous one, because the conversions below turn it
+    // into a plausible value rather than an error — an unusable amount becomes 0, and a bad
+    // isTransfer becomes false, which would persist an outbound transfer as ordinary income on
+    // its source account. So require each key to be present AND valid.
     static const QStringList requiredKeys = {
         QStringLiteral("accountId"), QStringLiteral("name"),
         QStringLiteral("amount"), QStringLiteral("frequency"),
@@ -312,15 +315,27 @@ void FinchClient::createRecurringRule(const QVariantMap& params)
         QStringLiteral("dayOfMonth"), QStringLiteral("semiMonthlyDays"),
         QStringLiteral("isTransfer"), QStringLiteral("transferTargetAccountId")
     };
-    QStringList missingKeys;
+    QStringList badKeys;
     for (const QString& key : requiredKeys) {
-        if (!params.contains(key))
-            missingKeys.append(key);
+        if (!params.contains(key) || !params.value(key).isValid())
+            badKeys.append(key);
     }
-    if (!missingKeys.isEmpty()) {
+    if (!badKeys.isEmpty()) {
         emit recurringRuleCreateFailed(
-            QStringLiteral("Internal error: rule request missing %1.")
-                .arg(missingKeys.join(QStringLiteral(", "))));
+            QStringLiteral("Internal error: rule request missing or unreadable: %1.")
+                .arg(badKeys.join(QStringLiteral(", "))));
+        return;
+    }
+
+    // The amount is the one field whose conversion can fail on an in-range-looking input: a
+    // magnitude past a double's exact-integer ceiling does not fit an int64 and converts to 0.
+    // Neither the daemon nor core validates a non-transfer amount, so a 0 would persist as a
+    // rule that silently projects nothing.
+    bool amountOk = false;
+    const qlonglong amount = params.value(QStringLiteral("amount")).toLongLong(&amountOk);
+    if (!amountOk || amount == 0) {
+        emit recurringRuleCreateFailed(
+            QStringLiteral("That amount is out of range. Please enter a smaller amount."));
         return;
     }
 
@@ -330,9 +345,6 @@ void FinchClient::createRecurringRule(const QVariantMap& params)
     auto stub = m_stub.get();
     std::string accountIdStr = params.value(QStringLiteral("accountId")).toString().toStdString();
     std::string nameStr = params.value(QStringLiteral("name")).toString().toStdString();
-    // toLongLong, not toInt: cents are int64 on the wire and a large amount arrives from QML
-    // as a double, which toInt would truncate.
-    qlonglong amount = params.value(QStringLiteral("amount")).toLongLong();
     int frequency = params.value(QStringLiteral("frequency")).toInt();
     std::string startDateStr = params.value(QStringLiteral("startDate")).toString().toStdString();
     std::string endDateStr = params.value(QStringLiteral("endDate")).toString().toStdString();
@@ -443,7 +455,9 @@ void FinchClient::startRecurringRulesFetch()
             entry["id"] = QString::fromStdString(rule.id());
             entry["accountId"] = QString::fromStdString(rule.account_id());
             entry["name"] = QString::fromStdString(rule.name());
-            // Signed cents; the panel formats and applies the sign.
+            // Signed cents for an ordinary rule, but a POSITIVE magnitude for a transfer, whose
+            // direction comes from the source/target pair rather than the stored sign — see
+            // ruleAmount in txformat.js, which mirrors core's effectOn.
             entry["amount"] = static_cast<qlonglong>(rule.amount());
             // Raw Frequency int; the panel maps it to a human label.
             entry["frequency"] = static_cast<int>(rule.frequency());

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -333,9 +333,17 @@ void FinchClient::createRecurringRule(const QVariantMap& params)
     // rule that silently projects nothing.
     bool amountOk = false;
     const qlonglong amount = params.value(QStringLiteral("amount")).toLongLong(&amountOk);
-    if (!amountOk || amount == 0) {
+    if (!amountOk) {
+        // Reachable from the UI: the magnitude field caps neither digits nor scale.
         emit recurringRuleCreateFailed(
-            QStringLiteral("That amount is out of range. Please enter a smaller amount."));
+            QStringLiteral("That amount is too large. Please enter a smaller amount."));
+        return;
+    }
+    if (amount == 0) {
+        // Not reachable from the UI — the form requires a magnitude above zero — so a zero here
+        // means the caller built the request wrong rather than the user mistyping.
+        emit recurringRuleCreateFailed(
+            QStringLiteral("Internal error: rule request carried a zero amount."));
         return;
     }
 

--- a/app/src/finchclient.cpp
+++ b/app/src/finchclient.cpp
@@ -305,9 +305,14 @@ void FinchClient::createRecurringRule(const QVariantMap& params)
     // Two distinct defects live here and only one is a missing key: a misspelled *key* is
     // absent, while a typo in a key's *value* expression yields a present key holding an
     // invalid QVariant. The second is the dangerous one, because the conversions below turn it
-    // into a plausible value rather than an error — an unusable amount becomes 0, and a bad
-    // isTransfer becomes false, which would persist an outbound transfer as ordinary income on
-    // its source account. So require each key to be present AND valid.
+    // into a plausible value rather than an error. So require each key to be present AND valid.
+    //
+    // Presence and validity are not the whole story, though: a *valid* variant of the wrong type
+    // still converts with a silent fallback. Where that fallback is harmless the daemon rejects
+    // it loudly (an empty account id, name, or start date; an unspecified frequency), and the
+    // checks below cover the two cases it would not catch. Note what is deliberately not checked:
+    // emptiness. An empty end date means open-ended and an empty destination means not-a-transfer,
+    // so rejecting empty or null values here would break the ordinary rule it is meant to protect.
     static const QStringList requiredKeys = {
         QStringLiteral("accountId"), QStringLiteral("name"),
         QStringLiteral("amount"), QStringLiteral("frequency"),
@@ -347,19 +352,47 @@ void FinchClient::createRecurringRule(const QVariantMap& params)
         return;
     }
 
+    // The other two numeric fields get the same conversion-integrity check the amount does.
+    // Their *range* is deliberately left to the daemon, which already rejects an unspecified or
+    // out-of-range frequency and an out-of-range day-of-month with a specific message — this
+    // guard is about a value that could not be read at all, not about domain validity.
+    bool frequencyOk = false;
+    const int frequency = params.value(QStringLiteral("frequency")).toInt(&frequencyOk);
+    bool dayOfMonthOk = false;
+    const int dayOfMonth = params.value(QStringLiteral("dayOfMonth")).toInt(&dayOfMonthOk);
+    if (!frequencyOk || !dayOfMonthOk) {
+        emit recurringRuleCreateFailed(
+            QStringLiteral("Internal error: rule request carried an unreadable "
+                           "frequency or day-of-month."));
+        return;
+    }
+
+    // The transfer flag and the destination are one fact expressed twice, and the caller derives
+    // the flag *from* the destination — so they must agree. Checking the invariant rather than
+    // the flag's type catches the one silently-corrupting case here no matter its cause: a flag
+    // that reads false while a destination is set persists an outbound transfer as ordinary
+    // income on its source account, with a phantom destination stored alongside it. A type
+    // assertion would catch only the wrong-type spelling of that mistake; this catches a wrong
+    // property, a stale expression, and an inverted condition too.
+    const bool isTransfer = params.value(QStringLiteral("isTransfer")).toBool();
+    const QString transferTarget =
+        params.value(QStringLiteral("transferTargetAccountId")).toString();
+    if (isTransfer != !transferTarget.isEmpty()) {
+        emit recurringRuleCreateFailed(
+            QStringLiteral("Internal error: rule request's transfer flag and destination "
+                           "disagree."));
+        return;
+    }
+
     m_createRecurringRuleInProgress = true;
     emit createRecurringRuleInProgressChanged();
 
     auto stub = m_stub.get();
     std::string accountIdStr = params.value(QStringLiteral("accountId")).toString().toStdString();
     std::string nameStr = params.value(QStringLiteral("name")).toString().toStdString();
-    int frequency = params.value(QStringLiteral("frequency")).toInt();
     std::string startDateStr = params.value(QStringLiteral("startDate")).toString().toStdString();
     std::string endDateStr = params.value(QStringLiteral("endDate")).toString().toStdString();
-    int dayOfMonth = params.value(QStringLiteral("dayOfMonth")).toInt();
-    bool isTransfer = params.value(QStringLiteral("isTransfer")).toBool();
-    std::string transferTargetStr =
-        params.value(QStringLiteral("transferTargetAccountId")).toString().toStdString();
+    std::string transferTargetStr = transferTarget.toStdString();
     QList<int> semiDays;
     for (const auto& d : params.value(QStringLiteral("semiMonthlyDays")).toList())
         semiDays.append(d.toInt());

--- a/app/src/finchclient.h
+++ b/app/src/finchclient.h
@@ -9,6 +9,7 @@
 #include <QString>
 #include <QStringList>
 #include <QVariantList>
+#include <QVariantMap>
 #include <memory>
 
 #include <grpcpp/grpcpp.h>
@@ -119,10 +120,10 @@ public:
     Q_INVOKABLE void recordTransaction(const QString& accountId, const QString& date,
                                        qlonglong amount, const QString& name,
                                        const QString& description, int status);
-    Q_INVOKABLE void createRecurringRule(const QString& accountId, const QString& name,
-                                         qlonglong amount, int frequency,
-                                         const QString& startDate, const QString& endDate,
-                                         int dayOfMonth, const QVariantList& semiMonthlyDays);
+    // Takes a params object rather than positional arguments: the call carries ten fields, and
+    // named keys remove the transpose hazard that many positional arguments invite. The
+    // required keys are enumerated (and enforced) in the implementation.
+    Q_INVOKABLE void createRecurringRule(const QVariantMap& params);
     Q_INVOKABLE void listRecurringRules(const QString& accountId);
     Q_INVOKABLE void fetchTimeSeries(const QString& fromDate, const QString& toDate,
                                      int interval, const QStringList& accountIds);

--- a/app/tests/MockFinchClient.qml
+++ b/app/tests/MockFinchClient.qml
@@ -49,8 +49,7 @@ QtObject {
     property int recordCallCount: 0
 
     // CreateRecurringRuleForm drives these; default in-progress false so the form starts
-    // enabled. Each arg is captured separately so a spec can catch a transpose in the 8-arg
-    // positional call.
+    // enabled. Each field is captured separately so a spec can assert them independently.
     property bool createRecurringRuleInProgress: false
     property string lastCreateAccountId: ""
     property string lastCreateName: ""
@@ -60,6 +59,12 @@ QtObject {
     property string lastCreateEndDate: ""
     property int lastCreateDayOfMonth: -1
     property var lastCreateSemiMonthlyDays: []
+    property bool lastCreateIsTransfer: false
+    property string lastCreateTransferTargetAccountId: ""
+    // The params object trades the positional-transpose hazard for a silent-key one: a
+    // mistyped key is not an error, it just arrives absent. Recording the key set lets a spec
+    // pin the contract the C++ reader depends on.
+    property var lastCreateKeys: []
     property int createRecurringRuleCallCount: 0
 
     signal accountCreated(string id)
@@ -113,16 +118,21 @@ QtObject {
     }
 
     // Mirror the real client: in-progress latches true synchronously on the call and clears
-    // when the test drives a terminal outcome via succeed/failCreateRecurringRule().
-    function createRecurringRule(accountId, name, amount, frequency, startDate, endDate, dayOfMonth, semiMonthlyDays) {
-        lastCreateAccountId = accountId
-        lastCreateName = name
-        lastCreateAmount = amount
-        lastCreateFrequency = frequency
-        lastCreateStartDate = startDate
-        lastCreateEndDate = endDate
-        lastCreateDayOfMonth = dayOfMonth
-        lastCreateSemiMonthlyDays = semiMonthlyDays
+    // when the test drives a terminal outcome via succeed/failCreateRecurringRule(). Takes the
+    // same single params object the real Q_INVOKABLE does, so the key names a spec pins here
+    // are the key names the C++ side reads.
+    function createRecurringRule(params) {
+        lastCreateAccountId = params.accountId
+        lastCreateName = params.name
+        lastCreateAmount = params.amount
+        lastCreateFrequency = params.frequency
+        lastCreateStartDate = params.startDate
+        lastCreateEndDate = params.endDate
+        lastCreateDayOfMonth = params.dayOfMonth
+        lastCreateSemiMonthlyDays = params.semiMonthlyDays
+        lastCreateIsTransfer = params.isTransfer
+        lastCreateTransferTargetAccountId = params.transferTargetAccountId
+        lastCreateKeys = Object.keys(params).sort()
         createRecurringRuleCallCount += 1
         createRecurringRuleInProgress = true
     }

--- a/app/tests/recurringruleform/tst_CreateRecurringRuleForm.qml
+++ b/app/tests/recurringruleform/tst_CreateRecurringRuleForm.qml
@@ -96,8 +96,12 @@ TestCase {
     }
 
     // A weekly rule sends signed cents, the trimmed name, the account, frequency value 1, the
-    // start date, an empty end date, day-of-month 0 and no semi-monthly days. Each arg is
-    // asserted independently — an 8-arg positional call is a transpose waiting to happen.
+    // start date, an empty end date, day-of-month 0, no semi-monthly days, and — with no
+    // destination chosen — no transfer. Each field is asserted independently.
+    //
+    // The empty target matters beyond completeness: core persists a non-empty
+    // transfer_target_account_id regardless of is_transfer, so a form that sent the picker's
+    // value unconditionally would write phantom-target rules.
     function test_submitSendsWeeklyArgs() {
         var ctx = build({ accountId: "a1" })
         ctx.form.nameText = "  Gym  "
@@ -115,6 +119,20 @@ TestCase {
         compare(ctx.mock.lastCreateEndDate, "")
         compare(ctx.mock.lastCreateDayOfMonth, 0)
         compare(ctx.mock.lastCreateSemiMonthlyDays.length, 0)
+        compare(ctx.mock.lastCreateIsTransfer, false)
+        compare(ctx.mock.lastCreateTransferTargetAccountId, "")
+    }
+
+    // The params object removes the positional-transpose hazard but adds a silent one: a
+    // mistyped key arrives absent rather than erroring. This pins the exact key set the C++
+    // reader unpacks, which no other spec can reach across the QML/C++ seam.
+    function test_submitSendsExpectedParamKeys() {
+        var ctx = build({ accountId: "a1" })
+        fillValidWeekly(ctx)
+        ctx.form.submit()
+        compare(ctx.mock.lastCreateKeys.join(","),
+                "accountId,amount,dayOfMonth,endDate,frequency,isTransfer,name,"
+                + "semiMonthlyDays,startDate,transferTargetAccountId")
     }
 
     function test_incomeIsPositive() {

--- a/app/tests/recurringruleform/tst_CreateRecurringRuleForm.qml
+++ b/app/tests/recurringruleform/tst_CreateRecurringRuleForm.qml
@@ -17,6 +17,22 @@ TestCase {
     readonly property int idxSemiMonthly: 2
     readonly property int idxMonthly: 3
 
+    // Three accounts, and the transfer specs deliberately source from the MIDDLE one. With a
+    // sentinel row at index 0 and the source filtered out, a source at index 0 makes the
+    // sentinel's +1 shift cancel the filter's -1 shift exactly — filtered row i would then be
+    // accounts[i] at every row, and a spec asserting the submitted id could not tell a correct
+    // currentValue read from an accounts[currentIndex] lookup. Sourcing from a2 breaks that
+    // coincidence: filtered row 1 is a1, while accounts[1] is a2.
+    readonly property var sampleAccounts: [
+        { id: "a1", name: "Checking" },
+        { id: "a2", name: "Savings" },
+        { id: "a3", name: "Credit" }
+    ]
+    // Index 0 is the "Not a transfer" sentinel; 1 and 2 are the two non-source accounts.
+    readonly property int idxNoTransfer: 0
+    readonly property int idxFirstTarget: 1
+    readonly property int idxLastTarget: 2
+
     Component { id: formFactory; CreateRecurringRuleForm {} }
     Component { id: mockFactory; MockFinchClient {} }
 
@@ -28,12 +44,22 @@ TestCase {
     function build(opts) {
         opts = opts || {}
         currentMock = mockFactory.createObject(testCase)
+        // Accounts are set before the form is built so the destination model is populated at
+        // completion, matching how the panel suite seeds its selector.
+        currentMock.accounts = (opts.accounts !== undefined) ? opts.accounts : sampleAccounts
         var props = { client: currentMock }
         if (opts.accountId !== undefined)
             props.accountId = opts.accountId
         currentForm = formFactory.createObject(testCase, props)
         verify(currentForm !== null, "form instantiated")
         return { form: currentForm, mock: currentMock }
+    }
+
+    // A valid weekly rule sourced from the middle account, ready for a destination choice.
+    function fillValidTransferFrom(ctx) {
+        ctx.form.nameText = "To savings"
+        ctx.form.amountText = "500"
+        ctx.form.frequencyIndex = idxWeekly
     }
 
     function cleanup() {
@@ -285,5 +311,171 @@ TestCase {
         ctx.form.submit()
         ctx.form.submit()
         compare(ctx.mock.createRecurringRuleCallCount, 1)
+    }
+
+    // --- Transfer mode ---------------------------------------------------------------------
+
+    // The destination list offers "not a transfer" as a real selectable row, not merely a
+    // placeholder, so a user who picks a destination can get back out without submitting. The
+    // source account is absent, which is what makes choosing it as its own target impossible
+    // rather than merely invalid.
+    function test_transferTargetsExcludeSourceAndOfferSentinel() {
+        var ctx = build({ accountId: "a2" })
+        var targets = ctx.form.transferTargets
+        compare(targets.length, 3)
+        compare(targets[idxNoTransfer].id, "")
+        compare(targets[idxFirstTarget].id, "a1")
+        compare(targets[idxLastTarget].id, "a3")
+    }
+
+    // Sourced from the middle account, filtered row 1 is a1 while accounts[1] is a2 — so this
+    // asserts the form submits the row's *id* and not an index into the unfiltered list.
+    function test_transferSubmitsSelectedRowIdNotIndex() {
+        var ctx = build({ accountId: "a2" })
+        fillValidTransferFrom(ctx)
+        ctx.form.transferTargetIndex = idxFirstTarget
+        ctx.form.submit()
+        compare(ctx.mock.lastCreateIsTransfer, true)
+        compare(ctx.mock.lastCreateTransferTargetAccountId, "a1")
+        compare(ctx.mock.lastCreateAccountId, "a2")
+    }
+
+    function test_transferSubmitsLastRowId() {
+        var ctx = build({ accountId: "a2" })
+        fillValidTransferFrom(ctx)
+        ctx.form.transferTargetIndex = idxLastTarget
+        ctx.form.submit()
+        compare(ctx.mock.lastCreateTransferTargetAccountId, "a3")
+    }
+
+    // A transfer's amount is a positive magnitude — direction comes from the source/target
+    // pair, and both the daemon and core reject a non-positive one. Expense is the form's
+    // default, so a form that passed its signed cents straight through would send -50000.
+    function test_transferSendsPositiveAmountDespiteExpenseDefault() {
+        var ctx = build({ accountId: "a2" })
+        fillValidTransferFrom(ctx)
+        ctx.form.expense = true
+        ctx.form.transferTargetIndex = idxFirstTarget
+        ctx.form.submit()
+        compare(ctx.mock.lastCreateAmount, 50000)
+    }
+
+    // The magnitude is sign-free by construction rather than by negating the signed value —
+    // negation would send a negative amount whenever Income was the standing choice.
+    function test_unsignedCentsPositiveForBothSigns() {
+        var ctx = build({ accountId: "a2" })
+        ctx.form.amountText = "500"
+        ctx.form.expense = true
+        compare(ctx.form.unsignedCents, 50000)
+        ctx.form.expense = false
+        compare(ctx.form.unsignedCents, 50000)
+    }
+
+    // Returning to the sentinel leaves transfer mode — the round trip a placeholder-only
+    // control could not express.
+    function test_returningToSentinelClearsTransfer() {
+        var ctx = build({ accountId: "a2" })
+        fillValidTransferFrom(ctx)
+        ctx.form.transferTargetIndex = idxFirstTarget
+        verify(ctx.form.isTransfer)
+        ctx.form.transferTargetIndex = idxNoTransfer
+        compare(ctx.form.isTransfer, false)
+        ctx.form.submit()
+        compare(ctx.mock.lastCreateIsTransfer, false)
+        compare(ctx.mock.lastCreateTransferTargetAccountId, "")
+    }
+
+    // Switching source must not leave a destination selected against the old list. Asserting
+    // the *submitted* target, not just the selection, is what catches a reset that loses a race
+    // with the model's own re-evaluation.
+    function test_changingSourceDropsHeldDestination() {
+        var ctx = build({ accountId: "a2" })
+        fillValidTransferFrom(ctx)
+        ctx.form.transferTargetIndex = idxFirstTarget
+        ctx.form.accountId = "a3"
+        compare(ctx.form.isTransfer, false)
+        ctx.form.submit()
+        compare(ctx.mock.lastCreateIsTransfer, false)
+        compare(ctx.mock.lastCreateTransferTargetAccountId, "")
+    }
+
+    // A follow-up rule must not silently inherit transfer mode from the one just created.
+    function test_successResetsDestinationToSentinel() {
+        var ctx = build({ accountId: "a2" })
+        fillValidTransferFrom(ctx)
+        ctx.form.transferTargetIndex = idxFirstTarget
+        ctx.form.submit()
+        ctx.mock.succeedCreateRecurringRule("rule-1")
+        compare(ctx.form.isTransfer, false)
+        compare(ctx.form.transferTargetIndex, idxNoTransfer)
+    }
+
+    // Direction is implied by the source/target pair, so the Expense/Income choice is
+    // meaningless in transfer mode and the control goes away. Asserted on the logical property,
+    // never on `visible`, which reads false offscreen regardless.
+    function test_signSelectorSuppressedInTransferMode() {
+        var ctx = build({ accountId: "a2" })
+        compare(ctx.form.signSelectorVisible, true)
+        ctx.form.transferTargetIndex = idxFirstTarget
+        compare(ctx.form.signSelectorVisible, false)
+        ctx.form.transferTargetIndex = idxNoTransfer
+        compare(ctx.form.signSelectorVisible, true)
+    }
+
+    // The preview must describe the leg the rule actually writes. Entering transfer mode with
+    // Income standing would otherwise leave a green "+" preview above a rule that debits the
+    // source — the app stating the wrong direction at the moment of authoring.
+    function test_transferPreviewReadsAsDebit() {
+        var ctx = build({ accountId: "a2" })
+        ctx.form.amountText = "500"
+        ctx.form.expense = false
+        compare(ctx.form.previewText, "$500.00")
+        ctx.form.transferTargetIndex = idxFirstTarget
+        compare(ctx.form.previewText, "-$500.00")
+    }
+
+    // Leaving transfer mode restores the sign the user had chosen rather than silently
+    // discarding it, matching the form's standing posture of preserving in-progress input.
+    function test_leavingTransferModeRestoresPriorSign() {
+        var ctx = build({ accountId: "a2" })
+        ctx.form.amountText = "500"
+        ctx.form.expense = false
+        ctx.form.transferTargetIndex = idxFirstTarget
+        compare(ctx.form.expense, true)
+        ctx.form.transferTargetIndex = idxNoTransfer
+        compare(ctx.form.expense, false)
+    }
+
+    // Past the 32-bit ceiling, and positive: a transfer magnitude must survive the same way
+    // the signed path does.
+    function test_largeTransferAmountStaysPositive() {
+        var ctx = build({ accountId: "a2" })
+        ctx.form.nameText = "Payoff sweep"
+        ctx.form.amountText = "30000000"
+        ctx.form.frequencyIndex = idxWeekly
+        ctx.form.transferTargetIndex = idxFirstTarget
+        ctx.form.submit()
+        compare(ctx.mock.lastCreateAmount, 3000000000)
+    }
+
+    // A stale daemon error (e.g. a rejected target) must not survive the correction, matching
+    // every other input in the form.
+    function test_destinationChangeClearsError() {
+        var ctx = build({ accountId: "a2" })
+        fillValidTransferFrom(ctx)
+        ctx.form.submit()
+        ctx.mock.failCreateRecurringRule("transfer target account not found")
+        compare(ctx.form.errorText, "transfer target account not found")
+        ctx.form.transferTargetIndex = idxFirstTarget
+        compare(ctx.form.errorText, "")
+    }
+
+    // With no source chosen the form is disabled anyway, but the list must not offer a
+    // destination before a source exists.
+    function test_noSourceOffersOnlySentinel() {
+        var ctx = build()
+        compare(ctx.form.accountId, "")
+        compare(ctx.form.transferTargets.length, 1)
+        compare(ctx.form.transferTargets[idxNoTransfer].id, "")
     }
 }

--- a/app/tests/recurringruleform/tst_CreateRecurringRuleForm.qml
+++ b/app/tests/recurringruleform/tst_CreateRecurringRuleForm.qml
@@ -478,4 +478,23 @@ TestCase {
         compare(ctx.form.transferTargets.length, 1)
         compare(ctx.form.transferTargets[idxNoTransfer].id, "")
     }
+
+    // transferAvailable is the only gate on the destination control, so inverting it would make
+    // transfer creation unreachable in the shipping app with every spec still green. Asserted on
+    // the logical property, which is what the visual `visible` binds to.
+    function test_transferAvailableWithOtherAccounts() {
+        var ctx = build({ accountId: "a2" })
+        compare(ctx.form.transferAvailable, true)
+    }
+
+    function test_transferUnavailableWithSingleAccount() {
+        var ctx = build({ accounts: [{ id: "a1", name: "Only" }], accountId: "a1" })
+        compare(ctx.form.transferTargets.length, 1)
+        compare(ctx.form.transferAvailable, false)
+    }
+
+    function test_transferUnavailableBeforeSourceChosen() {
+        var ctx = build()
+        compare(ctx.form.transferAvailable, false)
+    }
 }

--- a/app/tests/recurringrulespanel/tst_RecurringRulesPanel.qml
+++ b/app/tests/recurringrulespanel/tst_RecurringRulesPanel.qml
@@ -239,4 +239,85 @@ TestCase {
         compare(ctx.mock.recurringRulesCallCount, before + 1)
         compare(ctx.mock.lastRulesAccountId, "a1")
     }
+
+    // --- Transfer rules --------------------------------------------------------------------
+
+    // A transfer rule stores a POSITIVE magnitude and belongs to its source account; direction
+    // comes from which side of the transfer the viewing account is on. Rendering the stored
+    // amount as-is would show a $500 outbound transfer as a credit on the account it debits.
+    readonly property var transferRule: {
+        return { id: "r3", accountId: "a1", name: "To savings", amount: 50000, frequency: 4,
+                 startDate: "2025-01-01", endDate: "", dayOfMonth: 1, semiMonthlyDays: [],
+                 isTransfer: true, transferTargetAccountId: "a2", paused: false }
+    }
+
+    // Called by the ListView delegate, so asserting it exercises real production code. Reading
+    // a delegate's contents instead would depend on viewport geometry no spec in this suite
+    // relies on; the row's visual confirmation belongs to manual testing.
+    function test_rowLabelNamesTransferDestination() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, [transferRule])
+        compare(ctx.panel.rowLabel(transferRule), "To savings → Savings")
+    }
+
+    function test_rowAmountIsDebitForSourceAccount() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, [transferRule])
+        compare(ctx.panel.ruleAmountText(transferRule), "-$500.00")
+    }
+
+    function test_nonTransferRowKeepsStoredSign() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleRules)
+        compare(ctx.panel.rowLabel(sampleRules[0]), "Rent")
+        compare(ctx.panel.ruleAmountText(sampleRules[0]), "-$1500.00")
+    }
+
+    function test_detailPaneShowsTransferDirectionAndDestination() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, [transferRule])
+        ctx.panel.ruleList.currentIndex = 0
+        compare(ctx.panel.detailAmountText, "-$500.00")
+        verify(ctx.panel.detailTransferVisible)
+        compare(ctx.panel.detailTransferText, "Out to Savings")
+    }
+
+    function test_detailPaneHidesTransferRowForOrdinaryRule() {
+        var ctx = build()
+        selectAccountWith(ctx, 0, sampleRules)
+        ctx.panel.ruleList.currentIndex = 0
+        compare(ctx.panel.detailTransferVisible, false)
+    }
+
+    // Mirrors core's effectOn, which negates only when a transfer has a target. A rule flagged
+    // as a transfer with no target falls through to its stored signed amount, so the panel and
+    // the projection engine cannot disagree about direction on the same rule.
+    function test_transferWithoutTargetKeepsStoredSign() {
+        var ctx = build()
+        var orphan = { id: "r4", accountId: "a1", name: "Odd", amount: 50000, frequency: 4,
+                       startDate: "2025-01-01", endDate: "", dayOfMonth: 1, semiMonthlyDays: [],
+                       isTransfer: true, transferTargetAccountId: "", paused: false }
+        selectAccountWith(ctx, 0, [orphan])
+        compare(ctx.panel.ruleAmountText(orphan), "$500.00")
+        compare(ctx.panel.rowLabel(orphan), "Odd")
+    }
+
+    // An unknown destination falls back to the raw id — never "undefined" beside a money amount.
+    function test_unknownDestinationFallsBackToId() {
+        var ctx = build()
+        var dangling = { id: "r5", accountId: "a1", name: "Sweep", amount: 50000, frequency: 4,
+                         startDate: "2025-01-01", endDate: "", dayOfMonth: 1, semiMonthlyDays: [],
+                         isTransfer: true, transferTargetAccountId: "a9", paused: false }
+        selectAccountWith(ctx, 0, [dangling])
+        compare(ctx.panel.rowLabel(dangling), "Sweep → a9")
+    }
+
+    function test_pausedTransferShowsBothAnnotations() {
+        var ctx = build()
+        var paused = { id: "r6", accountId: "a1", name: "To savings", amount: 50000, frequency: 4,
+                       startDate: "2025-01-01", endDate: "", dayOfMonth: 1, semiMonthlyDays: [],
+                       isTransfer: true, transferTargetAccountId: "a2", paused: true }
+        selectAccountWith(ctx, 0, [paused])
+        compare(ctx.panel.rowLabel(paused), "To savings → Savings (paused)")
+    }
 }

--- a/app/tests/recurringrulespanel/tst_RecurringRulesPanel.qml
+++ b/app/tests/recurringrulespanel/tst_RecurringRulesPanel.qml
@@ -312,6 +312,20 @@ TestCase {
         compare(ctx.panel.rowLabel(dangling), "Sweep → a9")
     }
 
+    // "Is this a transfer with a destination" must mean one thing everywhere. The row label and
+    // the amount both treat a missing target as not-a-transfer; the detail pane must agree,
+    // rather than announcing a transfer to an account it cannot name.
+    function test_detailPaneHidesTransferRowWhenTargetMissing() {
+        var ctx = build()
+        var noTarget = { id: "r7", accountId: "a1", name: "Odd", amount: 50000, frequency: 4,
+                         startDate: "2025-01-01", endDate: "", dayOfMonth: 1, semiMonthlyDays: [],
+                         isTransfer: true, paused: false }
+        selectAccountWith(ctx, 0, [noTarget])
+        ctx.panel.ruleList.currentIndex = 0
+        compare(ctx.panel.detailTransferVisible, false)
+        compare(ctx.panel.detailTransferText, "")
+    }
+
     function test_pausedTransferShowsBothAnnotations() {
         var ctx = build()
         var paused = { id: "r6", accountId: "a1", name: "To savings", amount: 50000, frequency: 4,

--- a/app/tests/recurringrulespanel/tst_RecurringRulesPanel.qml
+++ b/app/tests/recurringrulespanel/tst_RecurringRulesPanel.qml
@@ -312,6 +312,22 @@ TestCase {
         compare(ctx.panel.rowLabel(dangling), "Sweep → a9")
     }
 
+    // Viewed from the account a transfer CREDITS, every rendering must flip: the amount is a
+    // credit, the row points inward, and the detail pane names the payer rather than the payee.
+    // Not reachable through the real client yet (rules are fetched scoped to their owner), but
+    // the amount already derives direction from the viewing account, so the labels beside it
+    // must agree rather than reading as outbound regardless.
+    function test_transferViewedFromDestinationReadsInbound() {
+        var ctx = build()
+        selectAccountWith(ctx, 1, [transferRule])   // index 1 is Savings, the rule's target
+        compare(ctx.panel.currentAccountId, "a2")
+        compare(ctx.panel.ruleAmountText(transferRule), "$500.00")
+        compare(ctx.panel.rowLabel(transferRule), "To savings ← Checking")
+        ctx.panel.ruleList.currentIndex = 0
+        verify(ctx.panel.detailTransferVisible)
+        compare(ctx.panel.detailTransferText, "In from Checking")
+    }
+
     // "Is this a transfer with a destination" must mean one thing everywhere. The row label and
     // the amount both treat a missing target as not-a-transfer; the detail pane must agree,
     // rather than announcing a transfer to an account it cannot name.


### PR DESCRIPTION
## Overview

The Qt app could create recurring rules, but only single-account ones — a recurring move between two of your own accounts still had to go through the MCP tools. This adds a transfer mode to the Recurring Rules create form, and corrects how that screen renders the rules it can now write.

Direction is the substance of the change. A transfer rule stores a positive magnitude and belongs to its source account; which way the money moves comes from which side of the transfer a given account sits on. The panel rendered the stored amount as-is, so a $500 outbound transfer read as a credit on the account it debits, and nothing named the destination. That was already wrong for transfers created through MCP — and making them creatable in the app would have meant the screen contradicting the rule it had just written.

## How it works

Two mechanics that are hard to infer from the diff.

**The destination picker's "Not a transfer" entry is a real selectable row, not an unselected placeholder.** Three properties rest on that. Leaving transfer mode stays possible at all — the form persists across navigation, so a placeholder-only control would make a mis-click unescapable short of submitting or restarting the app. The form reads the selected row's *value* rather than indexing the model, which matters because the model is filtered: an index into it is not an index into the account list, and a wrong-but-valid destination is something the daemon accepts without complaint. And because the value is model-derived, switching source accounts cannot leave a stale destination behind, so correctness does not depend on a reset winning a race with the model's own re-evaluation.

**The client's create call takes a params object instead of positional arguments.** The transfer fields would have taken it to ten. Named keys remove the transpose class but introduce quieter ones: a mistyped key arrives absent, a bad value expression arrives unreadable, and a valid value of the wrong type converts with a silent fallback — the conversions turn any of them into a plausible wrong value rather than an error, and an `isTransfer` reading false would persist an outbound transfer as ordinary income on its source.

The first two are rejected on presence and validity. The third is caught by requiring the transfer flag and the destination to agree: the caller derives one from the other, so they are one fact stated twice, and checking the invariant catches a wrong flag regardless of cause — a wrong type, a wrong property, a stale expression — where a type assertion would catch only the first. Emptiness is deliberately not checked, since an empty end date means open-ended and an empty destination means not-a-transfer.

A spec pins the params key set, but that seam is otherwise unreachable by the test suite, which drives a mock rather than the real client — so it was verified manually against a live daemon instead: a created transfer stores a positive magnitude with the right destination, an ordinary rule stores no destination at all, and projection returns both legs, a debit on the source and a credit on the destination, from the single stored record.

The app's direction logic mirrors core's `effectOn` branch for branch, including a fall-through that is not reachable through the API, so a partial copy cannot drift from the engine it duplicates.

One addition sits outside the feature: a note in the Qt app rule on checking which daemon build the app is actually talking to. Verifying this change surfaced the need for it — the installed daemon predated the projection fix the new behavior depends on, so the feature looked broken for a reason unrelated to it, and the install recipe does not restart an already-running service.

Closes #91.

Two things this change leaves alone, both predating it. The create form crowds the list and detail pane on this screen, and on the Transactions screen equally — tracked in #103. And the app's gRPC client has no automated coverage of its own, since the suite verifies components against a mock rather than the client itself — tracked in #105.
