### PR TITLE
docs(rules): document the sentinel-prefixed filtered-model test trap

### DIFF
--- a/.claude/rules/qt-app.md
+++ b/.claude/rules/qt-app.md
@@ -22,7 +22,21 @@ Qt Quick Controls types mark many properties as FINAL. NEVER declare custom prop
 
 A form ComboBox that submits a proto enum value must read `currentValue` (via `valueRole`), never `currentIndex`. The two coincide — and hide the bug — when a sentinel row sits at index 0 over a contiguous `1..N` enum: the row index then equals the enum value at every row, so a spec asserting the submitted value passes even if the code wrongly submits `currentIndex`.
 
-To keep the value-vs-index distinction testable, prefer the account-selector pattern — `currentIndex: -1` with a placeholder `displayText` and no sentinel row — so a row's index is one less than its enum value. A spec that then asserts the submitted enum value genuinely catches a `currentIndex`-for-`currentValue` bug. Reserve the sentinel-row form for models whose values aren't a contiguous run from 1.
+To keep the value-vs-index distinction testable, prefer the account-selector pattern — `currentIndex: -1` with a placeholder `displayText` and no sentinel row — so a row's index is one less than its enum value. A spec that then asserts the submitted enum value genuinely catches a `currentIndex`-for-`currentValue` bug. Reserve the sentinel-row form for models whose values aren't a contiguous run from 1 — and when such a model is also a filtered view of a source list, read the next section first: there the sentinel introduces a second coincidence of its own.
+
+## Sentinel-Prefixed Filtered Models: Index Arithmetic and Fixture Choice
+
+A ComboBox whose model is a source list with one element filtered out and a sentinel row prepended — the "none of these" shape, such as a transfer-destination picker that excludes the source account — submits an identity rather than an enum. Reading `currentIndex` instead of `currentValue` here indexes the *unfiltered* source list, so it yields a real but wrong identity, which a server accepts without complaint.
+
+Whether a spec can catch that depends entirely on which element the fixture filters out. The sentinel occupies row 0, so real rows start at 1. With the filtered-out element at source index *s*, filtered row *i* is source element `i-1` when `i-1 < s` and source element `i` otherwise, while the buggy read returns source element `i` at every row. The two coincide wherever `i > s`:
+
+- **Filter out the last element.** No row satisfies `i > s`, so every row diverges and the fixture cannot hide the bug.
+- Filtering out the **first** element is the worst case — every row coincides, so no assertion on the submitted identity can fail, whichever rows the spec drives.
+- Filtering out a middle element diverges only at rows up to *s*, so the spec must assert on one of those; an assertion on the last row proves nothing.
+
+Pick the fixture by that rule rather than re-deriving it each time. Where the scenario fixes the filtered-out element's position, tabulate row → identity for both the correct and the buggy read, and assert on a row where they differ.
+
+The sentinel row is a UX requirement, not a testing one: it is what makes "none" re-selectable. A form that persists across navigation needs that — with only a placeholder at `currentIndex: -1`, a mis-click into a real row cannot be undone without submitting or restarting the app.
 
 ## QML Numeric Property Width
 

--- a/.claude/rules/qt-app.md
+++ b/.claude/rules/qt-app.md
@@ -28,11 +28,11 @@ Use the sentinel-row form when "none" must be **re-selectable**: a form that per
 
 ## Sentinel-Prefixed Filtered Models: Catching an Index-for-Value Read
 
-A ComboBox whose model prepends a sentinel row to a source list with one element filtered out — the "none of these" shape, such as a transfer-destination picker that excludes the source account — submits an identity rather than an enum. Reading `currentIndex` instead of `currentValue` here indexes the *unfiltered* source list, yielding a real but wrong identity.
+A ComboBox whose model prepends a sentinel row to a source list with one element filtered out — the "none of these" shape, such as a transfer-destination picker that excludes the source account — submits an identity rather than an enum. The bug to catch is a row's `currentIndex` used to look up the *unfiltered* source list — `source[currentIndex]` — where `currentValue` was wanted: the index belongs to the filtered model, so the lookup yields a real but wrong identity.
 
 **Assert that the sentinel row submits no identity.** That catches the bug whichever element the fixture filters out: at the sentinel the correct read yields the empty value while an unfiltered-source index read yields the first element's identity, so the two always differ. This is the cheap, fixture-independent guard — and a spec covering the "none selected" case already carries it if it asserts the submitted identity is empty.
 
-If you also assert on a **real** row, the fixture decides whether that assertion can fail. Taking the buggy read to be `source[currentIndex]`, and the filtered-out element to sit at source index *s*, real row *i* holds source element `i-1` when `i-1 < s` and element `i` otherwise, while the buggy read returns element `i` throughout — so the two coincide wherever `i > s`:
+If you also assert on a **real** row, the fixture decides whether that assertion can fail. Assuming that read, and the filtered-out element sitting at source index *s*, real row *i* holds source element `i-1` when `i-1 < s` and element `i` otherwise, while the buggy read returns element `i` throughout — so the two coincide wherever `i > s`:
 
 - **Filter out the last element** and every real row diverges.
 - Filter out the **first** and no real row diverges, so an assertion there cannot fail whichever real row it drives.

--- a/.claude/rules/qt-app.md
+++ b/.claude/rules/qt-app.md
@@ -22,21 +22,25 @@ Qt Quick Controls types mark many properties as FINAL. NEVER declare custom prop
 
 A form ComboBox that submits a proto enum value must read `currentValue` (via `valueRole`), never `currentIndex`. The two coincide — and hide the bug — when a sentinel row sits at index 0 over a contiguous `1..N` enum: the row index then equals the enum value at every row, so a spec asserting the submitted value passes even if the code wrongly submits `currentIndex`.
 
-To keep the value-vs-index distinction testable, prefer the account-selector pattern — `currentIndex: -1` with a placeholder `displayText` and no sentinel row — so a row's index is one less than its enum value. A spec that then asserts the submitted enum value genuinely catches a `currentIndex`-for-`currentValue` bug. Reserve the sentinel-row form for models whose values aren't a contiguous run from 1 — and when such a model is also a filtered view of a source list, read the next section first: there the sentinel introduces a second coincidence of its own.
+To keep the value-vs-index distinction testable, prefer the account-selector pattern — `currentIndex: -1` with a placeholder `displayText` and no sentinel row — so a row's index is one less than its enum value. A spec that then asserts the submitted enum value genuinely catches a `currentIndex`-for-`currentValue` bug.
 
-## Sentinel-Prefixed Filtered Models: Index Arithmetic and Fixture Choice
+Use the sentinel-row form when "none" must be **re-selectable**: a form that persists across navigation needs it, because with only a placeholder at `currentIndex: -1` a mis-click into a real row cannot be undone without submitting or restarting the app. Values that aren't a contiguous run from 1 are a secondary reason to reach for it. Either way, when the model is also a filtered view of a source list, see § *Sentinel-Prefixed Filtered Models* — the sentinel there introduces an offset coincidence distinct from the index-equals-value one above.
 
-A ComboBox whose model is a source list with one element filtered out and a sentinel row prepended — the "none of these" shape, such as a transfer-destination picker that excludes the source account — submits an identity rather than an enum. Reading `currentIndex` instead of `currentValue` here indexes the *unfiltered* source list, so it yields a real but wrong identity, which a server accepts without complaint.
+## Sentinel-Prefixed Filtered Models: Catching an Index-for-Value Read
 
-Whether a spec can catch that depends entirely on which element the fixture filters out. The sentinel occupies row 0, so real rows start at 1. With the filtered-out element at source index *s*, filtered row *i* is source element `i-1` when `i-1 < s` and source element `i` otherwise, while the buggy read returns source element `i` at every row. The two coincide wherever `i > s`:
+A ComboBox whose model prepends a sentinel row to a source list with one element filtered out — the "none of these" shape, such as a transfer-destination picker that excludes the source account — submits an identity rather than an enum. Reading `currentIndex` instead of `currentValue` here indexes the *unfiltered* source list, yielding a real but wrong identity.
 
-- **Filter out the last element.** No row satisfies `i > s`, so every row diverges and the fixture cannot hide the bug.
-- Filtering out the **first** element is the worst case — every row coincides, so no assertion on the submitted identity can fail, whichever rows the spec drives.
-- Filtering out a middle element diverges only at rows up to *s*, so the spec must assert on one of those; an assertion on the last row proves nothing.
+**Assert that the sentinel row submits no identity.** That catches the bug whichever element the fixture filters out: at the sentinel the correct read yields the empty value while an unfiltered-source index read yields the first element's identity, so the two always differ. This is the cheap, fixture-independent guard — and a spec covering "creates a non-transfer rule" already carries it, provided it asserts the submitted target is empty rather than only that the transfer flag is false.
 
-Pick the fixture by that rule rather than re-deriving it each time. Where the scenario fixes the filtered-out element's position, tabulate row → identity for both the correct and the buggy read, and assert on a row where they differ.
+If you also assert on a **real** row, the fixture decides whether that assertion can fail. Taking the buggy read to be `source[currentIndex]`, and the filtered-out element to sit at source index *s*, real row *i* holds source element `i-1` when `i-1 < s` and element `i` otherwise, while the buggy read returns element `i` throughout — so the two coincide wherever `i > s`:
 
-The sentinel row is a UX requirement, not a testing one: it is what makes "none" re-selectable. A form that persists across navigation needs that — with only a placeholder at `currentIndex: -1`, a mis-click into a real row cannot be undone without submitting or restarting the app.
+- **Filter out the last element** and every real row diverges.
+- Filter out the **first** and no real row diverges, so an assertion there cannot fail whichever real row it drives.
+- Filter out a middle element and rows 1 through *s* inclusive diverge, none above. With three source elements and the middle one filtered out that means row 1 only, and an assertion on the last row proves nothing.
+
+Prefer the last-element fixture over re-deriving this. Only where the scenario fixes the filtered-out element's position, tabulate row → identity for the correct read and for the read you suspect, then assert where they differ.
+
+A wrong identity is silently acceptable only when it lands on some *other* account: this project's daemon and core both reject a transfer whose destination equals its source, so a buggy read returning the filtered-out element surfaces as `InvalidArgument` rather than a bad rule.
 
 ## QML Numeric Property Width
 

--- a/.claude/rules/qt-app.md
+++ b/.claude/rules/qt-app.md
@@ -30,7 +30,7 @@ Use the sentinel-row form when "none" must be **re-selectable**: a form that per
 
 A ComboBox whose model prepends a sentinel row to a source list with one element filtered out — the "none of these" shape, such as a transfer-destination picker that excludes the source account — submits an identity rather than an enum. Reading `currentIndex` instead of `currentValue` here indexes the *unfiltered* source list, yielding a real but wrong identity.
 
-**Assert that the sentinel row submits no identity.** That catches the bug whichever element the fixture filters out: at the sentinel the correct read yields the empty value while an unfiltered-source index read yields the first element's identity, so the two always differ. This is the cheap, fixture-independent guard — and a spec covering "creates a non-transfer rule" already carries it, provided it asserts the submitted target is empty rather than only that the transfer flag is false.
+**Assert that the sentinel row submits no identity.** That catches the bug whichever element the fixture filters out: at the sentinel the correct read yields the empty value while an unfiltered-source index read yields the first element's identity, so the two always differ. This is the cheap, fixture-independent guard — and a spec covering the "none selected" case already carries it if it asserts the submitted identity is empty.
 
 If you also assert on a **real** row, the fixture decides whether that assertion can fail. Taking the buggy read to be `source[currentIndex]`, and the filtered-out element to sit at source index *s*, real row *i* holds source element `i-1` when `i-1 < s` and element `i` otherwise, while the buggy read returns element `i` throughout — so the two coincide wherever `i > s`:
 

--- a/app/tests/recurringruleform/tst_CreateRecurringRuleForm.qml
+++ b/app/tests/recurringruleform/tst_CreateRecurringRuleForm.qml
@@ -17,12 +17,10 @@ TestCase {
     readonly property int idxSemiMonthly: 2
     readonly property int idxMonthly: 3
 
-    // Three accounts, and the transfer specs deliberately source from the MIDDLE one. With a
-    // sentinel row at index 0 and the source filtered out, a source at index 0 makes the
-    // sentinel's +1 shift cancel the filter's -1 shift exactly — filtered row i would then be
-    // accounts[i] at every row, and a spec asserting the submitted id could not tell a correct
-    // currentValue read from an accounts[currentIndex] lookup. Sourcing from a2 breaks that
-    // coincidence: filtered row 1 is a1, while accounts[1] is a2.
+    // Three accounts, with the transfer specs sourcing from the MIDDLE one so that filtered row
+    // 1 diverges from an unfiltered-index read (row 1 is a1, accounts[1] is a2). Only row 1
+    // diverges under this fixture — see the sentinel-prefixed-filtered-model section of the Qt
+    // app rule for why, and for the sentinel-row assertion that holds regardless of fixture.
     readonly property var sampleAccounts: [
         { id: "a1", name: "Checking" },
         { id: "a2", name: "Savings" },

--- a/app/tests/recurringruleform/tst_CreateRecurringRuleForm.qml
+++ b/app/tests/recurringruleform/tst_CreateRecurringRuleForm.qml
@@ -19,8 +19,9 @@ TestCase {
 
     // Three accounts, with the transfer specs sourcing from the MIDDLE one so that filtered row
     // 1 diverges from an unfiltered-index read (row 1 is a1, accounts[1] is a2). Only row 1
-    // diverges under this fixture — see the sentinel-prefixed-filtered-model section of the Qt
-    // app rule for why, and for the sentinel-row assertion that holds regardless of fixture.
+    // diverges under this fixture — see "Sentinel-Prefixed Filtered Models" in
+    // .claude/rules/qt-app.md for why, and for the sentinel-row assertion that holds
+    // regardless of fixture.
     readonly property var sampleAccounts: [
         { id: "a1", name: "Checking" },
         { id: "a2", name: "Savings" },


### PR DESCRIPTION
## Overview

A spec that proves a form submits a ComboBox row's *value* rather than an index into the model's unfiltered source list can be structurally incapable of failing, and nothing in the rule set said so. Recent work on recurring transfers hit exactly that: prepending a "none of these" sentinel row shifts row indices up by one while filtering the source account out shifts them down by one, and those cancel — so for the fixture in use, an index read would have returned the right answer at the row the spec drove. Both the plan and its independent review recommended that fixture. Working the arithmetic by hand is what caught it.

This adds a section to the Qt app rule so the next agent writing an identity-versus-position spec against a filtered model builds a fixture that can actually fail.

## How it works

The guidance leads with the guard that works for **any** fixture rather than with the arithmetic. The sentinel row diverges under an unfiltered-index read unconditionally — the correct read yields the empty value there, while the buggy read yields the first source element's identity — so a spec asserting that the "none selected" case submits no identity catches the bug whichever element the fixture filters out. Fixture choice then matters only for a spec that *also* asserts on a real row, and that case gets the constructive form (filter out the last element and every row diverges) rather than a derivation to re-run, since re-running the derivation is what got skipped.

That ordering rests on mutation testing rather than on reasoning: replacing the form's `currentValue` read with the unguarded index read fails nine specs, and the one that catches it most cleanly is the non-transfer spec asserting an empty target. Two bug shapes exist with very different detectability — a variant that guards index zero fails only one spec — so the section names which read its arithmetic assumes.

The enum-submission section above it also had a problem this exposed. Its closing advice was to reserve the sentinel-row form for enums whose values aren't a contiguous run from 1, which points the wrong way at a live case in this app: the account-creation form uses a sentinel over a contiguous enum, and the reason is that its "none" option has to be re-selectable, because the form persists across navigation and a placeholder-only control would make a mis-click unescapable. The criteria are now consolidated in priority order, with re-selectability as the driver.
